### PR TITLE
Second fragment neutral loss; address issue 72

### DIFF
--- a/Comet.cpp
+++ b/Comet.cpp
@@ -595,9 +595,9 @@ void LoadParameters(char *pszParamsFile,
 
                // the 8th entry can have to fragment NL values, comma separated
                if (pStr = strchr(szTmp1, ','))
-                  sscanf(szTmp, "%lf,%lf", &varModsParam.dNeutralLoss, &varModsParam.dNeutralLoss2);
+                  sscanf(szTmp1, "%lf,%lf", &varModsParam.dNeutralLoss, &varModsParam.dNeutralLoss2);
                else
-                  sscanf(szTmp, "%lf,%lf", &varModsParam.dNeutralLoss);
+                  sscanf(szTmp1, "%lf", &varModsParam.dNeutralLoss);
 
                // the 4th entry can either be just the max_num_var_mod or a comma separated
                // value composed of min_num,max_num

--- a/Comet.cpp
+++ b/Comet.cpp
@@ -594,7 +594,7 @@ void LoadParameters(char *pszParamsFile,
                char *pStr;
 
                // the 8th entry can have to fragment NL values, comma separated
-               if (pStr = strchr(szTmp1, ','))
+               if ( (pStr = strchr(szTmp1, ',')) )
                   sscanf(szTmp1, "%lf,%lf", &varModsParam.dNeutralLoss, &varModsParam.dNeutralLoss2);
                else
                   sscanf(szTmp1, "%lf", &varModsParam.dNeutralLoss);
@@ -1418,7 +1418,11 @@ void LoadParameters(char *pszParamsFile,
       }
    } // while
 
-   fgets(szParamBuf, SIZE_BUF, fp);
+   if ( (fgets(szParamBuf, SIZE_BUF, fp) == NULL))
+   {
+      sprintf(szErrorMsg, " Error - cannot fgets a line after expected [COMET_ENZYME_INFO]\n");
+      logout(szErrorMsg);
+   }
 
    // Get enzyme specificity.
    char szSearchEnzymeName[ENZYME_NAME_LEN];

--- a/Comet.cpp
+++ b/Comet.cpp
@@ -578,9 +578,10 @@ void LoadParameters(char *pszParamsFile,
             else if (!strncmp(szParamName, "variable_mod", 12) && strlen(szParamName)==14)
             {
                char szTmp[512];
+               char szTmp1[512];
 
                varModsParam.szVarModChar[0] = '\0';
-               sscanf(szParamVal, "%lf %31s %d %511s %d %d %d %lf",
+               sscanf(szParamVal, "%lf %31s %d %511s %d %d %d %s",
                      &varModsParam.dVarModMass,
                      varModsParam.szVarModChar,
                      &varModsParam.iBinaryMod,
@@ -588,11 +589,18 @@ void LoadParameters(char *pszParamsFile,
                      &varModsParam.iVarModTermDistance,
                      &varModsParam.iWhichTerm,
                      &varModsParam.iRequireThisMod,
-                     &varModsParam.dNeutralLoss);
+                     szTmp1);
+
+               char *pStr;
+
+               // the 8th entry can have to fragment NL values, comma separated
+               if (pStr = strchr(szTmp1, ','))
+                  sscanf(szTmp, "%lf,%lf", &varModsParam.dNeutralLoss, &varModsParam.dNeutralLoss2);
+               else
+                  sscanf(szTmp, "%lf,%lf", &varModsParam.dNeutralLoss);
 
                // the 4th entry can either be just the max_num_var_mod or a comma separated
                // value composed of min_num,max_num
-               char *pStr;
                if ( (pStr=strchr(szTmp, ',')) == NULL)
                {
                   sscanf(szTmp, "%d", &varModsParam.iMaxNumVarModAAPerMod);

--- a/CometSearch/CometData.h
+++ b/CometSearch/CometData.h
@@ -223,6 +223,7 @@ struct VarMods
 {
    double dVarModMass;
    double dNeutralLoss;
+   double dNeutralLoss2;    // 2nd neutral fragment NL
    int    iBinaryMod;
    int    iMaxNumVarModAAPerMod;
    int    iMinNumVarModAAPerMod;
@@ -244,6 +245,7 @@ struct VarMods
       iWhichTerm = 0;
       dVarModMass = 0.0;
       dNeutralLoss = 0.0;
+      dNeutralLoss2 = 0.0;
       szVarModChar[0] = '\0';
       bNtermMod = false;
       bCtermMod = false;
@@ -260,6 +262,7 @@ struct VarMods
       iWhichTerm = a.iWhichTerm;
       dVarModMass = a.dVarModMass;
       dNeutralLoss = a.dNeutralLoss;
+      dNeutralLoss2 = a.dNeutralLoss2;
       strcpy(szVarModChar, a.szVarModChar);
       bNtermMod  = a.bNtermMod;
       bCtermMod  = a.bCtermMod;
@@ -277,6 +280,7 @@ struct VarMods
       dVarModMass = a.dVarModMass;
       strcpy(szVarModChar, a.szVarModChar);
       dNeutralLoss = a.dNeutralLoss;
+      dNeutralLoss2 = a.dNeutralLoss2;
       bNtermMod  = a.bNtermMod;
       bCtermMod  = a.bCtermMod;
       bUseMod  = a.bUseMod;

--- a/CometSearch/CometDataInternal.h
+++ b/CometSearch/CometDataInternal.h
@@ -805,6 +805,7 @@ struct StaticParams
          variableModParameters.varModList[i].iWhichTerm = 0;             // specify N (0) or C-term (1)
          variableModParameters.varModList[i].dVarModMass = 0.0;
          variableModParameters.varModList[i].dNeutralLoss = 0.0;
+         variableModParameters.varModList[i].dNeutralLoss2 = 0.0;
          strcpy(variableModParameters.varModList[i].szVarModChar, "X");
 
 #ifdef CRUX

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -793,8 +793,9 @@ bool CometFragmentIndex::WritePlainPeptideIndex(ThreadPool *tp)
    // write VariableMod:
    fprintf(fp, "VariableMod:");
    for (int x = 0; x < FRAGINDEX_VMODS; ++x)
-      fprintf(fp, " %lf:%lf:%s", g_staticParams.variableModParameters.varModList[x].dVarModMass,
+      fprintf(fp, " %lf:%lf:%lf:%s", g_staticParams.variableModParameters.varModList[x].dVarModMass,
          g_staticParams.variableModParameters.varModList[x].dNeutralLoss,
+         g_staticParams.variableModParameters.varModList[x].dNeutralLoss2,
          g_staticParams.variableModParameters.varModList[x].szVarModChar);
    fprintf(fp, "\n");
 
@@ -1021,8 +1022,9 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
 
             iss >> subStr;  // parse each word which is a colon delimited triplet pair for modmass:neutralloss:modchars
 
-            int iRet = sscanf(subStr.c_str(), "%lf:%lf:%s", &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
+            int iRet = sscanf(subStr.c_str(), "%lf:%lf:%lf:%s", &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
                &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss),
+               &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss2),
                g_staticParams.variableModParameters.varModList[iNumMods].szVarModChar);
 
             iNumMods++;

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -387,11 +387,17 @@ void CometMassSpecUtils::GetPrevNextAA(FILE *fpfasta,
 
          if (strSeq.size() < 1)
          {
-            printf("Error - parsed sequence in GetPrevNextAA() is empty.  File pointer %ld, query %d, result %d.\n", *it, iWhichQuery, iWhichResult);
+            printf(" Error: parsed sequence in GetPrevNextAA() is empty.  File pointer %ld, query %d, result %d.\n", *it, iWhichQuery, iWhichResult);
             pOutput[iWhichResult].cPrevAA = pOutput[iWhichResult].cNextAA = '-';
             return;
          }
          char* szSequence = (char*)malloc(strSeq.size() + 1);
+
+         if (szSequence == NULL)
+         {
+            printf(" Error: cannot allocate memory for szSequence[%d]\n", strSeq.size() + 1);
+            exit(1);
+         }
          strcpy(szSequence, strSeq.c_str());
 
          int iLenSequence = (int)strlen(szSequence);
@@ -512,7 +518,7 @@ void CometMassSpecUtils::GetPrevNextAA(FILE *fpfasta,
 
       if (!bFound)
       {
-         printf(" Error, did not match peptide in GetPrevNextAA(); pep %s, iWhichQuery %d, iWhichResult %d\n",
+         printf(" Error: did not match peptide in GetPrevNextAA(); pep %s, iWhichQuery %d, iWhichResult %d\n",
                pOutput[iWhichResult].szPeptide, iWhichQuery, iWhichResult);
          exit(1);
       }

--- a/CometSearch/CometPostAnalysis.cpp
+++ b/CometSearch/CometPostAnalysis.cpp
@@ -532,68 +532,97 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                      {
                         for (int iMod = 0; iMod < VMODS; iMod++)
                         {
-                           if (iWhichIonSeries <= 2)  // abc ions
+                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                            {
-                              if (iCountNLB[iMod][iii] > 0)
+                              if (iWhichIonSeries <= 2)  // abc ions
                               {
-                                 int iScaleFactor = iCountNLB[iMod][iii];
-                                 double dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss / ctCharge);
-
-                                 if (dNewMass >= 0)
+                                 if (iCountNLB[iMod][iii] > 0)
                                  {
-                                    int iFragmentIonMass = BIN(dNewMass);
-
-                                    fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
-
-                                    if (fSpScore > FLOAT_ZERO)
+                                    int iScaleFactor = iCountNLB[iMod][iii];
+                                    double dNewMass;
+ 
+                                    if (iWhichNL == 0)
                                     {
-                                       iAddMatchedFragment = 1;
-
-                                       // Simple sum intensity.
-                                       dTmpIntenMatch += fSpScore;
-
-                                       // Increase score for consecutive fragment ion series matches.
-                                       if (ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge])
-                                          dAddConsecutive = 0.075;
-
-                                       ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 1;
+                                       if (g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss == 0.0)
+                                          continue;
+                                       dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss / ctCharge);
                                     }
                                     else
                                     {
-                                       ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 0;
+                                       if (g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2 == 0.0)
+                                          continue;
+                                       dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2 / ctCharge);
+                                    }
+
+                                    if (dNewMass >= 0)
+                                    {
+                                       int iFragmentIonMass = BIN(dNewMass);
+
+                                       fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
+
+                                       if (fSpScore > FLOAT_ZERO)
+                                       {
+                                          iAddMatchedFragment = 1;
+
+                                          // Simple sum intensity.
+                                          dTmpIntenMatch += fSpScore;
+
+                                          // Increase score for consecutive fragment ion series matches.
+                                          if (ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge])
+                                             dAddConsecutive = 0.075;
+
+                                          ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 1;
+                                       }
+                                       else
+                                       {
+                                          ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 0;
+                                       }
                                     }
                                  }
                               }
-                           }
-                           else // xyz ions
-                           {
-                              if (iCountNLY[iMod][iii] > 0)
+                              else // xyz ions
                               {
-                                 int iScaleFactor = iCountNLY[iMod][iii];
-                                 double dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss / ctCharge);
-                              
-                                 if (dNewMass >= 0)
+                                 if (iCountNLY[iMod][iii] > 0)
                                  {
-                                    int iFragmentIonMass = BIN(dNewMass);
+                                    int iScaleFactor = iCountNLY[iMod][iii];
+                                    double dNewMass;
 
-                                    fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
-
-                                    if (fSpScore > FLOAT_ZERO)
+                                    if (iWhichNL == 0)
                                     {
-                                       iAddMatchedFragment = 1;
-
-                                       // Simple sum intensity.
-                                       dTmpIntenMatch += fSpScore;
-
-                                       // Increase score for consecutive fragment ion series matches.
-                                       if (ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge])
-                                          dAddConsecutive = 0.075;
-
-                                       ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 1;
+                                       if (g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss == 0.0)
+                                          continue;
+                                       dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss / ctCharge);
                                     }
                                     else
                                     {
-                                       ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 0;
+                                       if (g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2 == 0.0)
+                                          continue;
+                                       dNewMass = dFragmentIonMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2 / ctCharge);
+                                    }
+
+                                    if (dNewMass >= 0)
+                                    {
+                                       int iFragmentIonMass = BIN(dNewMass);
+
+                                       fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
+
+                                       if (fSpScore > FLOAT_ZERO)
+                                       {
+                                          iAddMatchedFragment = 1;
+
+                                          // Simple sum intensity.
+                                          dTmpIntenMatch += fSpScore;
+
+                                          // Increase score for consecutive fragment ion series matches.
+                                          if (ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge])
+                                             dAddConsecutive = 0.075;
+
+                                          ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 1;
+                                       }
+                                       else
+                                       {
+                                          ionSeries[iWhichIonSeries].bPreviousMatch[ctCharge] = 0;
+                                       }
                                     }
                                  }
                               }

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -1457,7 +1457,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
             dYion += g_staticParams.massUtility.pdAAMassFragment[(int)szPeptide[iPosReverse]];
             if (piVarModSites[iPosReverse] > 0)
             {
-               int iPosReverseModSite = iPosReverse; //FIX check if this works and if so, remove redundant variable
+               int iPosReverseModSite = iPosReverse;
 
                int iMod = piVarModSites[iPosReverseModSite] - 1;
 
@@ -2041,38 +2041,45 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                   {
                      double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse);
 
-                     pbDuplFragment[BIN(dFragMass)] = false;
-                     _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+                     int iVal = BIN(dFragMass);
 
-                     // initialize fragmentNL
-                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                     if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
                      {
-                        for (int x=0; x<VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
+                        pbDuplFragment[iVal] = false;
+                        _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+
+                        // initialize fragmentNL
+                        if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                         {
-                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                           for (int x=0; x<VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
                            {
-                              if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
-                                 continue;
-                              else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
-                                 continue;
-
-                              if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                              for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                               {
-                                 double dNewMass;
+                                 if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                                    continue;
+                                 else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                                    continue;
 
-                                 if (iWhichNL == 0)
-                                    dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss/ctCharge;
-                                 else
-                                    dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2/ctCharge;
-
-                                 if (dNewMass >= 0.0)
+                                 if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
+                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
-                                    pbDuplFragment[BIN(dNewMass)] = false;
-                                    iFoundVariableMod = 2;
-                                 }
+                                    double dNewMass;
 
-                                 _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                                    if (iWhichNL == 0)
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss/ctCharge;
+                                    else
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2/ctCharge;
+
+                                    iVal = BIN(dNewMass);
+
+                                    if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
+                                    {
+                                       pbDuplFragment[iVal] = false;
+                                       iFoundVariableMod = 2;
+                                    }
+
+                                    _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                                 }
                               }
                            }
                         }
@@ -2088,7 +2095,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                   double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                   int iVal = BIN(dNLMass);
 
-                  if (iVal > 0)
+                  if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
                   {
                      pbDuplFragment[iVal] = false;
                      _uiBinnedPrecursorNL[ctNL][ctCharge] = 0;
@@ -2109,7 +2116,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                      double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse);
                      int iVal = BIN(dFragMass);
 
-                     if (pbDuplFragment[iVal] == false)
+                     if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                      {
                         _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
                         pbDuplFragment[iVal] = true;
@@ -2138,7 +2145,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
                                  iVal = BIN(dNewMass);
 
-                                 if (iVal > 0 && pbDuplFragment[iVal] == false)
+                                 if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                                  {
                                     _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
                                     pbDuplFragment[iVal] = true;
@@ -2159,7 +2166,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                   double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                   int iVal = BIN(dNLMass);
 
-                  if (iVal > 0 && pbDuplFragment[iVal] == false)
+                  if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                   {
                      _uiBinnedPrecursorNL[ctNL][ctCharge] = iVal;
                      pbDuplFragment[iVal] = true;
@@ -2258,38 +2265,44 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                      {
                         double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy);
 
-                        pbDuplFragment[BIN(dFragMass)] = false;
-                        _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+                        int iVal = BIN(dFragMass);
 
-                        // initialize fragmentNL
-                        if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                        if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
                         {
-                           for (int x = 0; x < VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
+                           pbDuplFragment[iVal] = false;
+                           _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+
+                           // initialize fragmentNL
+                           if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                            {
-                              for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                              for (int x = 0; x < VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
                               {
-                                 if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
-                                    continue;
-                                 else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
-                                    continue;
-
-                                 if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                 for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                                  {
-                                    double dNewMass;
+                                    if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                                       continue;
+                                    else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                                       continue;
 
-                                    if (iWhichNL == 0)
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
-                                    else
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
-
-                                    if (dNewMass >= 0.0)
+                                    if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
+                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
-                                       pbDuplFragment[BIN(dNewMass)] = false;
-                                       iFoundVariableModDecoy = 2;
-                                    }
+                                       double dNewMass;
 
-                                    _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                                       if (iWhichNL == 0)
+                                          dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
+                                       else
+                                          dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
+
+                                       iVal = BIN(dNewMass);
+                                       if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
+                                       {
+                                          pbDuplFragment[iVal] = false;
+                                          iFoundVariableModDecoy = 2;
+                                       }
+
+                                       _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                                    }
                                  }
                               }
                            }
@@ -2305,7 +2318,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                      double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                      int iVal = BIN(dNLMass);
 
-                     if (iVal > 0)
+                     if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex)
                      {
                         pbDuplFragment[iVal] = false;
                         _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = 0;
@@ -2326,7 +2339,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                         double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy);
                         int iVal = BIN(dFragMass);
 
-                        if (pbDuplFragment[iVal] == false)
+                        if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                         {
                            _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = iVal;
                            pbDuplFragment[iVal] = true;
@@ -2355,7 +2368,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
                                     iVal = BIN(dNewMass);
 
-                                    if (iVal > 0 && pbDuplFragment[iVal] == false)
+                                    if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                                     {
                                        _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
                                        pbDuplFragment[iVal] = true;
@@ -2376,7 +2389,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                      double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                      int iVal = BIN(dNLMass);
 
-                     if (iVal > 0 && pbDuplFragment[iVal] == false)
+                     if (iVal > 0 && iVal < g_massRange.g_uiMaxFragmentArrayIndex && pbDuplFragment[iVal] == false)
                      {
                         _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = iVal;
                         pbDuplFragment[iVal] = true;
@@ -2456,9 +2469,6 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
      sort(dbe.vectorPeffVariantComplex.begin(), dbe.vectorPeffVariantComplex.end());
 
    memset(piVarModCounts, 0, sizeof(piVarModCounts));
-
-   if (g_staticParams.options.bClipNtermAA) // skip the N-term residue of every peptide
-      iStartPos = 1;
 
    unsigned short siVarModProteinFilter = 0;  // bitwise representation of mmapProtein, all bits set to "0" initially
 
@@ -2813,9 +2823,14 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 
                               for (ctLen = 0; ctLen < iLenMinus1; ++ctLen)
                               {
-                                 pbDuplFragment[BIN(CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse))] = false;
-                                 _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+                                 int iVal = BIN(CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse));
+
+                                 if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+                                 {
+                                    pbDuplFragment[iVal] = false;
+                                    _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
                                  // note no need to initialize fragment NL positions as no mods here
+                                 }
                               }
 
                            }
@@ -2828,7 +2843,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                               int iVal = BIN(dNLMass);
 
-                              if (iVal > 0)
+                              if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                               {
                                  pbDuplFragment[iVal] = false;
                                  _uiBinnedPrecursorNL[ctNL][ctCharge] = 0;
@@ -2849,7 +2864,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               {
                                  int iVal = BIN(CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse));
 
-                                 if (pbDuplFragment[iVal] == false)
+                                 if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                                  {
                                     _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
                                     pbDuplFragment[iVal] = true;
@@ -2868,7 +2883,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                               int iVal = BIN(dNLMass);
 
-                              if (iVal > 0 && pbDuplFragment[iVal] == false)
+                              if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                               {
                                  _uiBinnedPrecursorNL[ctNL][ctCharge] = iVal;
                                  pbDuplFragment[iVal] = true;
@@ -2962,8 +2977,13 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 
                               for (ctLen = 0; ctLen < iLenMinus1; ++ctLen)
                               {
-                                 pbDuplFragment[BIN(CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy))] = false;
-                                 _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+                                 int iVal = BIN(CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy));
+
+                                 if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+                                 {
+                                    pbDuplFragment[iVal] = false;
+                                    _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+                                 }
                               }
                            }
                         }
@@ -2975,7 +2995,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                               int iVal = BIN(dNLMass);
 
-                              if (iVal > 0)
+                              if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                               {
                                  pbDuplFragment[iVal] = false;
                                  _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = 0;
@@ -2997,7 +3017,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                                  double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy);
                                  int iVal = BIN(dFragMass);
 
-                                 if (pbDuplFragment[iVal] == false)
+                                 if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                                  {
                                     _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = iVal;
                                     pbDuplFragment[iVal] = true;
@@ -3016,7 +3036,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                               int iVal = BIN(dNLMass);
 
-                              if (iVal > 0 && pbDuplFragment[iVal] == false)
+                              if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                               {
                                  _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = iVal;
                                  pbDuplFragment[iVal] = true;
@@ -6957,7 +6977,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
 
                if (piVarModSites[iPosReverseModSite] > 0)
                {
-                  int iMod = piVarModSites[iPosReverseModSite]-1;
+                  int iMod = piVarModSites[iPosReverseModSite] - 1;
 
                   dYion += g_staticParams.variableModParameters.varModList[iMod].dVarModMass;
 
@@ -6995,45 +7015,52 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   {
                      double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse);
 
-                     pbDuplFragment[BIN(dFragMass)] = false;
-                     _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+                     int iVal = BIN(dFragMass);
 
-                     // initialize fragmentNL
-                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                     if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                      {
-                        for (int x = 0; x < VMODS; ++x)
+                        pbDuplFragment[iVal] = false;
+                        _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+
+                        // initialize fragmentNL
+                        if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                         {
-                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                           for (int x = 0; x < VMODS; ++x)
                            {
-                              if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
-                                 continue;
-                              else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
-                                 continue;
-
-                              if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                 || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                              for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                               {
-                                 int iScaleFactor;
+                                 if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                                    continue;
+                                 else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                                    continue;
 
-                                 if (iWhichIonSeries <= 2)
-                                    iScaleFactor = iCountNLB[x][ctLen];
-                                 else
-                                    iScaleFactor = iCountNLY[x][ctLen];
-
-                                 double dNewMass;
-
-                                 if (iWhichNL == 0)
-                                    dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
-                                 else
-                                    dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
-
-                                 if (dNewMass > 0.0)
+                                 if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
+                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
-                                    pbDuplFragment[BIN(dNewMass)] = false;
-                                 }
-                              }
+                                    int iScaleFactor;
 
-                              _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                                    if (iWhichIonSeries <= 2)
+                                       iScaleFactor = iCountNLB[x][ctLen];
+                                    else
+                                       iScaleFactor = iCountNLY[x][ctLen];
+
+                                    double dNewMass;
+
+                                    if (iWhichNL == 0)
+                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
+                                    else
+                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
+
+                                    iVal = BIN(dNewMass);
+
+                                    if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+                                    {
+                                       pbDuplFragment[iVal] = false;
+                                    }
+                                 }
+
+                                 _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                              }
                            }
                         }
                      }
@@ -7049,9 +7076,9 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                   int iVal = BIN(dNLMass);
 
-                  if (iVal > 0)
+                  if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                   {
-                     pbDuplFragment[BIN(dNLMass)] = false;
+                     pbDuplFragment[iVal] = false;
                      _uiBinnedPrecursorNL[ctNL][ctCharge] = 0;
                   }
                }
@@ -7072,7 +7099,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
 
                      int iVal = BIN(dFragMass);
 
-                     if (pbDuplFragment[iVal] == false)
+                     if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                      {
                         _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
                         pbDuplFragment[iVal] = true;
@@ -7110,7 +7137,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                  {
                                     iVal = BIN(dNewMass);
 
-                                    if (pbDuplFragment[iVal] == false)
+                                    if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                                     {
                                        _uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
                                        pbDuplFragment[iVal] = true;
@@ -7133,7 +7160,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
 
                   int iVal = BIN(dNLMass);
 
-                  if (iVal > 0 && pbDuplFragment[iVal] == false)
+                  if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                   {
                      // increment 2nd charge dimension up from 0
                      _uiBinnedPrecursorNL[ctNL][ctCharge] = iVal;
@@ -7325,36 +7352,43 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                      {
                         double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy);
 
-                        pbDuplFragment[BIN(dFragMass)] = false;
-                        _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+                        int iVal = BIN(dFragMass);
 
-                        if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                        if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                         {
-                           for (int x = 0; x < VMODS; ++x)
+                           pbDuplFragment[iVal] = false;
+                           _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = 0;
+
+                           if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                            {
-                              for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                              for (int x = 0; x < VMODS; ++x)
                               {
-                                 if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
-                                    continue;
-                                 else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
-                                    continue;
-
-                                 if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                 for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                                  {
-                                    double dNewMass;
+                                    if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                                       continue;
+                                    else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                                       continue;
 
-                                    if (iWhichNL == 0)
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
-                                    else
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
-
-                                    if (dNewMass >= 0.0)
+                                    if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
+                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
-                                       pbDuplFragment[BIN(dNewMass)] = false;
+                                       double dNewMass;
+
+                                       if (iWhichNL == 0)
+                                          dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
+                                       else
+                                          dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
+
+                                       iVal = BIN(dNewMass);
+
+                                       if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+                                       {
+                                          pbDuplFragment[iVal] = false;
+                                       }
                                     }
+                                    _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
                                  }
-                                 _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
                               }
                            }
                         }
@@ -7370,7 +7404,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                      double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                      int iVal = BIN(dNLMass);
 
-                     if (iVal > 0)
+                     if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
                      {
                         pbDuplFragment[iVal] = false;
                         _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = 0;
@@ -7392,7 +7426,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                         double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforwardDecoy, _pdAAreverseDecoy);
                         int iVal = BIN(dFragMass);
 
-                        if (pbDuplFragment[iVal] == false)
+                        if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                         {
                            _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = iVal;
                            pbDuplFragment[iVal] = true;
@@ -7421,7 +7455,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
 
                                     iVal = BIN(dNewMass);
 
-                                    if (iVal > 0 && pbDuplFragment[iVal] == false)
+                                    if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                                     {
                                        _uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
                                        pbDuplFragment[iVal] = true;
@@ -7442,7 +7476,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                      double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
                      int iVal = BIN(dNLMass);
 
-                     if (iVal > 0 && pbDuplFragment[iVal] == false)
+                     if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
                      {
                         // increment 2nd charge dimension up from 0
                         _uiBinnedPrecursorNLDecoy[ctNL][ctCharge] = iVal;

--- a/CometSearch/CometSearch.h
+++ b/CometSearch/CometSearch.h
@@ -163,7 +163,7 @@ private:
                    int iLenPeptide,
                    int *piVarModSites,
                    struct sDBEntry *dbe,
-                   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS+1],
+                   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS+2],
                    unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
                    int iNumMatchedFragmentIons);
 /*
@@ -308,8 +308,8 @@ private:
    int                _iSizepdVarModSites;
    VarModInfo         _varModInfo;
 
-   unsigned int       _uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 1];
-   unsigned int       _uiBinnedIonMassesDecoy[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 1];
+   unsigned int       _uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];   // +2 for two fragment NL series
+   unsigned int       _uiBinnedIonMassesDecoy[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
    unsigned int       _uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
    unsigned int       _uiBinnedPrecursorNLDecoy[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
 

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -1490,6 +1490,7 @@ bool CometSearchManager::InitializeStaticParams()
                // ignore that case is this will cover 99% of the utility.
                if (     (g_staticParams.variableModParameters.varModList[i].dVarModMass== g_staticParams.variableModParameters.varModList[ii].dVarModMass)
                      && (g_staticParams.variableModParameters.varModList[i].dNeutralLoss == g_staticParams.variableModParameters.varModList[ii].dNeutralLoss)
+                     && (g_staticParams.variableModParameters.varModList[i].dNeutralLoss2 == g_staticParams.variableModParameters.varModList[ii].dNeutralLoss2)
                      && (g_staticParams.variableModParameters.varModList[i].iBinaryMod == g_staticParams.variableModParameters.varModList[ii].iBinaryMod)
                      && (g_staticParams.variableModParameters.varModList[i].iMaxNumVarModAAPerMod == g_staticParams.variableModParameters.varModList[ii].iMaxNumVarModAAPerMod)
                      && (g_staticParams.variableModParameters.varModList[i].iMinNumVarModAAPerMod == g_staticParams.variableModParameters.varModList[ii].iMinNumVarModAAPerMod)
@@ -3503,48 +3504,56 @@ bool CometSearchManager::DoSingleSpectrumSearch(int iPrecursorCharge,
                {
                   for (int iMod = 0; iMod < VMODS; ++iMod)
                   {
-                     double dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
-
-                     if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
+                     for (int iWhichNL = 0; iWhichNL < 2 ; ++iWhichNL)
                      {
-                        continue;  // continue if this iMod entry has no mod mass or no NL mass specified
-                     }
+                        double dNLmass;
 
-                     if (isNTerm)
-                     {
-                        // if have not already come across n-term mod residue for variable mod iMod, see if position i contains the variable mod
-                        if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[0].piVarModSites[i] == iMod + 1)
+                        if (iWhichNL == 0)
+                           dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
+                        else
+                           dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
+
+                        if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
                         {
-                           bAddNtermFragmentNeutralLoss[iMod] = true;
+                           continue;  // continue if this iMod entry has no mod mass or no NL mass specified
                         }
-                     }
-                     else
-                     {
-                        if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[0].piVarModSites[iPos] == iMod + 1)
+
+                        if (isNTerm)
                         {
-                           bAddCtermFragmentNeutralLoss[iMod] = true;
+                           // if have not already come across n-term mod residue for variable mod iMod, see if position i contains the variable mod
+                           if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[0].piVarModSites[i] == iMod + 1)
+                           {
+                              bAddNtermFragmentNeutralLoss[iMod] = true;
+                           }
                         }
-                     }
+                        else
+                        {
+                           if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[0].piVarModSites[iPos] == iMod + 1)
+                           {
+                              bAddCtermFragmentNeutralLoss[iMod] = true;
+                           }
+                        }
 
-                     if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
-                        || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
-                     {
-                        continue;  // no fragment NL yet in peptide so continue
-                     }
+                        if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
+                           || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
+                        {
+                           continue;  // no fragment NL yet in peptide so continue
+                        }
 
-                     double dNLfragMz = mz - (dNLmass / ctCharge);
-                     iTmp = BIN(dNLfragMz);
-                     if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
-                     {
-                        Fragment frag;
-                        frag.intensity = pdTmpSpectrum[iTmp];
-                        frag.mass = mass - dNLmass;
-                        frag.type = ionSeries;
-                        frag.number = fragNumber;
-                        frag.charge = ctCharge;
-                        frag.neutralLoss = true;
-                        frag.neutralLossMass = dNLmass;
-                        matchedFragments.push_back(frag);
+                        double dNLfragMz = mz - (dNLmass / ctCharge);
+                        iTmp = BIN(dNLfragMz);
+                        if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
+                        {
+                           Fragment frag;
+                           frag.intensity = pdTmpSpectrum[iTmp];
+                           frag.mass = mass - dNLmass;
+                           frag.type = ionSeries;
+                           frag.number = fragNumber;
+                           frag.charge = ctCharge;
+                           frag.neutralLoss = true;
+                           frag.neutralLossMass = dNLmass;
+                           matchedFragments.push_back(frag);
+                        }
                      }
                   }
                }
@@ -3873,48 +3882,56 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
                   {
                      for (int iMod = 0; iMod < VMODS; ++iMod)
                      {
-                        double dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
-
-                        if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
+                        for (int iWhichNL = 0; iWhichNL < 2 ; ++iWhichNL)
                         {
-                           continue;  // continue if this iMod entry has no mod mass or no NL mass specified
-                        }
+                           double dNLmass;
 
-                        if (isNTerm)
-                        {
-                           // if have not already come across n-term mod residue for variable mod iMod, see if position i contains the variable mod
-                           if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[idx].piVarModSites[i] == iMod + 1)
+                           if (iWhichNL == 0)
+                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
+                           else
+                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
+
+                           if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
                            {
-                              bAddNtermFragmentNeutralLoss[iMod] = true;
+                              continue;  // continue if this iMod entry has no mod mass or no NL mass specified
                            }
-                        }
-                        else
-                        {
-                           if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[idx].piVarModSites[iPos] == iMod + 1)
+
+                           if (isNTerm)
                            {
-                              bAddCtermFragmentNeutralLoss[iMod] = true;
+                              // if have not already come across n-term mod residue for variable mod iMod, see if position i contains the variable mod
+                              if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[idx].piVarModSites[i] == iMod + 1)
+                              {
+                                 bAddNtermFragmentNeutralLoss[iMod] = true;
+                              }
                            }
-                        }
+                           else
+                           {
+                              if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[idx].piVarModSites[iPos] == iMod + 1)
+                              {
+                                 bAddCtermFragmentNeutralLoss[iMod] = true;
+                              }
+                           }
 
-                        if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
-                           || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
-                        {
-                           continue;  // no fragment NL yet in peptide so continue
-                        }
+                           if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
+                              || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
+                           {
+                              continue;  // no fragment NL yet in peptide so continue
+                           }
 
-                        double dNLfragMz = mz - (dNLmass / ctCharge);
-                        iTmp = BIN(dNLfragMz);
-                        if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
-                        {
-                           Fragment frag;
-                           frag.intensity = pdTmpSpectrum[iTmp];
-                           frag.mass = mass - dNLmass;
-                           frag.type = ionSeries;
-                           frag.number = fragNumber;
-                           frag.charge = ctCharge;
-                           frag.neutralLoss = true;
-                           frag.neutralLossMass = dNLmass;
-                           eachMatchedFragments.push_back(frag);
+                           double dNLfragMz = mz - (dNLmass / ctCharge);
+                           iTmp = BIN(dNLfragMz);
+                           if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
+                           {
+                              Fragment frag;
+                              frag.intensity = pdTmpSpectrum[iTmp];
+                              frag.mass = mass - dNLmass;
+                              frag.type = ionSeries;
+                              frag.number = fragNumber;
+                              frag.charge = ctCharge;
+                              frag.neutralLoss = true;
+                              frag.neutralLossMass = dNLmass;
+                              eachMatchedFragments.push_back(frag);
+                           }
                         }
                      }
                   }

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -2013,9 +2013,10 @@ void CometSearchManager::GetStatusMessage(string &strStatusMsg)
 
 bool CometSearchManager::IsValidCometVersion(const string &version)
 {
+printf("OK comet_version %s, version.str %s\n", comet_version, version.c_str() );
     // Major version number must match to current binary
     if (strstr(comet_version, version.c_str())
-          || strstr(comet_version, "2024.0"))
+          || strstr(version.c_str(), "2024.0"))
     {
        return true;
     }

--- a/CometSearch/Common.h
+++ b/CometSearch/Common.h
@@ -70,7 +70,7 @@ using namespace std;
    #define GITHUBSHA ""
 #endif
 
-#define comet_version   "2024.02 rev. 1"
+#define comet_version   "2025.01 rev. 0"
 #define copyright "(c) University of Washington"
 extern string g_sCometVersion;   // version string including git hash
 


### PR DESCRIPTION
Adds support for a second fragment neutral loss for each variable modification parameter.
Fix bug reported by issue 72 by adding missing bounds checks on arrays.
Increment version string to v2025.01 rev. 0 in preparation for another release.