### PR TITLE
Peff edge case fixes

### DIFF
--- a/Comet.cpp
+++ b/Comet.cpp
@@ -71,7 +71,6 @@ int main(int argc, char *argv[])
       // error message again via g_cometStatus
       exit(1);
    }
-
    return (0);
 } // main
 

--- a/Comet.cpp
+++ b/Comet.cpp
@@ -71,6 +71,7 @@ int main(int argc, char *argv[])
       // error message again via g_cometStatus
       exit(1);
    }
+
    return (0);
 } // main
 

--- a/CometSearch/CometData.h
+++ b/CometSearch/CometData.h
@@ -501,7 +501,7 @@ class CometParam
 public:
    CometParam(CometParamType paramType, const string& strValue)
       : _paramType(paramType), _strValue(strValue) {}
-   virtual ~CometParam() {cout << "virtual ~CometParam()" << endl;}
+   virtual ~CometParam() {}
    string& GetStringValue() { return _strValue; }
 private:
    CometParamType _paramType;

--- a/CometSearch/CometData.h
+++ b/CometSearch/CometData.h
@@ -19,7 +19,7 @@
 
 #define SIZE_BUF                    8192
 #define SIZE_FILE                   512
-#define SIZE_ERROR                  1024
+#define SIZE_ERROR                  1408
 
 #define MAX_THREADS                 128
 
@@ -501,7 +501,7 @@ class CometParam
 public:
    CometParam(CometParamType paramType, const string& strValue)
       : _paramType(paramType), _strValue(strValue) {}
-   virtual ~CometParam() {}
+   virtual ~CometParam() {cout << "virtual ~CometParam()" << endl;}
    string& GetStringValue() { return _strValue; }
 private:
    CometParamType _paramType;

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -173,7 +173,8 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
                                               vector<string>& vProteinDecoys)   // the decoy protein names if applicable
 {
    char szProteinName[WIDTH_REFERENCE];
-   char szDecoyProteinName[WIDTH_REFERENCE];
+   int iDECOY_WIDTH_REFERENCE = WIDTH_REFERENCE+256;
+   char szDecoyProteinName[iDECOY_WIDTH_REFERENCE];
    std::vector<ProteinEntryStruct>::iterator it;
 
    int iLenDecoyPrefix = strlen(g_staticParams.szDecoyPrefix);

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -173,7 +173,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
                                               vector<string>& vProteinDecoys)   // the decoy protein names if applicable
 {
    char szProteinName[WIDTH_REFERENCE];
-   int iDECOY_WIDTH_REFERENCE = WIDTH_REFERENCE+256;
+   const int iDECOY_WIDTH_REFERENCE = WIDTH_REFERENCE+256;
    char szDecoyProteinName[iDECOY_WIDTH_REFERENCE];
    std::vector<ProteinEntryStruct>::iterator it;
 

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -249,7 +249,7 @@ bool CometSearch::RunSearch(int iPercentStart,
       int  iLenAttributeVariantComplex = (int)strlen(szPeffAttributeVariantComplex);
       int  iLenAttributeMod = (int)strlen(szPeffAttributeMod);
       int  iNumBadChars = 0; // count # of bad (non-printing) characters in header 
-
+ 
       bool bHeadOfFasta = true;
       // Loop through entire database.
       while(!feof(fp))
@@ -1579,7 +1579,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
    if (_proteinInfo.iPeffNewResidueCount>0) // if not a deletion, adjust the position by 1
       iPeffRequiredVariantPositionB--;
 
-   if (iPeffRequiredVariantPosition == strlen(szProteinSeq)) //Edge case where PEFF variant is simply a truncation of the c-terminal amino acids
+   if (iPeffRequiredVariantPosition == (int)strlen(szProteinSeq)) //Edge case where PEFF variant is simply a truncation of the c-terminal amino acids
    {
       iPeffRequiredVariantPosition--;
       iPeffRequiredVariantPositionB--;

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -3091,7 +3091,7 @@ bool CometSearchManager::WriteIndexedDatabase(void)
 
    ThreadPool * tp = _tp;
 
-   int iIndex_SIZE_FILE=SIZE_FILE+4;
+   const int iIndex_SIZE_FILE=SIZE_FILE+4;
    char szIndexFile[iIndex_SIZE_FILE];
    sprintf(szIndexFile, "%s.idx", g_staticParams.databaseInfo.szDatabase);
 

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -378,7 +378,7 @@ static void PrintOutfileHeader()
 {
    // print parameters
 
-   char szIsotope[16];
+   char szIsotope[32];
    char szPeak[16];
 
    sprintf(g_staticParams.szIonSeries, "ion series ABCXYZ nl: %d%d%d%d%d%d%d %d",
@@ -1719,11 +1719,11 @@ bool CometSearchManager::DoSearch()
       char szOutputDecoyPepXML[1024];
       char szOutputMzIdentML[1024];
       char szOutputDecoyMzIdentML[1024];
-      char szOutputMzIdentMLtmp[1024];  // intermediate tmp file
-      char szOutputDecoyMzIdentMLtmp[1024];  // intermediate tmp file
+      char szOutputMzIdentMLtmp[1032];  // intermediate tmp file
+      char szOutputDecoyMzIdentMLtmp[1032];  // intermediate tmp file
       char szOutputPercolator[1024];
-      char szOutputTxt[1024];
-      char szOutputDecoyTxt[1024];
+      char szOutputTxt[1280];
+      char szOutputDecoyTxt[1280];
 
       if (g_staticParams.options.bOutputSqtFile)
       {
@@ -2169,7 +2169,7 @@ bool CometSearchManager::DoSearch()
             sprintf(szStatusMsg, " %d\n", (int)g_pvQuery.size());
             if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.bIndexDb)
             {
-               char szOut[128];
+               char szOut[256];
                sprintf(szOut, "%s", szStatusMsg);
                logout(szOut);
             }
@@ -3091,7 +3091,8 @@ bool CometSearchManager::WriteIndexedDatabase(void)
 
    ThreadPool * tp = _tp;
 
-   char szIndexFile[SIZE_FILE];
+   int iIndex_SIZE_FILE=SIZE_FILE+4;
+   char szIndexFile[iIndex_SIZE_FILE];
    sprintf(szIndexFile, "%s.idx", g_staticParams.databaseInfo.szDatabase);
 
    if ((fptr = fopen(szIndexFile, "wb")) == NULL)

--- a/CometSearch/CometWriteOut.cpp
+++ b/CometSearch/CometWriteOut.cpp
@@ -73,7 +73,7 @@ bool CometWriteOut::PrintResults(int iWhichQuery,
         szBuf[SIZE_BUF],
         szStatsBuf[512],
         szMassLine[200],
-        szOutput[1024],
+        szOutput[1280],
         scan1[32],
         scan2[32];
    FILE *fpout;
@@ -268,7 +268,7 @@ bool CometWriteOut::PrintResults(int iWhichQuery,
 
    if (iLenMaxDuplicates > 0)
    {
-      char szTempStr[10];
+      char szTempStr[13];
 
       sprintf(szTempStr, " %+d", iLenMaxDuplicates);
       iLenMaxDuplicates = (int)strlen(szTempStr);

--- a/CometSearch/ThreadPool.h
+++ b/CometSearch/ThreadPool.h
@@ -196,9 +196,9 @@ public:
    void drainPool()
    {
       shutdown_ = true;
-      for (size_t i =0 ; i < threads_.size(); i++)
+      for (size_t i =0 ; i < data_.size(); i++)
       {
-         delete data_[i];
+	
 #ifdef _WIN32
          WaitForSingleObject(threads_[i],INFINITE);
 #else
@@ -206,23 +206,15 @@ public:
          pthread_join(threads_[i],&ignore);
 #endif
       }
+      
+      if (data_.size()) delete data_[0];
       data_.clear();
 
    }
 
    ~ThreadPool ()
    {
-      for (size_t i =0 ; i < threads_.size(); i++)
-      {
-         delete data_[i];
-#ifdef _WIN32
-         WaitForSingleObject(threads_[i],INFINITE);
-#else
-         void* ignore = 0;
-         pthread_join(threads_[i],&ignore);
-#endif
-      }
-      data_.clear();
+     drainPool();
    }
 
    void doJob (std::function <void (void)> func)


### PR DESCRIPTION
Two fixes for memory leaks, the second is critical.

1. Increased the array sizes for several character strings to accommodate when they get concatenated. This fixes several compilation-time warnings. Likely these bufferes would not be overrun, but at least now they are protected against it.
2. Critical fix to ThreadPool.h that was causing a memory leak during clean-up after Comet analysis completion. This was causing an intermittent seg fault 11 on Linux runs. Perhaps similar problems on other systems. It looks like CometSearchManager.cpp had some indirect code that ineffectively dealt with the issue (see approx. line 595) but I'm not sure. Further testing is needed.