### PR TITLE
Threaded rts

### DIFF
--- a/.github/workflows/aarch-linux-build.yml
+++ b/.github/workflows/aarch-linux-build.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [ created ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/aarch-macos-build.yml
+++ b/.github/workflows/aarch-macos-build.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [ created ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-14

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: uwpr/comet
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [ created ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-14

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -8,12 +8,15 @@ on:
   release:
     types: [ created ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: self-hosted
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Mark git working directory as safe
       shell: cmd

--- a/CometSearch/CometDataInternal.h
+++ b/CometSearch/CometDataInternal.h
@@ -265,7 +265,6 @@ struct Results
    char   cNextAA;                            // stores following flanking AA
    bool   bClippedM;                          // true if new N-term protein due to clipped methionine
    char   cHasVariableMod;                    // HasVariableModType enum: 0 = no variable mod, 1 = has variable mod, 2 = has AScorePro mod
-   string strSingleSearchProtein;             // used only in single spectrum search to return protein name from index file
    string sPeffOrigResidues;                  // original residue(s) of a PEFF variant
    string sAScoreProSiteScores;               // AScorePro site scores as comma-separated string
    int    iPeffOrigResiduePosition;           // position of PEFF variant substitution; -1 = n-term, iLenPeptide = c-term; -9=unused
@@ -764,6 +763,15 @@ struct IonInfo
    }
 };
 
+// Identifies which type of database is being searched.
+// Defined before StaticParams so iDbType can use DbType.
+enum class DbType
+{
+   FASTA_DB = 0,  // normal FASTA sequence database
+   FI_DB = 1,     // fragment ion index (.idx)
+   PI_DB = 2      // peptide index (.idx)
+};
+
 // static user params, won't change per thread - can make global!
 struct StaticParams
 {
@@ -793,7 +801,7 @@ struct StaticParams
    double          dOneMinusBinOffset;  // this is used in BIN() many times so calculate once
    IonInfo         ionInformation;
    int             iXcorrProcessingOffset;
-   int             iIndexDb;            // 0 = normal fasta; 1 = fragment ion indexed; 2 = peptide index
+   DbType          iDbType;            // FASTA_DB = normal fasta; FI_DB = fragment ion indexed; PI_DB = peptide index
    vector<double>  vectorMassOffsets;
    vector<double>  precursorNLIons;
    int             iPrecursorNLSize;
@@ -847,7 +855,7 @@ struct StaticParams
       szMod[0] = '\0';
 
       iXcorrProcessingOffset = 75;
-      iIndexDb = 0;
+      iDbType = DbType::FASTA_DB;
 
       databaseInfo.szDatabase[0] = '\0';
       speclibInfo.strSpecLibFile.clear();
@@ -1060,7 +1068,7 @@ extern int* PEPTIDE_MOD_SEQ_IDXS;
 extern int MOD_NUM;
 extern bool g_bPlainPeptideIndexRead;   // set to true if plain peptide index file is read (and fragment index generated)
                                         // poor choice of name for the fragment index .idx given peptide index is back
-extern bool g_bPeptideIndexRead;        // set to true if peptide index file is read
+extern  std::atomic<bool>  g_bPeptideIndexRead;        // set to true if peptide index file is read
 extern bool g_bSpecLibRead;             // set to true if spectral library file is read
 
 extern bool g_bPerformSpecLibSearch;    // set to true if doing spectral library search
@@ -1121,6 +1129,8 @@ struct Query
    Results*             _pResults;
    Results*             _pDecoys;
    SpecLibResults*      _pSpecLibResults;
+
+   std::chrono::high_resolution_clock::time_point tSearchStart;  // per-query search start time for iMaxIndexRunTime timeout
 
    Mutex accessMutex;
 

--- a/CometSearch/CometDataInternal.h
+++ b/CometSearch/CometDataInternal.h
@@ -1001,7 +1001,7 @@ struct StaticParams
       options.iFragIndexMinIonsScore = FRAGINDEX_MIN_IONS_SCORE;
       options.iFragIndexMinIonsReport = FRAGINDEX_MIN_IONS_REPORT;
       options.iFragIndexNumSpectrumPeaks = FRAGINDEX_MAX_NUMPEAKS;
-      options.iFragIndexSkipReadPrecursors = 0;
+      options.iFragIndexSkipReadPrecursors = 1;   // skip reading precursors by default
 
       options.dMS1MinMass = MS1_MIN_MASS;
       options.dMS1MaxMass = MS1_MAX_MASS;
@@ -1131,6 +1131,7 @@ struct Query
       iMatchPeptideCount = 0;
       iDecoyMatchPeptideCount = 0;
       uiHistogramCount = 0;
+      iMinXcorrHisto = 0;
 
       fPar[0]=0.0;
       fPar[1]=0.0;

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -569,8 +569,9 @@ bool CometFragmentIndex::WriteFIPlainPeptideIndex(ThreadPool *tp)
    string strIndexFile;
 
    auto tPlainPeptideIndexStartTime = chrono::steady_clock::now();
-
-   if (strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   
+   size_t databaseLen = strlen(g_staticParams.databaseInfo.szDatabase);
+   if (databaseLen >= 4 && strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
    {
       strIndexFile = g_staticParams.databaseInfo.szDatabase;  // .idx specified but not present to create it
       g_staticParams.databaseInfo.szDatabase[strlen(g_staticParams.databaseInfo.szDatabase) - 4] = '\0';
@@ -871,8 +872,12 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
    if (g_bPlainPeptideIndexRead)
       return 1;
 
-   if (g_staticParams.options.bCreateFragmentIndex && !strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   size_t databaseLen = strlen(g_staticParams.databaseInfo.szDatabase);
+   if (g_staticParams.options.bCreateFragmentIndex
+      && (databaseLen >=4 && !strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx")))
+   {
       strIndexFile = g_staticParams.databaseInfo.szDatabase + string(".idx");
+   }
    else // database already is .idx
       strIndexFile = g_staticParams.databaseInfo.szDatabase;
 

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -143,7 +143,7 @@ void CometFragmentIndex::PermuteIndexPeptideMods(vector<PlainPeptideIndexStruct>
 
 void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
 {
-   cout <<  " - generate fragment index\n"; fflush(stdout);
+   cout <<  " - generate fragment ion index\n"; fflush(stdout);
 
    Threading::InitMutex(&_vFragmentPeptidesMutex);
 
@@ -604,14 +604,14 @@ bool CometFragmentIndex::WriteFIPlainPeptideIndex(ThreadPool *tp)
    if (bSucceeded)
    {
       g_staticParams.options.bCreateFragmentIndex = true;
-      g_staticParams.iIndexDb = 0;
+      g_staticParams.iDbType = DbType::FASTA_DB;
 
       // this step calls RunSearch just to pull out all peptides
       // to write into the .idx pepties/proteins file
       bSucceeded = CometSearch::RunSearch(0, 0, tp);
 
       g_staticParams.options.bCreateFragmentIndex = false;
-      g_staticParams.iIndexDb = 1;
+      g_staticParams.iDbType = DbType::FI_DB;
    }
 
    if (bSwapIdxExtension)

--- a/CometSearch/CometFragmentIndexReader.h
+++ b/CometSearch/CometFragmentIndexReader.h
@@ -1,0 +1,74 @@
+// Copyright 2023 Jimmy Eng
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef _COMETFRAGMENTINDEXREADER_H_
+#define _COMETFRAGMENTINDEXREADER_H_
+
+#include "Common.h"
+#include "CometSearch.h"
+
+// Read-only wrapper for fragment index globals
+class FragmentIndexReader
+{
+public:
+   FragmentIndexReader()
+      : m_iFragmentIndex(const_cast<const unsigned int* const*>(g_iFragmentIndex))
+      , m_iCountFragmentIndex(const_cast<const unsigned int*>(g_iCountFragmentIndex))
+      , m_vFragmentPeptides(g_vFragmentPeptides)
+      , m_vRawPeptides(g_vRawPeptides)
+      , m_pvProteinsList(g_pvProteinsList)
+   {
+   }
+
+   // Const-only access methods
+   inline unsigned int GetFragmentIndexEntry(unsigned int bin, size_t idx) const
+   {
+      return m_iFragmentIndex[bin][idx];
+   }
+
+   inline unsigned int GetFragmentCount(unsigned int bin) const
+   {
+      return m_iCountFragmentIndex[bin];
+   }
+
+   inline const FragmentPeptidesStruct& GetFragmentPeptide(size_t idx) const
+   {
+      return m_vFragmentPeptides[idx];
+   }
+
+   inline const PlainPeptideIndexStruct& GetRawPeptide(size_t idx) const
+   {
+      return m_vRawPeptides[idx];
+   }
+
+   inline const vector<comet_fileoffset_t>& GetProteinList(size_t idx) const
+   {
+      return m_pvProteinsList[idx];
+   }
+
+private:
+   // Const pointers prevent modification
+   const unsigned int* const* m_iFragmentIndex;
+   const unsigned int* m_iCountFragmentIndex;
+   const vector<struct FragmentPeptidesStruct>& m_vFragmentPeptides;
+   const vector<PlainPeptideIndexStruct>& m_vRawPeptides;
+   const vector<vector<comet_fileoffset_t>>& m_pvProteinsList;
+
+   // Delete copy/assignment to prevent misuse
+   FragmentIndexReader(const FragmentIndexReader&) = delete;
+   FragmentIndexReader& operator=(const FragmentIndexReader&) = delete;
+};
+
+#endif // _COMETFRAGMENTINDEXREADER_H_

--- a/CometSearch/CometInterfaces.h
+++ b/CometSearch/CometInterfaces.h
@@ -34,7 +34,7 @@ public:
       virtual bool DoSearch() = 0;
       virtual bool InitializeSingleSpectrumSearch() = 0;
       virtual void FinalizeSingleSpectrumSearch() = 0;
-      virtual bool InitializeSingleSpectrumMS1Search() = 0;
+      virtual bool InitializeSingleSpectrumMS1Search(const double dMaxQueryRT) = 0;
       virtual void FinalizeSingleSpectrumMS1Search() = 0;
       virtual bool DoSingleSpectrumSearchMultiResults(const int topN,
                                                       const int iPrecursorCharge,

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -275,7 +275,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
    }
    else  // regular fasta database
    {
-      Results *pOutput;
+      Results* pOutput;
 
       if (iPrintTargetDecoy != 2)
          pOutput = g_pvQuery.at(iWhichQuery)->_pResults;
@@ -293,7 +293,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
       {
          if (pOutput[iWhichResult].pWhichProtein.size() > 0)
          {
-            for (auto it=pOutput[iWhichResult].pWhichProtein.begin(); it!=pOutput[iWhichResult].pWhichProtein.end(); ++it)
+            for (auto it = pOutput[iWhichResult].pWhichProtein.begin(); it != pOutput[iWhichResult].pWhichProtein.end(); ++it)
             {
                comet_fseek(fpdb, (*it).lWhichProtein, SEEK_SET);
                if (bReturnFullProteinString)
@@ -325,7 +325,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
          if (pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
          {
             // collate decoy proteins, if needed, from target-decoy search
-            for (auto it=pOutput[iWhichResult].pWhichDecoyProtein.begin(); it!=pOutput[iWhichResult].pWhichDecoyProtein.end(); ++it)
+            for (auto it = pOutput[iWhichResult].pWhichDecoyProtein.begin(); it != pOutput[iWhichResult].pWhichDecoyProtein.end(); ++it)
             {
                if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
                   break;

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -148,7 +148,7 @@ void CometMassSpecUtils::GetProteinSequence(FILE *fpfasta,
 {
    strSeq.clear();
 
-   if (!g_staticParams.iIndexDb)  // works only for regular FASTA
+   if (g_staticParams.iDbType == DbType::FASTA_DB)  // works only for regular FASTA
    {
       int iTmpCh;
 
@@ -198,7 +198,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
    // FIX:  protein references is so convoluted with the restoration of peptide index.  This
    // seems to work now but definitely needs to be revisited to be cleaned up.
    // Look into lProteinFilePosition and lWhichProtein with Results struct.
-   if (g_staticParams.iIndexDb)
+   if (g_staticParams.iDbType != DbType::FASTA_DB)
    {
       Results* pOutput;
 
@@ -210,11 +210,11 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
       int iPrintDuplicateProteinCt = 0; // track # proteins, exit when at iMaxDuplicateProteins
 
       // get target proteins
-      if (g_staticParams.iIndexDb == 1 || pOutput[iWhichResult].pWhichProtein.size() > 0)
+      if (g_staticParams.iDbType == DbType::FI_DB || pOutput[iWhichResult].pWhichProtein.size() > 0)
       {
          comet_fileoffset_t lEntry;
 
-         if (g_staticParams.iIndexDb == 1)
+         if (g_staticParams.iDbType == DbType::FI_DB)
             lEntry = pOutput[iWhichResult].lProteinFilePosition;
          else
             lEntry = pOutput[iWhichResult].pWhichProtein.at(0).lWhichProtein;
@@ -245,7 +245,7 @@ void CometMassSpecUtils::GetProteinNameString(FILE *fpdb,
       }
 
       // get decoy proteins for peptide index searches
-      if (g_staticParams.iIndexDb == 2 && pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
+      if (g_staticParams.iDbType == DbType::PI_DB && pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
       {
          comet_fileoffset_t lEntry = pOutput[iWhichResult].pWhichDecoyProtein.at(0).lWhichProtein;
          *uiNumTotProteins += (unsigned int)g_pvProteinsList.at(lEntry).size();

--- a/CometSearch/CometPeptideIndex.cpp
+++ b/CometSearch/CometPeptideIndex.cpp
@@ -157,7 +157,15 @@ bool CometPeptideIndex::ReadPeptideIndex(void)
    for (uint64_t i = 0; i < tNumPeptides; ++i)
    {
       DBIndex sEntry;
-      ReadPeptideIndexEntry(&sEntry, fp);
+      if (!ReadPeptideIndexEntry(&sEntry, fp))
+      {
+         g_pvDBIndex.clear();
+         delete[] lIndex;
+         fclose(fp);
+         logout(" Error - failed to read peptide index entry " + to_string(i)
+            + " from .idx file; file may be truncated or corrupt.\n");
+         return false;
+      }
       g_pvDBIndex.push_back(sEntry);
    }
 

--- a/CometSearch/CometPeptideIndex.cpp
+++ b/CometSearch/CometPeptideIndex.cpp
@@ -26,13 +26,162 @@ CometPeptideIndex::~CometPeptideIndex()
 {
 }
 
+// Read the full peptide index (.idx) file into global read-only structures:
+//   g_pvDBIndex         - all peptide entries, sorted by mass
+//   g_pvProteinsList    - vector-of-vectors mapping peptide to protein file positions
+//   g_pvProteinNames    - map of file offset to protein name string
+//   g_bPeptideIndexRead - guard flag
+//
+// The .idx binary layout (written by WritePeptideIndex):
+//   [text header lines ending with blank line]
+//   [protein names: each WIDTH_REFERENCE chars]
+//   [proteins list: count then per-entry (size + file offsets)]
+//   [peptide entries: each via ReadPeptideIndexEntry format]
+//   [footer: iMinMass(int), iMaxMass(int), tNumPeptides(uint64_t),
+//            lIndex[iMaxMass*10](comet_fileoffset_t), lEndOfPeptides, clProteinsFilePos]
+//
+bool CometPeptideIndex::ReadPeptideIndex(void)
+{
+   if (g_bPeptideIndexRead)
+      return true;
 
-bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
+   FILE* fp;
+   char szBuf[SIZE_BUF];
+
+   if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
+   {
+      string strErrorMsg = " Error - cannot open peptide index file \""
+         + string(g_staticParams.databaseInfo.szDatabase) + "\" for reading.\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   // Verify this is a peptide index file (not a fragment index)
+   if (fgets(szBuf, SIZE_BUF, fp) == NULL)
+   {
+      fclose(fp);
+      return false;
+   }
+   if (strncmp(szBuf, "Comet peptide index database", 28) != 0)
+   {
+      string strErrorMsg = " Error - \"" + string(g_staticParams.databaseInfo.szDatabase)
+         + "\" is not a peptide index file.\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      fclose(fp);
+      return false;
+   }
+
+   // Skip remaining header lines until blank line
+   while (fgets(szBuf, SIZE_BUF, fp) != NULL)
+   {
+      if (szBuf[0] == '\n' || szBuf[0] == '\r')
+         break;
+   }
+
+   // --- Read footer first to get layout positions ---
+   // Footer is at the very end of the file:
+   //   ... lEndOfPeptides(comet_fileoffset_t) clProteinsFilePos(comet_fileoffset_t)
+   // Seek to end minus 2 * sizeof(comet_fileoffset_t) to read both values
+   comet_fseek(fp, -2 * (long)clSizeCometFileOffset, SEEK_END);
+
+   comet_fileoffset_t lEndOfPeptides;
+   comet_fileoffset_t clProteinsFilePos;
+   size_t tTmpRead;
+   tTmpRead = fread(&lEndOfPeptides, clSizeCometFileOffset, 1, fp);
+   tTmpRead = fread(&clProteinsFilePos, clSizeCometFileOffset, 1, fp);
+
+   // --- Read the mass index and peptide count from lEndOfPeptides position ---
+   comet_fseek(fp, lEndOfPeptides, SEEK_SET);
+
+   int iMinMass, iMaxMass;
+   uint64_t tNumPeptides;
+   tTmpRead = fread(&iMinMass, sizeof(int), 1, fp);
+   tTmpRead = fread(&iMaxMass, sizeof(int), 1, fp);
+   tTmpRead = fread(&tNumPeptides, sizeof(uint64_t), 1, fp);
+
+   int iMaxPeptideMass10 = iMaxMass * 10;
+
+   // Read the mass index array: lIndex[0..iMaxPeptideMass10-1]
+   // Each entry is a file offset to the first peptide at that 0.1 Da mass bin
+   comet_fileoffset_t* lIndex = new comet_fileoffset_t[iMaxPeptideMass10];
+   tTmpRead = fread(lIndex, clSizeCometFileOffset, iMaxPeptideMass10, fp);
+
+   // --- Read protein names ---
+   // Protein names are stored between end-of-header and clProteinsFilePos
+   // Each protein name is WIDTH_REFERENCE chars.  We need to know how many
+   // there are.  Read them by seeking to the position right after the header
+   // and reading until clProteinsFilePos.
+
+   // Actually, the protein names are written BEFORE clProteinsFilePos.
+   // The structure is: [header][protein names][proteins list at clProteinsFilePos][peptides][footer]
+   // We need the protein name positions for g_pvProteinNames mapping.
+   // For the single-spectrum search path, protein names are resolved via
+   // g_pvProteinsList file offsets that point into the .idx file protein name region.
+   // We'll store them after reading the proteins list.
+
+   // --- Read proteins list (vector of vectors) from clProteinsFilePos ---
+   comet_fseek(fp, clProteinsFilePos, SEEK_SET);
+
+   size_t tNumProteinEntries;
+   tTmpRead = fread(&tNumProteinEntries, clSizeCometFileOffset, 1, fp);
+
+   g_pvProteinsList.clear();
+   g_pvProteinsList.resize(tNumProteinEntries);
+
+   for (size_t i = 0; i < tNumProteinEntries; ++i)
+   {
+      size_t tNumProteins;
+      tTmpRead = fread(&tNumProteins, sizeof(size_t), 1, fp);
+
+      g_pvProteinsList[i].resize(tNumProteins);
+      for (size_t j = 0; j < tNumProteins; ++j)
+      {
+         comet_fileoffset_t lProtFilePos;
+         tTmpRead = fread(&lProtFilePos, clSizeCometFileOffset, 1, fp);
+         g_pvProteinsList[i][j] = lProtFilePos;
+      }
+   }
+
+   // The file position after reading the proteins list is where the peptides start.
+   comet_fileoffset_t lFirstPeptidePos = comet_ftell(fp);
+
+   // --- Read all peptide entries into g_pvDBIndex ---
+   g_pvDBIndex.clear();
+   g_pvDBIndex.reserve((size_t)tNumPeptides);
+
+   // Seek to first peptide (right after the proteins list)
+   comet_fseek(fp, lFirstPeptidePos, SEEK_SET);
+
+   for (uint64_t i = 0; i < tNumPeptides; ++i)
+   {
+      DBIndex sEntry;
+      ReadPeptideIndexEntry(&sEntry, fp);
+      g_pvDBIndex.push_back(sEntry);
+   }
+
+   // g_pvDBIndex is already sorted by mass from the .idx file
+
+   delete[] lIndex;
+   fclose(fp);
+
+   logout(" Read peptide index: " + to_string(tNumPeptides) + " peptides, "
+      + to_string(tNumProteinEntries) + " protein groups\n");
+
+   g_staticParams.iDbType = DbType::PI_DB;
+   g_bPeptideIndexRead = true;
+
+   return true;
+}
+
+
+bool CometPeptideIndex::WritePeptideIndex(ThreadPool* tp)
 {
    bool bSucceeded;
-   FILE *fptr;
+   FILE* fptr;
 
-   const int iIndex_SIZE_FILE=SIZE_FILE+4;
+   const int iIndex_SIZE_FILE = SIZE_FILE + 4;
    char szIndexFile[iIndex_SIZE_FILE];
    sprintf(szIndexFile, "%s.idx", g_staticParams.databaseInfo.szDatabase);
 
@@ -111,7 +260,7 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
       {
          // each unique peptide, irregardless of mod state, will have the same list
          // of matched proteins
-         if (!strcmp(g_pvDBIndex.at(i).szPeptide, g_pvDBIndex.at(i-1).szPeptide))
+         if (!strcmp(g_pvDBIndex.at(i).szPeptide, g_pvDBIndex.at(i - 1).szPeptide))
          {
             temp.push_back(g_pvDBIndex.at(i).lIndexProteinFilePosition);
             g_pvDBIndex.at(i).lIndexProteinFilePosition = lProtCount;
@@ -122,7 +271,7 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
             // and store current protein reference into new temp
             // temp can have duplicates due to mod forms of peptide so make unique here
             sort(temp.begin(), temp.end());
-            temp.erase(unique(temp.begin(), temp.end()), temp.end() );
+            temp.erase(unique(temp.begin(), temp.end()), temp.end());
             pvProteinsListLocal.push_back(temp);
 
             lProtCount++; // start new row in pvProteinsListLocal
@@ -133,6 +282,7 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
          }
       }
    }
+
    // now at end of loop, push last temp onto pvProteinsListLocal
    sort(temp.begin(), temp.end());
    temp.erase(unique(temp.begin(), temp.end()), temp.end() );
@@ -203,10 +353,10 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
    for (int x = 0; x < VMODS; x++)
    {
       fprintf(fptr, " %s:%lf:%lf:%lf",
-            g_staticParams.variableModParameters.varModList[x].szVarModChar,
-            g_staticParams.variableModParameters.varModList[x].dVarModMass,
-            g_staticParams.variableModParameters.varModList[x].dNeutralLoss,
-            g_staticParams.variableModParameters.varModList[x].dNeutralLoss2);
+         g_staticParams.variableModParameters.varModList[x].szVarModChar,
+         g_staticParams.variableModParameters.varModList[x].dVarModMass,
+         g_staticParams.variableModParameters.varModList[x].dNeutralLoss,
+         g_staticParams.variableModParameters.varModList[x].dNeutralLoss2);
 
    }
    fprintf(fptr, "\n\n");
@@ -265,7 +415,7 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
    // next write out the peptides and track peptide mass index
    int iMaxPeptideMass = (int)(g_staticParams.options.dPeptideMassHigh);
    int iMaxPeptideMass10 = iMaxPeptideMass * 10;  // make mass index at resolution of 0.1 Da
-   comet_fileoffset_t *lIndex = new comet_fileoffset_t[iMaxPeptideMass10 + 1];
+   comet_fileoffset_t* lIndex = new comet_fileoffset_t[iMaxPeptideMass10 + 1];
    for (int x = 0; x <= iMaxPeptideMass10; x++)
       lIndex[x] = -1;
 
@@ -353,35 +503,207 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool *tp)
 }
 
 
-void CometPeptideIndex::ReadPeptideIndexEntry(struct DBIndex *sDBI, FILE *fp)
+bool CometPeptideIndex::ReadPeptideIndexEntry(struct DBIndex* sDBI, FILE* fp)
 {
    int iLen;
    size_t tTmp;
 
    tTmp = fread(&iLen, sizeof(int), 1, fp);
+   if (tTmp != 1) return false;
    tTmp = fread(sDBI->szPeptide, sizeof(char), iLen, fp);
+   if (tTmp != (size_t)iLen) return false;
    sDBI->szPeptide[iLen] = '\0';
 
    tTmp = fread(&(sDBI->cPrevAA), sizeof(char), 1, fp);
+   if (tTmp != 1) return false;
    tTmp = fread(&(sDBI->cNextAA), sizeof(char), 1, fp);
+   if (tTmp != 1) return false;
 
    unsigned char cNumMods;  // number of var mods encoded as position:residue pairs
    tTmp = fread(&cNumMods, sizeof(unsigned char), 1, fp);  // read how many var mods are stored
+   if (tTmp != 1) return false;
 
-   memset(sDBI->pcVarModSites, 0, sizeof(unsigned char)*iLen+2);
+   // Issue 3: Add parentheses for correct precedence: sizeof(unsigned char) * (iLen + 2)
+   memset(sDBI->pcVarModSites, 0, sizeof(unsigned char) * (iLen + 2));
    if (cNumMods > 0)
    {
-      for (unsigned char x=0; x<cNumMods; x++)
+      for (unsigned char x = 0; x < cNumMods; x++)
       {
          unsigned char cPosition;
          char cResidue;
          tTmp = fread(&cPosition, sizeof(unsigned char), 1, fp);
+         if (tTmp != 1) return false;
          tTmp = fread(&cResidue, sizeof(char), 1, fp);
+         if (tTmp != 1) return false;
          sDBI->pcVarModSites[(int)cPosition] = cResidue;
       }
    }
    // done reading mod sites
 
    tTmp = fread(&(sDBI->dPepMass), sizeof(double), 1, fp);
+   if (tTmp != 1) return false;
    tTmp = fread(&(sDBI->lIndexProteinFilePosition), sizeof(comet_fileoffset_t), 1, fp);
+   if (tTmp != 1) return false;
+
+   return true;
+}
+
+
+// Parses the .idx text header lines (MassType:, StaticMod:, DecoySearch:,
+// Enzyme:, Enzyme2:, VariableMod:) from fp.  Reads until the VariableMod:
+// line (inclusive), which is always the last header entry before the blank
+// line separator.
+//
+// Both SearchPeptideIndex(ThreadPool*) and InitializeMassesFromPeptideIndex()
+// call this helper so that any future .idx header format changes only need to
+// be made in one place.
+//
+// IMPORTANT: resets pdAAMassFragment AND pdAAMassParent via AssignMass()
+// before applying static mods, so this is safe to call whether or not
+// InitializeStaticParams() has already applied static mods.
+bool CometPeptideIndex::ParsePeptideIndexHeader(FILE* fp)
+{
+   char szBuf[SIZE_BUF];
+   bool bFoundStatic = false;
+   bool bFoundVariable = false;
+
+   // Ignore any static masses from the params file; only the values baked
+   // into the .idx header are authoritative for an index search.
+   memset(g_staticParams.staticModifications.pdStaticMods, 0,
+      sizeof(g_staticParams.staticModifications.pdStaticMods));
+
+   rewind(fp);
+
+   while (fgets(szBuf, SIZE_BUF, fp))
+   {
+      if (!strncmp(szBuf, "MassType:", 9))
+      {
+         sscanf(szBuf + 10, "%d %d",
+            &g_staticParams.massUtility.bMonoMassesParent,
+            &g_staticParams.massUtility.bMonoMassesFragment);
+      }
+      else if (!strncmp(szBuf, "StaticMod:", 10))
+      {
+         char* tok;
+         char  delims[] = " ";
+         int   x = 65;  // ASCII 'A'
+
+         // Reset BOTH mass arrays to bare (unmodified) residue masses before
+         // adding the static mods stored in the .idx header.  This prevents
+         // double-application when InitializeStaticParams() has already added
+         // static mods to pdAAMassParent.
+         CometMassSpecUtils::AssignMass(g_staticParams.massUtility.pdAAMassFragment,
+            g_staticParams.massUtility.bMonoMassesFragment,
+            &g_staticParams.massUtility.dOH2fragment);
+
+         CometMassSpecUtils::AssignMass(g_staticParams.massUtility.pdAAMassParent,
+            g_staticParams.massUtility.bMonoMassesParent,
+            &g_staticParams.massUtility.dOH2parent);
+
+         bFoundStatic = true;
+         tok = strtok(szBuf + 11, delims);
+         while (tok != NULL)
+         {
+            sscanf(tok, "%lf", &(g_staticParams.staticModifications.pdStaticMods[x]));
+            g_staticParams.massUtility.pdAAMassFragment[x] += g_staticParams.staticModifications.pdStaticMods[x];
+            g_staticParams.massUtility.pdAAMassParent[x] += g_staticParams.staticModifications.pdStaticMods[x];
+            tok = strtok(NULL, delims);
+            x++;
+            // 65-90 = A-Z; 91-94 = n/c-term peptide, n/c-term protein
+            if (x == 95)
+               break;
+         }
+
+         g_staticParams.staticModifications.dAddNterminusPeptide = g_staticParams.staticModifications.pdStaticMods[91];
+         g_staticParams.staticModifications.dAddCterminusPeptide = g_staticParams.staticModifications.pdStaticMods[92];
+         g_staticParams.staticModifications.dAddNterminusProtein = g_staticParams.staticModifications.pdStaticMods[93];
+         g_staticParams.staticModifications.dAddCterminusProtein = g_staticParams.staticModifications.pdStaticMods[94];
+
+         // Recalculate the precalculated masses that depend on terminal static mods.
+         g_staticParams.precalcMasses.dNtermProton =
+            g_staticParams.staticModifications.dAddNterminusPeptide + PROTON_MASS;
+
+         g_staticParams.precalcMasses.dCtermOH2Proton =
+            g_staticParams.staticModifications.dAddCterminusPeptide
+            + g_staticParams.massUtility.dOH2fragment
+            + PROTON_MASS;
+
+         g_staticParams.precalcMasses.dOH2ProtonCtermNterm =
+            g_staticParams.massUtility.dOH2parent
+            + PROTON_MASS
+            + g_staticParams.staticModifications.dAddCterminusPeptide
+            + g_staticParams.staticModifications.dAddNterminusPeptide;
+      }
+      else if (!strncmp(szBuf, "DecoySearch:", 12))
+      {
+         sscanf(szBuf, "DecoySearch: %d", &(g_staticParams.options.iDecoySearch));
+      }
+      else if (!strncmp(szBuf, "Enzyme:", 7))
+      {
+         sscanf(szBuf, "Enzyme: %s [%d %s %s]",
+            g_staticParams.enzymeInformation.szSearchEnzymeName,
+            &(g_staticParams.enzymeInformation.iSearchEnzymeOffSet),
+            g_staticParams.enzymeInformation.szSearchEnzymeBreakAA,
+            g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA);
+      }
+      else if (!strncmp(szBuf, "Enzyme2:", 8))
+      {
+         sscanf(szBuf, "Enzyme2: %s [%d %s %s]",
+            g_staticParams.enzymeInformation.szSearchEnzyme2Name,
+            &(g_staticParams.enzymeInformation.iSearchEnzyme2OffSet),
+            g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA,
+            g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA);
+      }
+      else if (!strncmp(szBuf, "VariableMod:", 12))
+      {
+         string strMods = szBuf + 13;
+         istringstream iss(strMods);
+         int iNumMods = 0;
+
+         bFoundVariable = true;
+
+         do
+         {
+            string subStr;
+            iss >> subStr;
+            std::replace(subStr.begin(), subStr.end(), ':', ' ');
+            int iRet = sscanf(subStr.c_str(), "%s %lf %lf %lf",
+               g_staticParams.variableModParameters.varModList[iNumMods].szVarModChar,
+               &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
+               &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss),
+               &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss2));
+
+            if (iRet != 4)
+            {
+               string strErrorMsg = " Error parsing mod entry: " + subStr + ".\n";
+               logerr(strErrorMsg);
+               return false;
+            }
+
+            if (g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss != 0.0)
+               g_staticParams.variableModParameters.bUseFragmentNeutralLoss = true;
+
+            iNumMods++;
+            if (iNumMods == VMODS)
+               break;
+         } while (iss);
+
+         // VariableMod: is always the last relevant header line.
+         break;
+      }
+   }
+
+   if (!(bFoundStatic && bFoundVariable))
+   {
+      string strErrorMsg = " Error with index database format. Mods not parsed ("
+         + std::to_string(bFoundStatic) + " " + std::to_string(bFoundVariable) + ").\n";
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   // Peptide index searches always have variable mod search enabled because
+   // mod sites are baked into every index entry.
+   g_staticParams.variableModParameters.bVarModSearch = true;
+
+   return true;
 }

--- a/CometSearch/CometPeptideIndex.h
+++ b/CometSearch/CometPeptideIndex.h
@@ -17,13 +17,14 @@
 #define _COMETPEPTIDEINDEX_H_
 
 #include "Common.h"
-#include "CometPostAnalysis.h"
+#include "CometDataInternal.h"
+#include "CometMassSpecUtils.h"
 #include "CometSearch.h"
 #include "CometStatus.h"
-#include "CometMassSpecUtils.h"
-#include "ThreadPool.h"
 
-
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
 
 class CometPeptideIndex
 {
@@ -31,11 +32,18 @@ public:
    CometPeptideIndex();
    ~CometPeptideIndex();
 
-   static bool WritePeptideIndex(ThreadPool *tp);
-   static void ReadPeptideIndexEntry(struct DBIndex *sDBI, FILE *fp);
+   static bool ReadPeptideIndex(void);
+   static bool WritePeptideIndex(ThreadPool* tp);
+   static bool ReadPeptideIndexEntry(struct DBIndex* sDBI, FILE* fp);
 
-private:
-   static Mutex _vFragmentPeptidesMutex;
+   // Parses the .idx text header (MassType, StaticMod, DecoySearch, Enzyme,
+   // Enzyme2, VariableMod lines) from an already-open file pointer.
+   // Updates g_staticParams in-place and must only be called once per index
+   // load (guarded by g_bPeptideIndexRead). Called by both
+   // SearchPeptideIndex(ThreadPool*) and InitializeMassesFromPeptideIndex()
+   // to avoid duplication.
+   static bool ParsePeptideIndexHeader(FILE* fp);
+
 };
 
 #endif // _COMETPEPTIDEINDEX_H_

--- a/CometSearch/CometPostAnalysis.cpp
+++ b/CometSearch/CometPostAnalysis.cpp
@@ -87,8 +87,9 @@ void CometPostAnalysis::PostAnalysisThreadProc(PostAnalysisThreadData *pThreadDa
    (void)tp; // suppress unused parameter warning
 
    int iQueryIndex = pThreadData->iQueryIndex;
+   Query* pQuery = g_pvQuery.at(iQueryIndex);
 
-   AnalyzeSP(iQueryIndex);
+   AnalyzeSP(pQuery);
 
    // Calculate E-values if necessary.
    // Only time to not calculate E-values is for .out/.sqt output only and
@@ -98,15 +99,12 @@ void CometPostAnalysis::PostAnalysisThreadProc(PostAnalysisThreadData *pThreadDa
          || g_staticParams.options.bOutputPercolatorFile
          || g_staticParams.options.bOutputTxtFile)
    {
-      if (g_pvQuery.at(iQueryIndex)->iMatchPeptideCount > 0
-            || g_pvQuery.at(iQueryIndex)->iDecoyMatchPeptideCount > 0)
-      {
-         CalculateEValue(iQueryIndex, 0);
-      }
+      if (pQuery->iMatchPeptideCount > 0 || pQuery->iDecoyMatchPeptideCount > 0)
+         CalculateEValue(pQuery, false);
    }
 
    // this has to happen after AnalyzeSP as results are sorted in that fn
-   CalculateDeltaCn(iQueryIndex);
+   CalculateDeltaCn(pQuery);
 
    // Calculate A-Score if specified and peptide has phospho mod
    if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
@@ -116,15 +114,16 @@ void CometPostAnalysis::PostAnalysisThreadProc(PostAnalysisThreadData *pThreadDa
 
       // also skip AScore if peptide has a teriminal modification until I can figure out how
       // to handle that properly
-      if (g_pvQuery.at(iQueryIndex)->_pResults[0].piVarModSites[g_pvQuery.at(iQueryIndex)->_pResults[0].usiLenPeptide] != 0
-         || g_pvQuery.at(iQueryIndex)->_pResults[0].piVarModSites[g_pvQuery.at(iQueryIndex)->_pResults[0].usiLenPeptide + 1] != 0)
+      if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0
+         || pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
       {
          bHasTerminalVariableMod = true;
       }
 
       if (!bHasTerminalVariableMod)
-         CalculateAScorePro(iQueryIndex, g_AScoreInterface);
+         CalculateAScorePro(pQuery, g_AScoreInterface);
    }
+
 
    delete pThreadData;
    pThreadData = NULL;
@@ -240,20 +239,6 @@ void CometPostAnalysis::CalculateDeltaCn(Query* pQuery)
 }
 
 
-// Original overload: delegates to the Query* version.
-void CometPostAnalysis::CalculateDeltaCn(int iWhichQuery)
-{
-   CalculateDeltaCn(g_pvQuery.at(iWhichQuery));
-}
-
-
-// Original overload: delegates to the Query* version.
-void CometPostAnalysis::AnalyzeSP(int iWhichQuery)
-{
-   AnalyzeSP(g_pvQuery.at(iWhichQuery));
-}
-
-
 // Thread-local overload: accepts Query* directly, no g_pvQuery access.
 void CometPostAnalysis::AnalyzeSP(Query* pQuery)
 {
@@ -364,8 +349,8 @@ void CometPostAnalysis::AnalyzeSP(Query* pQuery)
 
 // Thread-local overload: accepts Query* directly, no g_pvQuery access.
 void CometPostAnalysis::CalculateSP(Results* pOutput,
-   Query* pQuery,
-   int iSize)
+                                    Query* pQuery,
+                                    int iSize)
 {
    int i;
    double pdAAforward[MAX_PEPTIDE_LEN];
@@ -722,172 +707,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
 }
 
 
-// Original overload: delegates to the Query* version.
-void CometPostAnalysis::CalculateSP(Results* pOutput,
-                                    int iWhichQuery,
-                                    int iSize)
-{
-   CalculateSP(pOutput, g_pvQuery.at(iWhichQuery), iSize);
-}
-
-
 using namespace AScoreProCpp;
-
-void CometPostAnalysis::CalculateAScorePro(int iWhichQuery,
-                                           AScoreDllInterface* ascoreInterface)
-{
-   std::string sequence;
-   double precursorMz;
-   int precursorCharge;
-
-   // sanity check here; AScorePro will segfault if peptide length is 0
-   if (g_pvQuery.at(iWhichQuery)->_pResults[0].usiLenPeptide <= 0)
-      return;
-
-   // if specific variable mod specified, check if peptide contains that mod
-   if (g_pvQuery.at(iWhichQuery)->_pResults[0].cHasVariableMod != HasVariableModType_AScorePro)
-      return;
-
-   precursorCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState;
-   precursorMz = (g_pvQuery.at(iWhichQuery)->_pResults[0].dPepMass + (precursorCharge - 1) * PROTON_MASS) / precursorCharge;
-
-   // Generate peptide sequence of format "K.M0LAES1DDSGDEES1VSQTDK.T" where the mod char is the mod #
-   sequence = g_pvQuery.at(iWhichQuery)->_pResults[0].cPrevAA + std::string(".");
-   for (int i = 0; i < g_pvQuery.at(iWhichQuery)->_pResults[0].usiLenPeptide; ++i)
-   {
-      sequence += g_pvQuery.at(iWhichQuery)->_pResults[0].szPeptide[i];
-
-      if (g_staticParams.variableModParameters.bVarModSearch && g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites[i] != 0)
-      {
-         if (g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites[i] > 0)
-         {
-            sequence += std::to_string(g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites[i]);
-         }
-         else
-         {
-            sequence += "?";    // PEFF:  no clue how to specify mod encoding
-         }
-      }
-   }
-   sequence += std::string(".") + g_pvQuery.at(iWhichQuery)->_pResults[0].cNextAA;
-
-   // Calculate AScore using the DLL interface
-   AScoreOutput result = ascoreInterface->CalculateScoreWithOptions(sequence,
-      g_pvQuery.at(iWhichQuery)->vRawFragmentPeakMassIntensity, precursorMz, precursorCharge, g_AScoreOptions);
-
-   // The question is what to do with AScore results.  For now, I plan on using the AScore
-   // localized peptide to replace the original peptide in the results structure and report
-   // both the score and site scores.
-   if (!result.peptides.empty())
-   {
-      g_pvQuery.at(iWhichQuery)->_pResults[0].fAScorePro = (float)result.peptides[0].getScore();
-
-      if (g_pvQuery.at(iWhichQuery)->_pResults[0].fAScorePro >= ASCORE_CUTOFF_TO_ACCEPT)
-      {
-         // set piVarModSites and pdVarModSites based on AScore localized peptide
-         memset(g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites, 0, (unsigned short)(sizeof(int) * MAX_PEPTIDE_LEN_P2));
-         memset(g_pvQuery.at(iWhichQuery)->_pResults[0].pdVarModSites, 0, (unsigned short)(sizeof(double) * MAX_PEPTIDE_LEN_P2));
-
-         std::string sPeptide = result.peptides[0].toString();
-
-         // Extract the peptide portion (between the two dots)
-         size_t firstDot = sPeptide.find('.');
-         size_t lastDot = sPeptide.rfind('.');
-         std::string peptide = sPeptide.substr(firstDot + 1, lastDot - firstDot - 1);
-
-         int position = 0; // position within peptide
-         int iPosMinus1 = 0;
-         for (size_t i = 0; i < peptide.size();)
-         {
-            if (std::isalpha(peptide[i]))
-            {
-               // Amino acid -> increment residue counter
-               position++;
-               i++;
-            }
-            else if (std::isdigit(peptide[i]))
-            {
-               // Modification reference -> capture full number
-               size_t j = i;
-               while (j < peptide.size() && std::isdigit(peptide[j]))
-               {
-                  j++;
-               }
-
-               int modIndex = std::stoi(peptide.substr(i, j - i));
-
-               // sanity check
-               if (modIndex < 0 || modIndex > VMODS)
-               {
-                  std::cerr << "Error: (1) AScorePro returned invalid modification index " << modIndex << " in peptide " << sPeptide << std::endl;
-                  return;
-               }
-
-               iPosMinus1 = position - 1;
-               if (iPosMinus1 >= 0 && iPosMinus1 < MAX_PEPTIDE_LEN)
-               {
-                  g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites[iPosMinus1] = modIndex;
-                  g_pvQuery.at(iWhichQuery)->_pResults[0].pdVarModSites[iPosMinus1] = g_staticParams.variableModParameters.varModList[modIndex - 1].dVarModMass;
-               }
-               else
-               {
-                  // FIX: need to do something more here to address mod sites that might not be correct anymore
-                  std::cerr << "Error: (2) AScorePro returned invalid modification position " << (iPosMinus1) << " in peptide " << sPeptide << std::endl;
-                  return;
-               }
-
-               i = j;
-            }
-            else
-            {
-               // Unexpected character, skip it
-               i++;
-            }
-         }
-
-         // Report site score as a string composed of space separated "position:score" pairs
-         g_pvQuery.at(iWhichQuery)->_pResults[0].sAScoreProSiteScores.clear();
-         int iPosition;
-         double dScore;
-         char szBuffer[32];
-
-         for (size_t i = 0; i < result.sites.size(); ++i)
-         {
-            iPosition = result.sites[i].getPosition();
-            dScore = result.sites[i].getScore();
-
-            snprintf(szBuffer, sizeof(szBuffer), "%.2f", dScore);
-
-            if (i > 0)
-               g_pvQuery.at(iWhichQuery)->_pResults[0].sAScoreProSiteScores += " ";
-            g_pvQuery.at(iWhichQuery)->_pResults[0].sAScoreProSiteScores += std::to_string(iPosition) + ":" + szBuffer;
-         }
-      }
-      else
-      {
-         g_pvQuery.at(iWhichQuery)->_pResults[0].sAScoreProSiteScores = "";
-      }
-
-      /*
-            // Print results
-            std::cout << "\n\n";
-            std::cout << "Original sequence: " << sequence << "\n";
-            std::cout << "     Best peptide: " << result.peptides[0].toString() << "\n";
-            std::cout << "  Peptides scored: " << result.peptides.size() << "\n";
-            std::cout << "     Sites scored: " << result.sites.size() << "\n";
-            std::cout << "            Score: " << result.peptides[0].getScore() << "\n";
-            std::cout << "      Site scores: ";
-            for (size_t i = 0; i < 6; ++i)
-            {
-               if (i < result.sites.size())
-                  std::cout << result.sites[i].getScore() << " (" << result.sites[i].getPosition() << +") \t";
-               else
-                  break;
-            }
-            std::cout << "\n";
-      */
-   }
-}
 
 // Thread-local overload: accepts Query* directly, no g_pvQuery access.
 void CometPostAnalysis::CalculateAScorePro(Query* pQuery,
@@ -1412,13 +1232,6 @@ bool CometPostAnalysis::GenerateXcorrDecoys(Query* pQuery)
 }
 
 
-// Original overload: delegates to the Query* version.
-bool CometPostAnalysis::GenerateXcorrDecoys(int iWhichQuery)
-{
-   return GenerateXcorrDecoys(g_pvQuery.at(iWhichQuery));
-}
-
-
 float CometPostAnalysis::FindSpScore(Query *pQuery,
                                      int bin,
                                      int iMax)
@@ -1509,13 +1322,3 @@ bool CometPostAnalysis::CalculateEValue(Query* pQuery,
 
    return true;
 }
-
-
-// Original overload: delegates to the Query* version.
-bool CometPostAnalysis::CalculateEValue(int iWhichQuery,
-                                        bool bTopHitOnly)
-{
-   return CalculateEValue(g_pvQuery.at(iWhichQuery), bTopHitOnly);
-}
-
-

--- a/CometSearch/CometPostAnalysis.cpp
+++ b/CometSearch/CometPostAnalysis.cpp
@@ -108,7 +108,7 @@ void CometPostAnalysis::PostAnalysisThreadProc(PostAnalysisThreadData *pThreadDa
 
    // Calculate A-Score if specified and peptide has phospho mod
    if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
-      && g_pvQuery.at(iQueryIndex)->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
+      && pQuery->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
    {
       bool bHasTerminalVariableMod = false;
 
@@ -235,7 +235,7 @@ void CometPostAnalysis::CalculateDeltaCn(Query* pQuery)
 
    // After ProcessResults for decoys (if any)
    if (g_staticParams.options.iDecoySearch == 2)
-      CalculateDeltaCnsAndRank(pQuery->_pDecoys, pQuery->iMatchPeptideCount);
+      CalculateDeltaCnsAndRank(pQuery->_pDecoys, pQuery->iDecoyMatchPeptideCount);
 }
 
 
@@ -361,7 +361,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
 
    for (i = 0; i < iSize; ++i)
    {
-      if (!g_staticParams.iIndexDb)
+      if (g_staticParams.iDbType == DbType::FASTA_DB)
       {
          // hijack here to make protein vector unique
          if (pOutput[i].pWhichProtein.size() > 1)
@@ -409,7 +409,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
          double dBion = g_staticParams.precalcMasses.dNtermProton;
          double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
 
-         // recalculate dCalcPepMass here for deterministic mass
+         // recalculate dCalcPepMass here for deterministic mass, done only for FASTA DB 
          double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
 
          double dTmpIntenMatch = 0.0;
@@ -426,13 +426,13 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
          if (pOutput[i].cPrevAA == '-' || pOutput[i].bClippedM)
          {
             dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-            if (!g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType == DbType::FASTA_DB)  // no need to recalc pepmass for indexed DBs
                dCalcPepMass += g_staticParams.staticModifications.dAddNterminusProtein;
          }
          if (pOutput[i].cNextAA == '-')
          {
             dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-            if (!g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType == DbType::FASTA_DB)
                dCalcPepMass += g_staticParams.staticModifications.dAddCterminusProtein;
          }
 
@@ -440,7 +440,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
             && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] > 0))
          {
             dBion += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] - 1].dVarModMass;
-            if (!g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType == DbType::FASTA_DB)
                dCalcPepMass += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] - 1].dVarModMass;
          }
 
@@ -448,7 +448,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
             && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] > 0))
          {
             dYion += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] - 1].dVarModMass;
-            if (!g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType == DbType::FASTA_DB)
                dCalcPepMass += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] - 1].dVarModMass;
          }
 
@@ -492,7 +492,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
 
             dBion += g_staticParams.massUtility.pdAAMassFragment[(int)pOutput[i].szPeptide[ii]];
             dYion += g_staticParams.massUtility.pdAAMassFragment[(int)pOutput[i].szPeptide[iPos]];
-            if (!g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType == DbType::FASTA_DB)
                dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[(int)pOutput[i].szPeptide[ii]];
 
             if (g_staticParams.variableModParameters.bVarModSearch)
@@ -500,7 +500,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
                if (pOutput[i].piVarModSites[ii] != 0)
                {
                   dBion += pOutput[i].pdVarModSites[ii];
-                  if (!g_staticParams.iIndexDb)
+                  if (g_staticParams.iDbType == DbType::FASTA_DB)
                      dCalcPepMass += pOutput[i].pdVarModSites[ii];
 
                   int iMod = pOutput[i].piVarModSites[ii];
@@ -536,7 +536,7 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
 
          // Add last amino acid mass as above loop stops before peptide length minus 1
          dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[(int)pOutput[i].szPeptide[iLenMinus1]];
-         if (!g_staticParams.iIndexDb && g_staticParams.variableModParameters.bVarModSearch && pOutput[i].piVarModSites[iLenMinus1] != 0)
+         if (g_staticParams.iDbType == DbType::FASTA_DB && g_staticParams.variableModParameters.bVarModSearch && pOutput[i].piVarModSites[iLenMinus1] != 0)
             dCalcPepMass += pOutput[i].pdVarModSites[iLenMinus1];
 
          int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
@@ -693,13 +693,13 @@ void CometPostAnalysis::CalculateSP(Results* pOutput,
 
          // If searching FASTA file, recalculate peptide mass to address rounding issues
          // when adding/subtracting residues when parsing a protein sequence to get pepmass.
-         if (!g_staticParams.iIndexDb)
+         if (g_staticParams.iDbType == DbType::FASTA_DB)
             pOutput[i].dPepMass = dCalcPepMass;
 
          pOutput[i].fScoreSp = (float)((dTmpIntenMatch * usiMatchedFragmentIonCt * (1.0 + dConsec)) /
             ((pOutput[i].usiLenPeptide - 1.0) * usiMaxFragCharge * g_staticParams.ionInformation.iNumIonSeriesUsed));
-         // round Sp to 3 significant digits
-         pOutput[i].fScoreSp = (float)((((int)pOutput[i].fScoreSp) * 100) / 100.0);
+         // round Sp to 2 decimal places
+         pOutput[i].fScoreSp = (float)(((int)(pOutput[i].fScoreSp * 100.0 + 0.5)) / 100.0);
 
          pOutput[i].usiMatchedIons = usiMatchedFragmentIonCt;
       }

--- a/CometSearch/CometPostAnalysis.cpp
+++ b/CometSearch/CometPostAnalysis.cpp
@@ -228,11 +228,9 @@ void CometPostAnalysis::CalculateDeltaCnsAndRank(Results* pOutput,
 }
 
 
-void CometPostAnalysis::CalculateDeltaCn(int iWhichQuery)
+// Thread-local overload: accepts Query* directly, no g_pvQuery access.
+void CometPostAnalysis::CalculateDeltaCn(Query* pQuery)
 {
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
-
    // After ProcessResults for targets
    CalculateDeltaCnsAndRank(pQuery->_pResults, pQuery->iMatchPeptideCount);
 
@@ -241,10 +239,24 @@ void CometPostAnalysis::CalculateDeltaCn(int iWhichQuery)
       CalculateDeltaCnsAndRank(pQuery->_pDecoys, pQuery->iMatchPeptideCount);
 }
 
+
+// Original overload: delegates to the Query* version.
+void CometPostAnalysis::CalculateDeltaCn(int iWhichQuery)
+{
+   CalculateDeltaCn(g_pvQuery.at(iWhichQuery));
+}
+
+
+// Original overload: delegates to the Query* version.
 void CometPostAnalysis::AnalyzeSP(int iWhichQuery)
 {
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
+   AnalyzeSP(g_pvQuery.at(iWhichQuery));
+}
 
+
+// Thread-local overload: accepts Query* directly, no g_pvQuery access.
+void CometPostAnalysis::AnalyzeSP(Query* pQuery)
+{
    // need this sort first for all iNumStored hits
    std::sort(pQuery->_pResults, pQuery->_pResults + g_staticParams.options.iNumStored, SortFnXcorr);
 
@@ -255,7 +267,7 @@ void CometPostAnalysis::AnalyzeSP(int iWhichQuery)
       iSize = g_staticParams.options.iNumStored;
 
    // Target search
-   CalculateSP(pQuery->_pResults, iWhichQuery, iSize);
+   CalculateSP(pQuery->_pResults, pQuery, iSize);
 
    std::sort(pQuery->_pResults, pQuery->_pResults + iSize, SortFnSp);
 
@@ -308,7 +320,7 @@ void CometPostAnalysis::AnalyzeSP(int iWhichQuery)
       if (iSize > g_staticParams.options.iNumPeptideOutputLines)
          iSize = g_staticParams.options.iNumPeptideOutputLines;
 
-      CalculateSP(pQuery->_pDecoys, iWhichQuery, iSize);
+      CalculateSP(pQuery->_pDecoys, pQuery, iSize);
 
       std::sort(pQuery->_pDecoys, pQuery->_pDecoys + iSize, SortFnSp);
       pQuery->_pDecoys[0].usiRankSp = 1;
@@ -350,17 +362,17 @@ void CometPostAnalysis::AnalyzeSP(int iWhichQuery)
 }
 
 
-// Peptide masses are recalculated here as well
-void CometPostAnalysis::CalculateSP(Results *pOutput,
-                                    int iWhichQuery,
-                                    int iSize)
+// Thread-local overload: accepts Query* directly, no g_pvQuery access.
+void CometPostAnalysis::CalculateSP(Results* pOutput,
+   Query* pQuery,
+   int iSize)
 {
    int i;
    double pdAAforward[MAX_PEPTIDE_LEN];
    double pdAAreverse[MAX_PEPTIDE_LEN];
    IonSeriesStruct ionSeries[9];
 
-   int  _iSizepiVarModSites = sizeof(int)*MAX_PEPTIDE_LEN_P2;
+   int  _iSizepiVarModSites = sizeof(int) * MAX_PEPTIDE_LEN_P2;
 
    for (i = 0; i < iSize; ++i)
    {
@@ -424,7 +436,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
          if (!g_staticParams.variableModParameters.bVarModSearch)
             memset(pOutput[i].piVarModSites, 0, _iSizepiVarModSites);
 
-         usiMaxFragCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiMaxFragCharge;
+         usiMaxFragCharge = pQuery->_spectrumInfoInternal.usiMaxFragCharge;
 
          if (pOutput[i].cPrevAA == '-' || pOutput[i].bClippedM)
          {
@@ -440,7 +452,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
          }
 
          if (g_staticParams.variableModParameters.bVarModSearch
-               && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] > 0))
+            && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] > 0))
          {
             dBion += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide] - 1].dVarModMass;
             if (!g_staticParams.iIndexDb)
@@ -448,14 +460,14 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
          }
 
          if (g_staticParams.variableModParameters.bVarModSearch
-               && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] > 0))
+            && (pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] > 0))
          {
             dYion += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] - 1].dVarModMass;
             if (!g_staticParams.iIndexDb)
                dCalcPepMass += g_staticParams.variableModParameters.varModList[pOutput[i].piVarModSites[pOutput[i].usiLenPeptide + 1] - 1].dVarModMass;
          }
 
-         for (ii=0; ii<g_staticParams.ionInformation.iNumIonSeriesUsed; ++ii)
+         for (ii = 0; ii < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ii)
          {
             int iii;
 
@@ -468,16 +480,16 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
 
          if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
          {
-            for (int x=0; x<VMODS; x++)
+            for (int x = 0; x < VMODS; x++)
             {
-               memset(iCountNLB[x], 0, sizeof(int)*MAX_PEPTIDE_LEN);
-               memset(iCountNLY[x], 0, sizeof(int)*MAX_PEPTIDE_LEN);
+               memset(iCountNLB[x], 0, sizeof(int) * MAX_PEPTIDE_LEN);
+               memset(iCountNLY[x], 0, sizeof(int) * MAX_PEPTIDE_LEN);
             }
          }
 
          // Generate pdAAforward for _pResults[0].szPeptide.
          int iLenMinus1 = pOutput[i].usiLenPeptide - 1;
-         for (ii=0; ii<iLenMinus1; ++ii)
+         for (ii = 0; ii < iLenMinus1; ++ii)
          {
             int iPos = iLenMinus1 - ii;
 
@@ -485,10 +497,10 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
             {
                if (ii > 0)
                {
-                  for (int x = 0 ; x < VMODS; x++)
+                  for (int x = 0; x < VMODS; x++)
                   {
-                     iCountNLB[x][ii] = iCountNLB[x][ii-1]; // running sum/count of # of var mods contained at position i
-                     iCountNLY[x][ii] = iCountNLY[x][ii-1]; // running sum/count of # of var mods contained at position i (R to L in sequence)
+                     iCountNLB[x][ii] = iCountNLB[x][ii - 1]; // running sum/count of # of var mods contained at position i
+                     iCountNLY[x][ii] = iCountNLY[x][ii - 1]; // running sum/count of # of var mods contained at position i (R to L in sequence)
                   }
                }
             }
@@ -511,9 +523,9 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                   if (iMod > 0)
                   {
                      if (g_staticParams.options.bScaleFragmentNL)
-                        iCountNLB[iMod-1][ii] += 1;
+                        iCountNLB[iMod - 1][ii] += 1;
                      else
-                        iCountNLB[iMod-1][ii] = 1;
+                        iCountNLB[iMod - 1][ii] = 1;
                   }
                }
 
@@ -526,9 +538,9 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                   if (iMod > 0)
                   {
                      if (g_staticParams.options.bScaleFragmentNL)
-                        iCountNLY[iMod-1][ii] += 1;
+                        iCountNLY[iMod - 1][ii] += 1;
                      else
-                        iCountNLY[iMod-1][ii] = 1;
+                        iCountNLY[iMod - 1][ii] = 1;
                   }
                }
             }
@@ -542,7 +554,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
          if (!g_staticParams.iIndexDb && g_staticParams.variableModParameters.bVarModSearch && pOutput[i].piVarModSites[iLenMinus1] != 0)
             dCalcPepMass += pOutput[i].pdVarModSites[iLenMinus1];
 
-         int iMax = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
+         int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
 
          for (ctCharge = 1; ctCharge <= usiMaxFragCharge; ++ctCharge)
          {
@@ -552,7 +564,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
 
                // As both _pdAAforward and _pdAAreverse are increasing, loop through
                // iLenPeptide-1 to complete set of internal fragment ions.
-               for (int iii=0; iii<pOutput[i].usiLenPeptide-1; ++iii)
+               for (int iii = 0; iii < pOutput[i].usiLenPeptide - 1; ++iii)
                {
                   // Gets fragment ion mass.
                   dFragmentIonMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, iii, ctCharge, pdAAforward, pdAAreverse);
@@ -565,7 +577,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                      double dAddConsecutive = 0.0;
                      int iAddMatchedFragment = 0;
 
-                     fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
+                     fSpScore = FindSpScore(pQuery, iFragmentIonMass, iMax);
 
                      if (fSpScore > FLOAT_ZERO)
                      {
@@ -597,7 +609,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                                  {
                                     int iScaleFactor = iCountNLB[iMod][iii];
                                     double dNewMass;
- 
+
                                     if (iWhichNL == 0)
                                     {
                                        if (g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss == 0.0)
@@ -615,7 +627,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                                     {
                                        int iFragmentIonMass = BIN(dNewMass);
 
-                                       fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
+                                       fSpScore = FindSpScore(pQuery, iFragmentIonMass, iMax);
 
                                        if (fSpScore > FLOAT_ZERO)
                                        {
@@ -661,7 +673,7 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
                                     {
                                        int iFragmentIonMass = BIN(dNewMass);
 
-                                       fSpScore = FindSpScore(g_pvQuery.at(iWhichQuery), iFragmentIonMass, iMax);
+                                       fSpScore = FindSpScore(pQuery, iFragmentIonMass, iMax);
 
                                        if (fSpScore > FLOAT_ZERO)
                                        {
@@ -702,12 +714,22 @@ void CometPostAnalysis::CalculateSP(Results *pOutput,
          pOutput[i].fScoreSp = (float)((dTmpIntenMatch * usiMatchedFragmentIonCt * (1.0 + dConsec)) /
             ((pOutput[i].usiLenPeptide - 1.0) * usiMaxFragCharge * g_staticParams.ionInformation.iNumIonSeriesUsed));
          // round Sp to 3 significant digits
-         pOutput[i].fScoreSp =  (float)(( ((int)pOutput[i].fScoreSp)  * 100)  / 100.0);
+         pOutput[i].fScoreSp = (float)((((int)pOutput[i].fScoreSp) * 100) / 100.0);
 
          pOutput[i].usiMatchedIons = usiMatchedFragmentIonCt;
       }
    }
 }
+
+
+// Original overload: delegates to the Query* version.
+void CometPostAnalysis::CalculateSP(Results* pOutput,
+                                    int iWhichQuery,
+                                    int iSize)
+{
+   CalculateSP(pOutput, g_pvQuery.at(iWhichQuery), iSize);
+}
+
 
 using namespace AScoreProCpp;
 
@@ -727,7 +749,7 @@ void CometPostAnalysis::CalculateAScorePro(int iWhichQuery,
       return;
 
    precursorCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState;
-   precursorMz = (g_pvQuery.at(iWhichQuery)->_pResults[0].dPepMass + (precursorCharge -1) * PROTON_MASS) / precursorCharge;
+   precursorMz = (g_pvQuery.at(iWhichQuery)->_pResults[0].dPepMass + (precursorCharge - 1) * PROTON_MASS) / precursorCharge;
 
    // Generate peptide sequence of format "K.M0LAES1DDSGDEES1VSQTDK.T" where the mod char is the mod #
    sequence = g_pvQuery.at(iWhichQuery)->_pResults[0].cPrevAA + std::string(".");
@@ -807,7 +829,7 @@ void CometPostAnalysis::CalculateAScorePro(int iWhichQuery,
                   g_pvQuery.at(iWhichQuery)->_pResults[0].piVarModSites[iPosMinus1] = modIndex;
                   g_pvQuery.at(iWhichQuery)->_pResults[0].pdVarModSites[iPosMinus1] = g_staticParams.variableModParameters.varModList[modIndex - 1].dVarModMass;
                }
-               else 
+               else
                {
                   // FIX: need to do something more here to address mod sites that might not be correct anymore
                   std::cerr << "Error: (2) AScorePro returned invalid modification position " << (iPosMinus1) << " in peptide " << sPeptide << std::endl;
@@ -846,30 +868,160 @@ void CometPostAnalysis::CalculateAScorePro(int iWhichQuery,
          g_pvQuery.at(iWhichQuery)->_pResults[0].sAScoreProSiteScores = "";
       }
 
-/*
-      // Print results
-      std::cout << "\n\n";
-      std::cout << "Original sequence: " << sequence << "\n";
-      std::cout << "     Best peptide: " << result.peptides[0].toString() << "\n";
-      std::cout << "  Peptides scored: " << result.peptides.size() << "\n";
-      std::cout << "     Sites scored: " << result.sites.size() << "\n";
-      std::cout << "            Score: " << result.peptides[0].getScore() << "\n";
-      std::cout << "      Site scores: ";
-      for (size_t i = 0; i < 6; ++i)
+      /*
+            // Print results
+            std::cout << "\n\n";
+            std::cout << "Original sequence: " << sequence << "\n";
+            std::cout << "     Best peptide: " << result.peptides[0].toString() << "\n";
+            std::cout << "  Peptides scored: " << result.peptides.size() << "\n";
+            std::cout << "     Sites scored: " << result.sites.size() << "\n";
+            std::cout << "            Score: " << result.peptides[0].getScore() << "\n";
+            std::cout << "      Site scores: ";
+            for (size_t i = 0; i < 6; ++i)
+            {
+               if (i < result.sites.size())
+                  std::cout << result.sites[i].getScore() << " (" << result.sites[i].getPosition() << +") \t";
+               else
+                  break;
+            }
+            std::cout << "\n";
+      */
+   }
+}
+
+// Thread-local overload: accepts Query* directly, no g_pvQuery access.
+void CometPostAnalysis::CalculateAScorePro(Query* pQuery,
+                                           AScoreDllInterface* ascoreInterface)
+{
+   std::string sequence;
+   double precursorMz;
+   int precursorCharge;
+
+   // sanity check here; AScorePro will segfault if peptide length is 0
+   if (pQuery->_pResults[0].usiLenPeptide <= 0)
+      return;
+
+   // if specific variable mod specified, check if peptide contains that mod
+   if (pQuery->_pResults[0].cHasVariableMod != HasVariableModType_AScorePro)
+      return;
+
+   precursorCharge = pQuery->_spectrumInfoInternal.usiChargeState;
+   precursorMz = (pQuery->_pResults[0].dPepMass + (precursorCharge - 1) * PROTON_MASS) / precursorCharge;
+
+   // Generate peptide sequence of format "K.M0LAES1DDSGDEES1VSQTDK.T" where the mod char is the mod #
+   sequence = pQuery->_pResults[0].cPrevAA + std::string(".");
+   for (int i = 0; i < pQuery->_pResults[0].usiLenPeptide; ++i)
+   {
+      sequence += pQuery->_pResults[0].szPeptide[i];
+
+      if (g_staticParams.variableModParameters.bVarModSearch && pQuery->_pResults[0].piVarModSites[i] != 0)
       {
-         if (i < result.sites.size())
-            std::cout << result.sites[i].getScore() << " (" << result.sites[i].getPosition() << +") \t";
+         if (pQuery->_pResults[0].piVarModSites[i] > 0)
+         {
+            sequence += std::to_string(pQuery->_pResults[0].piVarModSites[i]);
+         }
          else
-            break;
+         {
+            sequence += "?";    // PEFF:  no clue how to specify mod encoding
+         }
       }
-      std::cout << "\n";
-*/
+   }
+   sequence += std::string(".") + pQuery->_pResults[0].cNextAA;
+
+   // Calculate AScore using the DLL interface
+   AScoreOutput result = ascoreInterface->CalculateScoreWithOptions(sequence,
+      pQuery->vRawFragmentPeakMassIntensity, precursorMz, precursorCharge, g_AScoreOptions);
+
+   if (!result.peptides.empty())
+   {
+      pQuery->_pResults[0].fAScorePro = (float)result.peptides[0].getScore();
+
+      if (pQuery->_pResults[0].fAScorePro >= ASCORE_CUTOFF_TO_ACCEPT)
+      {
+         // set piVarModSites and pdVarModSites based on AScore localized peptide
+         memset(pQuery->_pResults[0].piVarModSites, 0, (unsigned short)(sizeof(int) * MAX_PEPTIDE_LEN_P2));
+         memset(pQuery->_pResults[0].pdVarModSites, 0, (unsigned short)(sizeof(double) * MAX_PEPTIDE_LEN_P2));
+
+         std::string sPeptide = result.peptides[0].toString();
+
+         // Extract the peptide portion (between the two dots)
+         size_t firstDot = sPeptide.find('.');
+         size_t lastDot = sPeptide.rfind('.');
+         std::string peptide = sPeptide.substr(firstDot + 1, lastDot - firstDot - 1);
+
+         int position = 0; // position within peptide
+         int iPosMinus1 = 0;
+         for (size_t i = 0; i < peptide.size();)
+         {
+            if (std::isalpha(peptide[i]))
+            {
+               position++;
+               i++;
+            }
+            else if (std::isdigit(peptide[i]))
+            {
+               size_t j = i;
+               while (j < peptide.size() && std::isdigit(peptide[j]))
+               {
+                  j++;
+               }
+
+               int modIndex = std::stoi(peptide.substr(i, j - i));
+
+               if (modIndex < 0 || modIndex > VMODS)
+               {
+                  std::cerr << "Error: (1) AScorePro returned invalid modification index " << modIndex << " in peptide " << sPeptide << std::endl;
+                  return;
+               }
+
+               iPosMinus1 = position - 1;
+               if (iPosMinus1 >= 0 && iPosMinus1 < MAX_PEPTIDE_LEN)
+               {
+                  pQuery->_pResults[0].piVarModSites[iPosMinus1] = modIndex;
+                  pQuery->_pResults[0].pdVarModSites[iPosMinus1] = g_staticParams.variableModParameters.varModList[modIndex - 1].dVarModMass;
+               }
+               else
+               {
+                  std::cerr << "Error: (2) AScorePro returned invalid modification position " << (iPosMinus1) << " in peptide " << sPeptide << std::endl;
+                  return;
+               }
+
+               i = j;
+            }
+            else
+            {
+               i++;
+            }
+         }
+
+         // Report site score as a string composed of space separated "position:score" pairs
+         pQuery->_pResults[0].sAScoreProSiteScores.clear();
+         int iPosition;
+         double dScore;
+         char szBuffer[32];
+
+         for (size_t i = 0; i < result.sites.size(); ++i)
+         {
+            iPosition = result.sites[i].getPosition();
+            dScore = result.sites[i].getScore();
+
+            snprintf(szBuffer, sizeof(szBuffer), "%.2f", dScore);
+
+            if (i > 0)
+               pQuery->_pResults[0].sAScoreProSiteScores += " ";
+            pQuery->_pResults[0].sAScoreProSiteScores += std::to_string(iPosition) + ":" + szBuffer;
+         }
+      }
+      else
+      {
+         pQuery->_pResults[0].sAScoreProSiteScores = "";
+      }
    }
 }
 
 
-bool CometPostAnalysis::ProteinEntryCmp(const struct ProteinEntryStruct &a,
-                                        const struct ProteinEntryStruct &b)
+bool CometPostAnalysis::ProteinEntryCmp(const struct ProteinEntryStruct& a,
+   const struct ProteinEntryStruct& b)
 {
    if (a.lWhichProtein == b.lWhichProtein)
       return a.iStartResidue < b.iStartResidue;
@@ -878,8 +1030,8 @@ bool CometPostAnalysis::ProteinEntryCmp(const struct ProteinEntryStruct &a,
 }
 
 
-bool CometPostAnalysis::SortFnSp(const Results &a,
-                                 const Results &b)
+bool CometPostAnalysis::SortFnSp(const Results& a,
+   const Results& b)
 {
    if (a.fScoreSp > b.fScoreSp)
       return true;
@@ -907,8 +1059,8 @@ bool CometPostAnalysis::SortFnSp(const Results &a,
 }
 
 
-bool CometPostAnalysis::SortFnXcorr(const Results &a,
-                                    const Results &b)
+bool CometPostAnalysis::SortFnXcorr(const Results& a,
+   const Results& b)
 {
    if (a.fXcorr > b.fXcorr)
       return true;
@@ -937,7 +1089,7 @@ bool CometPostAnalysis::SortFnXcorr(const Results &a,
 
 
 bool CometPostAnalysis::SortSpecLibFnXcorrMS1(const SpecLibResultsMS1& a,
-                                              const SpecLibResultsMS1& b)
+   const SpecLibResultsMS1& b)
 {
    if (a.fDotProduct > b.fDotProduct)
       return true;
@@ -946,8 +1098,8 @@ bool CometPostAnalysis::SortSpecLibFnXcorrMS1(const SpecLibResultsMS1& a,
 }
 
 
-bool CometPostAnalysis::SortFnMod(const Results &a,
-                                  const Results &b)
+bool CometPostAnalysis::SortFnMod(const Results& a,
+   const Results& b)
 {
    // must compare character at a time
    // actually not sure why strcmp doesn't work
@@ -964,91 +1116,12 @@ bool CometPostAnalysis::SortFnMod(const Results &a,
 }
 
 
-bool CometPostAnalysis::CalculateEValue(int iWhichQuery,
-                                        bool bTopHitOnly)
-{
-   int i;
-   int *piHistogram;
-   int iMaxCorr;
-   int iStartCorr;
-   int iNextCorr;
-   double dSlope;
-   double dIntercept;
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
-
-   piHistogram = pQuery->iXcorrHistogram;
-
-   if (pQuery->uiHistogramCount < EXPECT_DECOY_SIZE)
-   {
-      if (!GenerateXcorrDecoys(iWhichQuery))
-      {
-         return false;
-      }
-   }
-
-   LinearRegression(piHistogram, &dSlope, &dIntercept, &iMaxCorr, &iStartCorr, &iNextCorr);
-
-   pQuery->fPar[0] = (float)dIntercept;  // b
-   pQuery->fPar[1] = (float)dSlope    ;  // m
-   pQuery->fPar[2] = (float)iStartCorr;
-   pQuery->fPar[3] = (float)iNextCorr;
-   pQuery->siMaxXcorr = (short)iMaxCorr;
-
-   dSlope *= 10.0; // Used in pow() function so do multiply outside of for loop.
-
-   int iLoopCount;
-
-   iLoopCount = pQuery->iMatchPeptideCount;
-   if (pQuery->iDecoyMatchPeptideCount > iLoopCount)
-      iLoopCount = pQuery->iDecoyMatchPeptideCount;
-
-   if (iLoopCount > g_staticParams.options.iNumPeptideOutputLines)
-      iLoopCount = g_staticParams.options.iNumPeptideOutputLines;
-
-   for (i=0; i<iLoopCount; ++i)
-   {
-      if (dSlope >= 0.0)
-      {
-         if (i<pQuery->iMatchPeptideCount)
-            pQuery->_pResults[i].dExpect = 999.0;
-         if (i<pQuery->iDecoyMatchPeptideCount)
-            pQuery->_pDecoys[i].dExpect = 999.0;
-      }
-      else
-      {
-         double dExpect;
-         if (i<pQuery->iMatchPeptideCount)
-         {
-            dExpect = pow(10.0, dSlope * pQuery->_pResults[i].fXcorr + dIntercept);
-            if (dExpect > 999.0)
-               dExpect = 999.0;
-            pQuery->_pResults[i].dExpect = dExpect;
-         }
-
-         if (i<pQuery->iDecoyMatchPeptideCount)
-         {
-            dExpect = pow(10.0, dSlope * pQuery->_pDecoys[i].fXcorr + dIntercept);
-            if (dExpect > 999.0)
-               dExpect = 999.0;
-            pQuery->_pDecoys[i].dExpect = dExpect;
-         }
-      }
-
-      if (bTopHitOnly)
-         break;
-   }
-
-   return true;
-}
-
-
-void CometPostAnalysis::LinearRegression(int *piHistogram,
-                                         double *slope,
-                                         double *intercept,
-                                         int *iMaxXcorr,
-                                         int *iStartXcorr,
-                                         int *iNextXcorr)
+void CometPostAnalysis::LinearRegression(int* piHistogram,
+   double* slope,
+   double* intercept,
+   int* iMaxXcorr,
+   int* iStartXcorr,
+   int* iNextXcorr)
 {
    double Sx, Sxy;      // Sum of square distances.
    double Mx, My;       // means
@@ -1060,12 +1133,12 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
 
    int i;
    int iNextCorr;    // 2nd best xcorr index
-   int iMaxCorr=0;   // max xcorr index
+   int iMaxCorr = 0;   // max xcorr index
    int iStartCorr;
    int iNumPoints;
 
    // Find maximum correlation score index.
-   for (i=HISTO_SIZE-2; i>=0; i--)
+   for (i = HISTO_SIZE - 2; i >= 0; i--)
    {
       if (piHistogram[i] > 0)
          break;
@@ -1075,15 +1148,15 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
    iNextCorr = 0;
    bool bFoundFirstNonZeroEntry = false;
 
-   for (i=0; i<iMaxCorr; ++i)
+   for (i = 0; i < iMaxCorr; ++i)
    {
       if (piHistogram[i] == 0 && bFoundFirstNonZeroEntry && i >= 10)
       {
          // register iNextCorr if there's a histo value of 0 consecutively
-         if (piHistogram[i+1] == 0 || i+1 == iMaxCorr)
+         if (piHistogram[i + 1] == 0 || i + 1 == iMaxCorr)
          {
-            if (i>0)
-               iNextCorr = i-1;
+            if (i > 0)
+               iNextCorr = i - 1;
             break;
          }
       }
@@ -1091,7 +1164,7 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
          bFoundFirstNonZeroEntry = true;
    }
 
-   if (i==iMaxCorr)
+   if (i == iMaxCorr)
    {
       iNextCorr = iMaxCorr;
 
@@ -1114,23 +1187,23 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
 
    // Create cumulative distribution function from iNextCorr down, skipping the outliers.
    pdCumulative[iNextCorr] = piHistogram[iNextCorr];
-   for (i=iNextCorr-1; i>=0; i--)
+   for (i = iNextCorr - 1; i >= 0; i--)
    {
-      pdCumulative[i] = pdCumulative[i+1] + piHistogram[i];
-      if (piHistogram[i+1] == 0)
-         pdCumulative[i+1] = 0.0;
+      pdCumulative[i] = pdCumulative[i + 1] + piHistogram[i];
+      if (piHistogram[i + 1] == 0)
+         pdCumulative[i + 1] = 0.0;
    }
 
    // log10
-   for (i=iNextCorr; i>=0; i--)
+   for (i = iNextCorr; i >= 0; i--)
    {
       piHistogram[i] = (int)pdCumulative[i];  // First store cumulative in histogram.
       if (pdCumulative[i] > 0.0)
          pdCumulative[i] = log10(pdCumulative[i]);
       else
       {
-         if (pdCumulative[i+1] > 0.0)
-            pdCumulative[i] = log10(pdCumulative[i+1]);
+         if (pdCumulative[i + 1] > 0.0)
+            pdCumulative[i] = log10(pdCumulative[i + 1]);
          else
             pdCumulative[i] = 0.0;
       }
@@ -1138,7 +1211,7 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
 
    iStartCorr = iNextCorr - 5;
    int iNumZeroes = 0;
-   for (i=iStartCorr; i<=iNextCorr; ++i)
+   for (i = iStartCorr; i <= iNextCorr; ++i)
       if (pdCumulative[i] == 0)
          iNumZeroes++;
 
@@ -1147,15 +1220,15 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
    if (iStartCorr < 0)
       iStartCorr = 0;
 
-   Mx=My=a=b=0.0;
+   Mx = My = a = b = 0.0;
 
    while (iStartCorr >= 0 && iNextCorr > iStartCorr + 2)
    {
-      Sx=Sxy=SumX=SumY=0.0;
-      iNumPoints=0;
+      Sx = Sxy = SumX = SumY = 0.0;
+      iNumPoints = 0;
 
       // Calculate means.
-      for (i=iStartCorr; i<=iNextCorr; ++i)
+      for (i = iStartCorr; i <= iNextCorr; ++i)
       {
          if (piHistogram[i] > 0)
          {
@@ -1174,7 +1247,7 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
          Mx = My = 0.0;
 
       // Calculate sum of squares.
-      for (i=iStartCorr; i<=iNextCorr; ++i)
+      for (i = iStartCorr; i <= iNextCorr; ++i)
       {
          if (pdCumulative[i] > 0)
          {
@@ -1184,8 +1257,8 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
             dX = i - Mx;
             dY = pdCumulative[i] - My;
 
-            Sx  += dX*dX;
-            Sxy += dX*dY;
+            Sx += dX * dX;
+            Sxy += dX * dY;
          }
       }
 
@@ -1200,7 +1273,7 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
          iStartCorr--;
    }
 
-   a = My - b*Mx;  // y-intercept
+   a = My - b * Mx;  // y-intercept
 
    *slope = b;
    *intercept = a;
@@ -1210,9 +1283,10 @@ void CometPostAnalysis::LinearRegression(int *piHistogram,
 }
 
 
+// Original overload: delegates to the Query* version.
 // Make synthetic decoy spectra to fill out correlation histogram by going
 // through each candidate peptide and rotating spectra in m/z space.
-bool CometPostAnalysis::GenerateXcorrDecoys(int iWhichQuery)
+bool CometPostAnalysis::GenerateXcorrDecoys(Query* pQuery)
 {
    int i;
    int ii;
@@ -1228,8 +1302,6 @@ bool CometPostAnalysis::GenerateXcorrDecoys(int iWhichQuery)
    int *piHistogram;
 
    int iFragmentIonMass;
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
 
    piHistogram = pQuery->iXcorrHistogram;
 
@@ -1340,6 +1412,13 @@ bool CometPostAnalysis::GenerateXcorrDecoys(int iWhichQuery)
 }
 
 
+// Original overload: delegates to the Query* version.
+bool CometPostAnalysis::GenerateXcorrDecoys(int iWhichQuery)
+{
+   return GenerateXcorrDecoys(g_pvQuery.at(iWhichQuery));
+}
+
+
 float CometPostAnalysis::FindSpScore(Query *pQuery,
                                      int bin,
                                      int iMax)
@@ -1353,3 +1432,90 @@ float CometPostAnalysis::FindSpScore(Query *pQuery,
 
    return pQuery->ppfSparseSpScoreData[x][y];
 }
+
+
+bool CometPostAnalysis::CalculateEValue(Query* pQuery,
+                                        bool bTopHitOnly)
+{
+   int i;
+   int *piHistogram;
+   int iMaxCorr;
+   int iStartCorr;
+   int iNextCorr;
+   double dSlope;
+   double dIntercept;
+
+   piHistogram = pQuery->iXcorrHistogram;
+
+   if (pQuery->uiHistogramCount < EXPECT_DECOY_SIZE)
+   {
+      if (!GenerateXcorrDecoys(pQuery))
+      {
+         return false;
+      }
+   }
+
+   LinearRegression(piHistogram, &dSlope, &dIntercept, &iMaxCorr, &iStartCorr, &iNextCorr);
+
+   pQuery->fPar[0] = (float)dIntercept;  // b
+   pQuery->fPar[1] = (float)dSlope    ;  // m
+   pQuery->fPar[2] = (float)iStartCorr;
+   pQuery->fPar[3] = (float)iNextCorr;
+   pQuery->siMaxXcorr = (short)iMaxCorr;
+
+   dSlope *= 10.0; // Used in pow() function so do multiply outside of for loop.
+
+   int iLoopCount;
+
+   iLoopCount = pQuery->iMatchPeptideCount;
+   if (pQuery->iDecoyMatchPeptideCount > iLoopCount)
+      iLoopCount = pQuery->iDecoyMatchPeptideCount;
+
+   if (iLoopCount > g_staticParams.options.iNumPeptideOutputLines)
+      iLoopCount = g_staticParams.options.iNumPeptideOutputLines;
+
+   for (i=0; i<iLoopCount; ++i)
+   {
+      if (dSlope >= 0.0)
+      {
+         if (i<pQuery->iMatchPeptideCount)
+            pQuery->_pResults[i].dExpect = 999.0;
+         if (i<pQuery->iDecoyMatchPeptideCount)
+            pQuery->_pDecoys[i].dExpect = 999.0;
+      }
+      else
+      {
+         double dExpect;
+         if (i<pQuery->iMatchPeptideCount)
+         {
+            dExpect = pow(10.0, dSlope * pQuery->_pResults[i].fXcorr + dIntercept);
+            if (dExpect > 999.0)
+               dExpect = 999.0;
+            pQuery->_pResults[i].dExpect = dExpect;
+         }
+
+         if (i<pQuery->iDecoyMatchPeptideCount)
+         {
+            dExpect = pow(10.0, dSlope * pQuery->_pDecoys[i].fXcorr + dIntercept);
+            if (dExpect > 999.0)
+               dExpect = 999.0;
+            pQuery->_pDecoys[i].dExpect = dExpect;
+         }
+      }
+
+      if (bTopHitOnly)
+         break;
+   }
+
+   return true;
+}
+
+
+// Original overload: delegates to the Query* version.
+bool CometPostAnalysis::CalculateEValue(int iWhichQuery,
+                                        bool bTopHitOnly)
+{
+   return CalculateEValue(g_pvQuery.at(iWhichQuery), bTopHitOnly);
+}
+
+

--- a/CometSearch/CometPostAnalysis.h
+++ b/CometSearch/CometPostAnalysis.h
@@ -45,15 +45,24 @@ public:
    static void PostAnalysisThreadProc(PostAnalysisThreadData *pThreadData,
                                       ThreadPool* tp);
    static void CalculateDeltaCn(int i);
+   static void CalculateDeltaCn(Query* pQuery);
    static void CalculateDeltaCnsAndRank(Results* pOutput,
                                        int iNumPrintLines);
    static void AnalyzeSP(int i);
+   static void AnalyzeSP(Query* pQuery);
    static void CalculateSP(Results *pOutput,
                            int iWhichQuery,
                            int iSize);
+   static void CalculateSP(Results *pOutput,
+                           Query *pQuery,
+                           int iSize);
    static bool CalculateEValue(int iWhichQuery,
                                bool bTopHitOnly);
+   static bool CalculateEValue(Query* pQuery,
+                               bool bTopHitOnly);
    static void CalculateAScorePro(int iWhichQuery,
+                                  AScoreProCpp::AScoreDllInterface* ascoreInterface);
+   static void CalculateAScorePro(Query* pQuery,
                                   AScoreProCpp::AScoreDllInterface* ascoreInterface);
    static bool SortFnXcorr(const Results &a,
                            const Results &b);
@@ -68,6 +77,7 @@ private:
    static bool SortFnMod(const Results &a,
                          const Results &b);
    static bool GenerateXcorrDecoys(int iWhichQuery);
+   static bool GenerateXcorrDecoys(Query* pQuery);
    static void LinearRegression(int *pHistogram,
                                 double *dSlope,
                                 double *dIntercept,

--- a/CometSearch/CometPostAnalysis.h
+++ b/CometSearch/CometPostAnalysis.h
@@ -43,8 +43,8 @@ public:
    ~CometPostAnalysis();
    static bool PostAnalysis(ThreadPool* tp);
    static void PostAnalysisThreadProc(PostAnalysisThreadData* pThreadData,
-      ThreadPool* tp);
-   // Query*-based overloads — the only versions now
+                                      ThreadPool* tp);
+   // Query*-based overloads, the only versions now
    static void CalculateDeltaCn(Query* pQuery);
    static void CalculateDeltaCnsAndRank(Results* pOutput,
                                         int iNumPrintLines);

--- a/CometSearch/CometPostAnalysis.h
+++ b/CometSearch/CometPostAnalysis.h
@@ -42,53 +42,43 @@ public:
    CometPostAnalysis();
    ~CometPostAnalysis();
    static bool PostAnalysis(ThreadPool* tp);
-   static void PostAnalysisThreadProc(PostAnalysisThreadData *pThreadData,
-                                      ThreadPool* tp);
-   static void CalculateDeltaCn(int i);
+   static void PostAnalysisThreadProc(PostAnalysisThreadData* pThreadData,
+      ThreadPool* tp);
+   // Query*-based overloads — the only versions now
    static void CalculateDeltaCn(Query* pQuery);
    static void CalculateDeltaCnsAndRank(Results* pOutput,
-                                       int iNumPrintLines);
-   static void AnalyzeSP(int i);
+                                        int iNumPrintLines);
    static void AnalyzeSP(Query* pQuery);
-   static void CalculateSP(Results *pOutput,
-                           int iWhichQuery,
+   static void CalculateSP(Results* pOutput,
+                           Query* pQuery,
                            int iSize);
-   static void CalculateSP(Results *pOutput,
-                           Query *pQuery,
-                           int iSize);
-   static bool CalculateEValue(int iWhichQuery,
-                               bool bTopHitOnly);
    static bool CalculateEValue(Query* pQuery,
                                bool bTopHitOnly);
-   static void CalculateAScorePro(int iWhichQuery,
-                                  AScoreProCpp::AScoreDllInterface* ascoreInterface);
    static void CalculateAScorePro(Query* pQuery,
                                   AScoreProCpp::AScoreDllInterface* ascoreInterface);
-   static bool SortFnXcorr(const Results &a,
-                           const Results &b);
+   static bool SortFnXcorr(const Results& a,
+                           const Results& b);
    static bool SortSpecLibFnXcorrMS1(const SpecLibResultsMS1& a,
                                      const SpecLibResultsMS1& b);
 
 private:
 
-   static bool SortFnSp(const Results &a,
-                        const Results &b);
-
-   static bool SortFnMod(const Results &a,
-                         const Results &b);
-   static bool GenerateXcorrDecoys(int iWhichQuery);
+   static bool SortFnSp(const Results& a,
+                        const Results& b);
+   static bool SortFnMod(const Results& a,
+                         const Results& b);
    static bool GenerateXcorrDecoys(Query* pQuery);
-   static void LinearRegression(int *pHistogram,
-                                double *dSlope,
-                                double *dIntercept,
-                                int *iMaxCorr,
-                                int *iStartCorr,
-                                int *iNextCorr);
-   static float FindSpScore(Query *pQuery,
+   static void LinearRegression(int* pHistogram,
+                                double* dSlope,
+                                double* dIntercept,
+                                int* iMaxCorr,
+                                int* iStartCorr,
+                                int* iNextCorr);
+   static float FindSpScore(Query* pQuery,
                             int bin,
                             int iMax);
-   static bool ProteinEntryCmp(const struct ProteinEntryStruct &a,
-                               const struct ProteinEntryStruct &b);
+   static bool ProteinEntryCmp(const struct ProteinEntryStruct& a,
+                               const struct ProteinEntryStruct& b);
 };
 
 

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -1116,7 +1116,7 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
 }
 
 // Shared core: builds a fully preprocessed Query* from the input spectrum data.
-// Allocates its own scratch buffers on the heap — fully thread-safe.
+// Allocates its own scratch buffers on the heap - fully thread-safe.
 // Does NOT push the Query* into g_pvQuery.
 // Returns nullptr on failure.
 Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
@@ -1182,7 +1182,24 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
    pPre.dHighestIntensity = 0;
 
    // --- Inline LoadIons logic for raw arrays instead of Spectrum object ---
+
+   // Compute base-peak intensity so we can apply both absolute and percentage cutoffs
+   double dBasePeakIntensity = 0.0;
+   for (int i = 0; i < iNumPeaks; ++i)
+   {
+      if (pdInten[i] > dBasePeakIntensity)
+         dBasePeakIntensity = pdInten[i];
+   }
+   // Start with the configured absolute minimum intensity
    double dIntensityCutoff = g_staticParams.options.dMinIntensity;
+   // If a minimum percentage of the base-peak intensity is configured, apply it as well
+   if (g_staticParams.options.dMinPercentageIntensity > 0.0 && dBasePeakIntensity > 0.0)
+   {
+      double dPctCutoff = dBasePeakIntensity * g_staticParams.options.dMinPercentageIntensity;
+      if (dPctCutoff > dIntensityCutoff)
+         dIntensityCutoff = dPctCutoff;
+   }
+
    int iNumFragmentPeaks = 0;
 
    for (int i = iNumPeaks - 1; i >= 0; --i)
@@ -1194,7 +1211,7 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
 
       if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
       {
-         if (g_staticParams.iIndexDb == 1 && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
+         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
          {
             pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
             iNumFragmentPeaks++;
@@ -1304,7 +1321,7 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
 
    if (pPre.dHighestIntensity <= 0.0)
    {
-      // No usable peaks — clean up and return null
+      // No usable peaks - clean up and return null
       delete[] pdTmpFastXcorrData;
       delete[] pdTmpCorrelationData;
       delete[] pfFastXcorrData;
@@ -1508,7 +1525,6 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
       pScoring->_pResults[j].usiMatchedIons = 0;
       pScoring->_pResults[j].usiTotalIons = 0;
       pScoring->_pResults[j].szPeptide[0] = '\0';
-      pScoring->_pResults[j].strSingleSearchProtein.clear();
       pScoring->_pResults[j].sAScoreProSiteScores.clear();
       pScoring->_pResults[j].pWhichProtein.clear();
       pScoring->_pResults[j].sPeffOrigResidues.clear();
@@ -1534,7 +1550,6 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
          pScoring->_pDecoys[j].usiMatchedIons = 0;
          pScoring->_pDecoys[j].usiTotalIons = 0;
          pScoring->_pDecoys[j].szPeptide[0] = '\0';
-         pScoring->_pDecoys[j].strSingleSearchProtein.clear();
          pScoring->_pDecoys[j].sAScoreProSiteScores.clear();
          pScoring->_pDecoys[j].pWhichProtein.clear();
          pScoring->_pDecoys[j].sPeffOrigResidues.clear();
@@ -2115,7 +2130,7 @@ bool CometPreprocess::LoadIons(struct Query *pScoring,
 
    int iNumFragmentPeaks = 0;
 
-   if (g_staticParams.iIndexDb && mstSpectrum.size() > FRAGINDEX_MAX_NUMPEAKS)
+   if (g_staticParams.iDbType != DbType::FASTA_DB && mstSpectrum.size() > FRAGINDEX_MAX_NUMPEAKS)
    {
       // sorts spectrum in ascending order by intensity
       mstSpectrum.sortIntensity();
@@ -2135,10 +2150,12 @@ bool CometPreprocess::LoadIons(struct Query *pScoring,
 
       if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
       {
-         if (g_staticParams.iIndexDb == 1 && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
+         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
          {
             // Store list of fragment masses for fragment index search
-            // Intensities don't matter here
+            // Intensities don't matter here. Note that peaks are sorted in
+            // ascending order by intensity so that the most intense peaks
+            // are stored in vfRawFragmentPeakMass.
             pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
 
             iNumFragmentPeaks++;
@@ -2609,7 +2626,7 @@ QueryMS1* CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(double* pdMass
       }
    }
 
-   // Normalize to unit vector — must match library normalization
+   // Normalize to unit vector - must match library normalization
    double dSumSquares = 0.0;
    for (int i = 0; i < iArraySizeMS1; ++i)
    {
@@ -2626,7 +2643,7 @@ QueryMS1* CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(double* pdMass
    }
    else
    {
-      // Empty spectrum after filtering — return null
+      // Empty spectrum after filtering - return null
       delete[] pQueryMS1->pfFastXcorrData;
       pQueryMS1->pfFastXcorrData = nullptr;
       delete pQueryMS1;

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -735,6 +735,7 @@ void CometPreprocess::PreprocessThreadProcMS1(PreprocessThreadData* pPreprocessT
    auto tStartTime = std::chrono::high_resolution_clock::now();
    const auto timeout_duration = std::chrono::seconds(240);
 
+
    while (true)
    {
       for (i = 0; i < g_staticParams.options.iNumThreads; ++i)
@@ -798,10 +799,6 @@ void CometPreprocess::PreprocessThreadProcMS1(PreprocessThreadData* pPreprocessT
 
    for (int ii = 0; ii < pPreprocessThreadDataMS1->mstSpectrum.size(); ++ii)
    {
-      // store original spectrum
-//    auto p1 = std::make_pair(pPreprocessThreadDataMS1->mstSpectrum.at(ii).mz, pPreprocessThreadDataMS1->mstSpectrum.at(ii).intensity);
-//    pTmp.vSpecLibPeaks.push_back(p1);
-
       double dMass = pPreprocessThreadDataMS1->mstSpectrum.at(ii).mz;
 
       if (g_staticParams.options.dMS1MinMass <= dMass && dMass <= g_staticParams.options.dMS1MaxMass)
@@ -1118,6 +1115,470 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
    return true;
 }
 
+// Shared core: builds a fully preprocessed Query* from the input spectrum data.
+// Allocates its own scratch buffers on the heap — fully thread-safe.
+// Does NOT push the Query* into g_pvQuery.
+// Returns nullptr on failure.
+Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
+                                                     double dMZ,
+                                                     double *pdMass,
+                                                     double *pdInten,
+                                                     int iNumPeaks,
+                                                     double *pdTmpSpectrum)
+{
+   double dMass = dMZ * iPrecursorCharge - PROTON_MASS * (iPrecursorCharge - 1);
+
+   Query *pScoring = new Query();
+
+   pScoring->_pepMassInfo.dExpPepMass = dMass;
+   pScoring->_spectrumInfoInternal.usiChargeState = iPrecursorCharge;
+   pScoring->_spectrumInfoInternal.dTotalIntensity = 0.0;
+   pScoring->_spectrumInfoInternal.iScanNumber = 0;
+   pScoring->_spectrumInfoInternal.fRTime = 0.0;
+   pScoring->_spectrumInfoInternal.szNativeID[0] = '\0';
+
+   if (iPrecursorCharge == 1)
+      pScoring->_spectrumInfoInternal.usiMaxFragCharge = 1;
+   else
+   {
+      pScoring->_spectrumInfoInternal.usiMaxFragCharge = iPrecursorCharge - 1;
+
+      if (pScoring->_spectrumInfoInternal.usiMaxFragCharge > g_staticParams.options.iMaxFragmentCharge)
+         pScoring->_spectrumInfoInternal.usiMaxFragCharge = g_staticParams.options.iMaxFragmentCharge;
+   }
+
+   double dCushion = GetMassCushion(pScoring->_pepMassInfo.dExpPepMass);
+   pScoring->_spectrumInfoInternal.iArraySize = (int)((pScoring->_pepMassInfo.dExpPepMass + dCushion) * g_staticParams.dInverseBinWidth);
+
+   if (!AdjustMassTol(pScoring))
+   {
+      delete pScoring;
+      return nullptr;
+   }
+
+   // Build a synthetic Spectrum from the input arrays for LoadIons/Preprocess.
+   // The caller's pdTmpSpectrum is used as scratch storage for binned raw data below.
+   // We need 6 scratch buffers that the existing Preprocess() expects:
+   //   pdTmpRawData, pdTmpFastXcorrData, pdTmpCorrelationData (double)
+   //   pfFastXcorrData, pfFastXcorrDataNL, pfSpScoreData (float)
+   //
+   // For single-spectrum search, pdTmpSpectrum is already sized to iArraySizeGlobal.
+   // We allocate the other 5 buffers on the heap for thread safety.
+
+   size_t iGlobalBytes = (size_t)g_staticParams.iArraySizeGlobal;
+
+   double *pdTmpRawData         = pdTmpSpectrum;  // reuse caller-provided buffer
+   double *pdTmpFastXcorrData   = new double[iGlobalBytes]();
+   double *pdTmpCorrelationData = new double[iGlobalBytes]();
+   float  *pfFastXcorrData      = new float[iGlobalBytes]();
+   float  *pfFastXcorrDataNL    = new float[iGlobalBytes]();
+   float  *pfSpScoreData        = new float[iGlobalBytes]();
+
+   // Zero the raw data buffer (caller may not have cleared it)
+   memset(pdTmpRawData, 0, iGlobalBytes * sizeof(double));
+
+   struct PreprocessStruct pPre;
+   pPre.iHighestIon = 0;
+   pPre.dHighestIntensity = 0;
+
+   // --- Inline LoadIons logic for raw arrays instead of Spectrum object ---
+   double dIntensityCutoff = g_staticParams.options.dMinIntensity;
+   int iNumFragmentPeaks = 0;
+
+   for (int i = iNumPeaks - 1; i >= 0; --i)
+   {
+      double dIon = pdMass[i];
+      double dIntensity = pdInten[i];
+
+      pScoring->_spectrumInfoInternal.dTotalIntensity += dIntensity;
+
+      if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
+      {
+         if (g_staticParams.iIndexDb == 1 && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
+         {
+            pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
+            iNumFragmentPeaks++;
+         }
+         if (g_staticParams.options.iPrintAScoreProScore)
+         {
+            pScoring->vRawFragmentPeakMassIntensity.emplace_back(dIon, dIntensity);
+         }
+
+         if (dIon < (pScoring->_pepMassInfo.dExpPepMass + 50.0))
+         {
+            int iBinIon = BIN(dIon);
+
+            double dSqrtInten = sqrt(dIntensity);
+
+            if (iBinIon > pPre.iHighestIon)
+               pPre.iHighestIon = iBinIon;
+
+            if ((iBinIon < pScoring->_spectrumInfoInternal.iArraySize)
+                  && (dSqrtInten > pdTmpRawData[iBinIon]))
+            {
+               if (g_staticParams.options.iRemovePrecursor == 1)
+               {
+                  double dPrecMZ = (pScoring->_pepMassInfo.dExpPepMass
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+
+                  if (fabs(dIon - dPrecMZ) > g_staticParams.options.dRemovePrecursorTol)
+                  {
+                     if (dSqrtInten > pdTmpRawData[iBinIon])
+                        pdTmpRawData[iBinIon] = dSqrtInten;
+                     if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
+                        pPre.dHighestIntensity = pdTmpRawData[iBinIon];
+                  }
+               }
+               else if (g_staticParams.options.iRemovePrecursor == 2)
+               {
+                  int bNotPrec = 1;
+                  for (int j = 1; j <= pScoring->_spectrumInfoInternal.usiChargeState; ++j)
+                  {
+                     double dPrecMZ = (pScoring->_pepMassInfo.dExpPepMass + (j - 1.0) * PROTON_MASS) / (double)(j);
+                     if (fabs(dIon - dPrecMZ) < g_staticParams.options.dRemovePrecursorTol)
+                     {
+                        bNotPrec = 0;
+                        break;
+                     }
+                  }
+                  if (bNotPrec)
+                  {
+                     if (dSqrtInten > pdTmpRawData[iBinIon])
+                        pdTmpRawData[iBinIon] = dSqrtInten;
+                     if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
+                        pPre.dHighestIntensity = pdTmpRawData[iBinIon];
+                  }
+               }
+               else if (g_staticParams.options.iRemovePrecursor == 3)
+               {
+                  double dMZ1 = (pScoring->_pepMassInfo.dExpPepMass - 79.9799
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+                  double dMZ2 = (pScoring->_pepMassInfo.dExpPepMass - 97.9952
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+
+                  if (fabs(dIon - dMZ1) > g_staticParams.options.dRemovePrecursorTol
+                        && fabs(dIon - dMZ2) > g_staticParams.options.dRemovePrecursorTol)
+                  {
+                     if (dSqrtInten > pdTmpRawData[iBinIon])
+                        pdTmpRawData[iBinIon] = dSqrtInten;
+                     if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
+                        pPre.dHighestIntensity = pdTmpRawData[iBinIon];
+                  }
+               }
+               else if (g_staticParams.options.iRemovePrecursor == 4)
+               {
+                  double dMZ1 = (pScoring->_pepMassInfo.dExpPepMass - 18.010565
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+                  double dMZ2 = (pScoring->_pepMassInfo.dExpPepMass - 36.021129
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+                  double dMZ3 = (pScoring->_pepMassInfo.dExpPepMass - 63.997737
+                        + (pScoring->_spectrumInfoInternal.usiChargeState - 1.0) * PROTON_MASS)
+                     / (double)(pScoring->_spectrumInfoInternal.usiChargeState);
+
+                  if (fabs(dIon - dMZ1) > g_staticParams.options.dRemovePrecursorTol
+                        && fabs(dIon - dMZ2) > g_staticParams.options.dRemovePrecursorTol
+                        && fabs(dIon - dMZ3) > g_staticParams.options.dRemovePrecursorTol)
+                  {
+                     if (dSqrtInten > pdTmpRawData[iBinIon])
+                        pdTmpRawData[iBinIon] = dSqrtInten;
+                     if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
+                        pPre.dHighestIntensity = pdTmpRawData[iBinIon];
+                  }
+               }
+               else // iRemovePrecursor==0
+               {
+                  if (dSqrtInten > pdTmpRawData[iBinIon])
+                     pdTmpRawData[iBinIon] = dSqrtInten;
+                  if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
+                     pPre.dHighestIntensity = pdTmpRawData[iBinIon];
+               }
+            }
+         }
+      }
+   }
+
+   if (pPre.dHighestIntensity <= 0.0)
+   {
+      // No usable peaks — clean up and return null
+      delete[] pdTmpFastXcorrData;
+      delete[] pdTmpCorrelationData;
+      delete[] pfFastXcorrData;
+      delete[] pfFastXcorrDataNL;
+      delete[] pfSpScoreData;
+      delete pScoring;
+      return nullptr;
+   }
+
+   // --- MakeCorrData: normalize to 100, windowed ---
+   MakeCorrData(pdTmpRawData, pdTmpCorrelationData, pPre.iHighestIon, pPre.dHighestIntensity);
+
+   // --- Make fast xcorr spectrum ---
+   int i;
+   double dSum = 0.0;
+   int iTmpRange = 2 * g_staticParams.iXcorrProcessingOffset + 1;
+   double dTmp = 1.0 / (iTmpRange - 1.0);
+   double dMinXcorrInten = 0.0;
+
+   for (i = 0; i < g_staticParams.iXcorrProcessingOffset; ++i)
+      dSum += pdTmpCorrelationData[i];
+   for (i = g_staticParams.iXcorrProcessingOffset; i < pScoring->_spectrumInfoInternal.iArraySize + g_staticParams.iXcorrProcessingOffset; ++i)
+   {
+      if (dMinXcorrInten < pdTmpCorrelationData[i])
+         dMinXcorrInten = pdTmpCorrelationData[i];
+
+      if (i < pScoring->_spectrumInfoInternal.iArraySize)
+         dSum += pdTmpCorrelationData[i];
+      if (i >= iTmpRange)
+         dSum -= pdTmpCorrelationData[i - iTmpRange];
+      pdTmpFastXcorrData[i - g_staticParams.iXcorrProcessingOffset] = (dSum - pdTmpCorrelationData[i - g_staticParams.iXcorrProcessingOffset]) * dTmp;
+   }
+
+   pScoring->iMinXcorrHisto = (int)(dMinXcorrInten * 10.0 * 0.005 + 0.5);
+
+   pfFastXcorrData[0] = 0.0;
+   for (i = 1; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
+   {
+      double dVal = pdTmpCorrelationData[i] - pdTmpFastXcorrData[i];
+
+      pfFastXcorrData[i] = (float)dVal;
+
+      if (g_staticParams.ionInformation.iTheoreticalFragmentIons == 0)
+      {
+         int iTmpIdx;
+         iTmpIdx = i - 1;
+         pfFastXcorrData[i] += (float)((pdTmpCorrelationData[iTmpIdx] - pdTmpFastXcorrData[iTmpIdx]) * 0.5);
+         iTmpIdx = i + 1;
+         if (iTmpIdx < pScoring->_spectrumInfoInternal.iArraySize)
+            pfFastXcorrData[i] += (float)((pdTmpCorrelationData[iTmpIdx] - pdTmpFastXcorrData[iTmpIdx]) * 0.5);
+      }
+
+      if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
+            && (g_staticParams.ionInformation.iIonVal[ION_SERIES_A]
+               || g_staticParams.ionInformation.iIonVal[ION_SERIES_B]
+               || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
+      {
+         int iTmpIdx;
+         pfFastXcorrDataNL[i] = pfFastXcorrData[i];
+
+         iTmpIdx = i - g_staticParams.precalcMasses.iMinus17;
+         if (iTmpIdx >= 0)
+            pfFastXcorrDataNL[i] += (float)((pdTmpCorrelationData[iTmpIdx] - pdTmpFastXcorrData[iTmpIdx]) * 0.2);
+
+         iTmpIdx = i - g_staticParams.precalcMasses.iMinus18;
+         if (iTmpIdx >= 0)
+            pfFastXcorrDataNL[i] += (float)((pdTmpCorrelationData[iTmpIdx] - pdTmpFastXcorrData[iTmpIdx]) * 0.2);
+      }
+   }
+
+   // --- Build sparse matrices on the Query ---
+   int x, y;
+   pScoring->iFastXcorrDataSize = (pScoring->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE) + 1;
+
+   // Sparse NL matrix
+   if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
+         && (g_staticParams.ionInformation.iIonVal[ION_SERIES_A]
+            || g_staticParams.ionInformation.iIonVal[ION_SERIES_B]
+            || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
+   {
+      try
+      {
+         pScoring->ppfSparseFastXcorrDataNL = new float*[pScoring->iFastXcorrDataSize]();
+      }
+      catch (std::bad_alloc&)
+      {
+         delete[] pdTmpFastXcorrData;
+         delete[] pdTmpCorrelationData;
+         delete[] pfFastXcorrData;
+         delete[] pfFastXcorrDataNL;
+         delete[] pfSpScoreData;
+         delete pScoring;
+         return nullptr;
+      }
+
+      for (i = 1; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
+      {
+         if (pfFastXcorrDataNL[i] > FLOAT_ZERO || pfFastXcorrDataNL[i] < -FLOAT_ZERO)
+         {
+            x = i / SPARSE_MATRIX_SIZE;
+            if (pScoring->ppfSparseFastXcorrDataNL[x] == NULL)
+            {
+               pScoring->ppfSparseFastXcorrDataNL[x] = new float[SPARSE_MATRIX_SIZE]();
+            }
+            y = i - (x * SPARSE_MATRIX_SIZE);
+            pScoring->ppfSparseFastXcorrDataNL[x][y] = pfFastXcorrDataNL[i];
+         }
+      }
+   }
+
+   // Sparse fast xcorr matrix
+   try
+   {
+      pScoring->ppfSparseFastXcorrData = new float*[pScoring->iFastXcorrDataSize]();
+   }
+   catch (std::bad_alloc&)
+   {
+      delete[] pdTmpFastXcorrData;
+      delete[] pdTmpCorrelationData;
+      delete[] pfFastXcorrData;
+      delete[] pfFastXcorrDataNL;
+      delete[] pfSpScoreData;
+      delete pScoring;
+      return nullptr;
+   }
+
+   for (i = 1; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
+   {
+      if (pfFastXcorrData[i] > FLOAT_ZERO || pfFastXcorrData[i] < -FLOAT_ZERO)
+      {
+         x = i / SPARSE_MATRIX_SIZE;
+         if (pScoring->ppfSparseFastXcorrData[x] == NULL)
+         {
+            pScoring->ppfSparseFastXcorrData[x] = new float[SPARSE_MATRIX_SIZE]();
+         }
+         y = i - (x * SPARSE_MATRIX_SIZE);
+         pScoring->ppfSparseFastXcorrData[x][y] = pfFastXcorrData[i];
+      }
+   }
+
+   // Sparse Sp score matrix
+   pScoring->iSpScoreData = pScoring->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE + 1;
+
+   try
+   {
+      pScoring->ppfSparseSpScoreData = new float*[pScoring->iSpScoreData]();
+   }
+   catch (std::bad_alloc&)
+   {
+      delete[] pdTmpFastXcorrData;
+      delete[] pdTmpCorrelationData;
+      delete[] pfFastXcorrData;
+      delete[] pfFastXcorrDataNL;
+      delete[] pfSpScoreData;
+      delete pScoring;
+      return nullptr;
+   }
+
+   for (i = 0; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
+   {
+      pfSpScoreData[i] = (float)(100.0 * pdTmpRawData[i] / pPre.dHighestIntensity);
+   }
+
+   for (i = 0; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
+   {
+      if (pfSpScoreData[i] > FLOAT_ZERO)
+      {
+         x = i / SPARSE_MATRIX_SIZE;
+         if (pScoring->ppfSparseSpScoreData[x] == NULL)
+         {
+            pScoring->ppfSparseSpScoreData[x] = new float[SPARSE_MATRIX_SIZE]();
+         }
+         y = i - (x * SPARSE_MATRIX_SIZE);
+         pScoring->ppfSparseSpScoreData[x][y] = pfSpScoreData[i];
+      }
+   }
+
+   // Free heap-allocated scratch buffers (pdTmpRawData is caller-owned pdTmpSpectrum)
+   delete[] pdTmpFastXcorrData;
+   delete[] pdTmpCorrelationData;
+   delete[] pfFastXcorrData;
+   delete[] pfFastXcorrDataNL;
+   delete[] pfSpScoreData;
+
+   // Allocate _pResults (and _pDecoys if needed) so the Query is ready for search.
+   // This mirrors what AllocateResultsMem() does for batch-search g_pvQuery entries.
+   pScoring->_pResults = new Results[g_staticParams.options.iNumStored];
+   pScoring->iMatchPeptideCount = 0;
+   pScoring->iDecoyMatchPeptideCount = 0;
+   memset(pScoring->iXcorrHistogram, 0, sizeof(pScoring->iXcorrHistogram));
+
+   for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
+   {
+      pScoring->_pResults[j].dPepMass = 0.0;
+      pScoring->_pResults[j].dExpect = 999;
+      pScoring->_pResults[j].fScoreSp = 0.0;
+      pScoring->_pResults[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
+      pScoring->_pResults[j].fAScorePro = 0.0;
+      pScoring->_pResults[j].usiLenPeptide = 0;
+      pScoring->_pResults[j].usiRankSp = 0;
+      pScoring->_pResults[j].usiMatchedIons = 0;
+      pScoring->_pResults[j].usiTotalIons = 0;
+      pScoring->_pResults[j].szPeptide[0] = '\0';
+      pScoring->_pResults[j].strSingleSearchProtein.clear();
+      pScoring->_pResults[j].sAScoreProSiteScores.clear();
+      pScoring->_pResults[j].pWhichProtein.clear();
+      pScoring->_pResults[j].sPeffOrigResidues.clear();
+      pScoring->_pResults[j].iPeffOrigResiduePosition = -9;
+
+      if (g_staticParams.options.iDecoySearch)
+         pScoring->_pResults[j].pWhichDecoyProtein.clear();
+   }
+
+   if (g_staticParams.options.iDecoySearch == 2)
+   {
+      pScoring->_pDecoys = new Results[g_staticParams.options.iNumStored];
+
+      for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
+      {
+         pScoring->_pDecoys[j].dPepMass = 0.0;
+         pScoring->_pDecoys[j].dExpect = 999;
+         pScoring->_pDecoys[j].fScoreSp = 0.0;
+         pScoring->_pDecoys[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
+         pScoring->_pDecoys[j].fAScorePro = 0.0;
+         pScoring->_pDecoys[j].usiLenPeptide = 0;
+         pScoring->_pDecoys[j].usiRankSp = 0;
+         pScoring->_pDecoys[j].usiMatchedIons = 0;
+         pScoring->_pDecoys[j].usiTotalIons = 0;
+         pScoring->_pDecoys[j].szPeptide[0] = '\0';
+         pScoring->_pDecoys[j].strSingleSearchProtein.clear();
+         pScoring->_pDecoys[j].sAScoreProSiteScores.clear();
+         pScoring->_pDecoys[j].pWhichProtein.clear();
+         pScoring->_pDecoys[j].sPeffOrigResidues.clear();
+         pScoring->_pDecoys[j].iPeffOrigResiduePosition = -9;
+      }
+   }
+
+   return pScoring;
+}
+
+
+// Thread-local public wrapper: returns Query* without touching g_pvQuery.
+// Caller owns the returned Query* and must delete it when done.
+Query* CometPreprocess::PreprocessSingleSpectrumThreadLocal(int iPrecursorCharge,
+                                                            double dMZ,
+                                                            double *pdMass,
+                                                            double *pdInten,
+                                                            int iNumPeaks,
+                                                            double *pdTmpSpectrum)
+{
+   return PreprocessSingleSpectrumCore(iPrecursorCharge, dMZ, pdMass, pdInten, iNumPeaks, pdTmpSpectrum);
+}
+
+
+// Original public entry point: builds Query* via Core, then pushes into g_pvQuery.
+// Preserves backward compatibility with existing callers.
+bool CometPreprocess::PreprocessSingleSpectrum(int iPrecursorCharge,
+                                               double dMZ,
+                                               double *pdMass,
+                                               double *pdInten,
+                                               int iNumPeaks,
+                                               double *pdTmpSpectrum)
+{
+   Query* pScoring = PreprocessSingleSpectrumCore(iPrecursorCharge, dMZ, pdMass, pdInten, iNumPeaks, pdTmpSpectrum);
+
+   if (pScoring == nullptr)
+      return false;
+
+   Threading::LockMutex(g_pvQueryMutex);
+   g_pvQuery.push_back(pScoring);
+   Threading::UnlockMutex(g_pvQueryMutex);
+
+   return true;
+}
 
 //-->MH
 // Loads spectrum into spectrum object.
@@ -1257,10 +1718,7 @@ bool CometPreprocess::PreprocessSpectrum(Spectrum &spec,
                                          float *pfFastXcorrDataNL,
                                          float *pfSpScoreData)
 {
-   int z;
-
    int iScanNumber = spec.getScanNumber();
-
    int iSpectrumCharge = 0;
 
    // To run a search, all that's needed is MH+ and Z. So need to generate
@@ -1362,7 +1820,7 @@ bool CometPreprocess::PreprocessSpectrum(Spectrum &spec,
                }
                else
                {
-                  for (z = g_staticParams.options.iStartCharge; z <= g_staticParams.options.iEndCharge; ++z)
+                  for (int z = g_staticParams.options.iStartCharge; z <= g_staticParams.options.iEndCharge; ++z)
                   {
                      vChargeStates.push_back(make_pair(z, dMZ));
                   }
@@ -1429,8 +1887,9 @@ bool CometPreprocess::PreprocessSpectrum(Spectrum &spec,
             pScoring->_pepMassInfo.dExpPepMass = dMass;
             pScoring->_spectrumInfoInternal.usiChargeState = iPrecursorCharge;
             pScoring->_spectrumInfoInternal.dTotalIntensity = 0.0;
-            pScoring->_spectrumInfoInternal.fRTime = (float)(60.0 * spec.getRTime());  // convert from minutes to seconds
             pScoring->_spectrumInfoInternal.iScanNumber = iScanNumber;
+            pScoring->_spectrumInfoInternal.fRTime = (float)(60.0 * spec.getRTime());  // convert from minutes to seconds
+            pScoring->_spectrumInfoInternal.szNativeID[0] = '\0';
 
             if (iPrecursorCharge == 1)
                pScoring->_spectrumInfoInternal.usiMaxFragCharge = 1;
@@ -1457,6 +1916,7 @@ bool CometPreprocess::PreprocessSpectrum(Spectrum &spec,
 
             if (!AdjustMassTol(pScoring))
             {
+               delete pScoring;
                return false;
             }
 
@@ -1465,6 +1925,7 @@ bool CometPreprocess::PreprocessSpectrum(Spectrum &spec,
             //       of repeating for each charge state.
             if (!Preprocess(pScoring, spec, pdTmpRawData, pdTmpFastXcorrData, pdTmpCorrelationData, pfFastXcorrData, pfFastXcorrDataNL, pfSpScoreData))
             {
+               delete pScoring;
                return false;
             }
 
@@ -1801,31 +2262,33 @@ bool CometPreprocess::LoadIons(struct Query *pScoring,
 }
 
 
+
+
 // pdTmpRawData now holds raw data, pdTmpCorrelationData is windowed data after this function
 // FIX: need to check why both iArraySize and iHighestIons are used
 void CometPreprocess::MakeCorrData(double* pdTmpRawData,
-                                   double* pdTmpCorrelationData,
-                                   int iHighestIon,
-                                   double dHighestIntensity)
+   double* pdTmpCorrelationData,
+   int iHighestIon,
+   double dHighestIntensity)
 {
    int  i,
-        ii,
-        iBin,
-        iWindowSize,
-        iNumWindows=10;
+      ii,
+      iBin,
+      iWindowSize,
+      iNumWindows = 10;
    double dMaxWindowInten,
-          dTmp1,
-          dTmp2;
+      dTmp1,
+      dTmp2;
 
    iWindowSize = (int)((iHighestIon) / iNumWindows) + 1;
 
-   for (i=0; i<iNumWindows; ++i)
+   for (i = 0; i < iNumWindows; ++i)
    {
       dMaxWindowInten = 0.0;
 
-      for (ii=0; ii<iWindowSize; ++ii)    // Find max inten. in window.
+      for (ii = 0; ii < iWindowSize; ++ii)    // Find max inten. in window.
       {
-         iBin = i*iWindowSize+ii;
+         iBin = i * iWindowSize + ii;
          if (iBin <= iHighestIon && iBin < g_staticParams.iArraySizeGlobal)
          {
             if (pdTmpRawData[iBin] > dMaxWindowInten)
@@ -1838,13 +2301,13 @@ void CometPreprocess::MakeCorrData(double* pdTmpRawData,
          dTmp1 = 50.0 / dMaxWindowInten;
          dTmp2 = 0.05 * dHighestIntensity;
 
-         for (ii=0; ii<iWindowSize; ++ii)    // Normalize to max inten. in window.
+         for (ii = 0; ii < iWindowSize; ++ii)    // Normalize to max inten. in window.
          {
-            iBin = i*iWindowSize+ii;
+            iBin = i * iWindowSize + ii;
             if (iBin <= iHighestIon && iBin < g_staticParams.iArraySizeGlobal)
             {
                if (pdTmpRawData[iBin] > dTmp2)
-                  pdTmpCorrelationData[iBin] = pdTmpRawData[iBin]*dTmp1;
+                  pdTmpCorrelationData[iBin] = pdTmpRawData[iBin] * dTmp1;
             }
          }
       }
@@ -1862,14 +2325,14 @@ bool CometPreprocess::AllocateMemory(int maxNumThreads)
 
    //MH: Initally mark all arrays as available (i.e. false=not inuse).
    pbMemoryPool = new bool[maxNumThreads];
-   for (i=0; i<maxNumThreads; ++i)
+   for (i = 0; i < maxNumThreads; ++i)
    {
       pbMemoryPool[i] = false;
    }
 
    //MH: Allocate arrays
-   ppdTmpRawDataArr = new double*[maxNumThreads]();
-   for (i=0; i<maxNumThreads; ++i)
+   ppdTmpRawDataArr = new double* [maxNumThreads]();
+   for (i = 0; i < maxNumThreads; ++i)
    {
       try
       {
@@ -1888,8 +2351,8 @@ bool CometPreprocess::AllocateMemory(int maxNumThreads)
    }
 
    //MH: Allocate arrays
-   ppdTmpFastXcorrDataArr = new double*[maxNumThreads]();
-   for (i=0; i<maxNumThreads; ++i)
+   ppdTmpFastXcorrDataArr = new double* [maxNumThreads]();
+   for (i = 0; i < maxNumThreads; ++i)
    {
       try
       {
@@ -1908,8 +2371,8 @@ bool CometPreprocess::AllocateMemory(int maxNumThreads)
    }
 
    //MH: Allocate arrays
-   ppdTmpCorrelationDataArr = new double*[maxNumThreads]();
-   for (i=0; i<maxNumThreads; ++i)
+   ppdTmpCorrelationDataArr = new double* [maxNumThreads]();
+   for (i = 0; i < maxNumThreads; ++i)
    {
       try
       {
@@ -1933,7 +2396,7 @@ bool CometPreprocess::AllocateMemory(int maxNumThreads)
    {
       try
       {
-        ppfFastXcorrData[i] = new float[g_staticParams.iArraySizeGlobal]();
+         ppfFastXcorrData[i] = new float[g_staticParams.iArraySizeGlobal]();
       }
       catch (std::bad_alloc& ba)
       {
@@ -2000,24 +2463,24 @@ bool CometPreprocess::DeallocateMemory(int maxNumThreads)
    if (!g_bCometPreprocessMemoryAllocated)
       return true;
 
-   delete [] pbMemoryPool;
+   delete[] pbMemoryPool;
 
-   for (i=0; i<maxNumThreads; ++i)
+   for (i = 0; i < maxNumThreads; ++i)
    {
-      delete [] ppdTmpRawDataArr[i];
-      delete [] ppdTmpFastXcorrDataArr[i];
-      delete [] ppdTmpCorrelationDataArr[i];
-      delete [] ppfFastXcorrData[i];
-      delete [] ppfFastXcorrDataNL[i];
-      delete [] ppfSpScoreData[i];
+      delete[] ppdTmpRawDataArr[i];
+      delete[] ppdTmpFastXcorrDataArr[i];
+      delete[] ppdTmpCorrelationDataArr[i];
+      delete[] ppfFastXcorrData[i];
+      delete[] ppfFastXcorrDataNL[i];
+      delete[] ppfSpScoreData[i];
    }
 
-   delete [] ppdTmpRawDataArr;
-   delete [] ppdTmpFastXcorrDataArr;
-   delete [] ppdTmpCorrelationDataArr;
-   delete [] ppfFastXcorrData;
-   delete [] ppfFastXcorrDataNL;
-   delete [] ppfSpScoreData;
+   delete[] ppdTmpRawDataArr;
+   delete[] ppdTmpFastXcorrDataArr;
+   delete[] ppdTmpCorrelationDataArr;
+   delete[] ppfFastXcorrData;
+   delete[] ppfFastXcorrDataNL;
+   delete[] ppfSpScoreData;
 
    g_bCometPreprocessMemoryAllocated = false;
 
@@ -2027,350 +2490,6 @@ bool CometPreprocess::DeallocateMemory(int maxNumThreads)
 bool CometPreprocess::IsValidInputType(int inputType)
 {
    return (inputType == InputType_MZXML || inputType == InputType_RAW);
-}
-
-
-bool CometPreprocess::PreprocessSingleSpectrum(int iPrecursorCharge,
-                                               double dMZ,
-                                               double *pdMass,
-                                               double *pdInten,
-                                               int iNumPeaks,
-                                               double *pdTmpSpectrum)
-{
-   float* pfFastXcorrData;
-   float* pfFastXcorrDataNL;
-   float* pfSpScoreData;
-   Query *pScoring = new Query();
-
-   pScoring->_pepMassInfo.dExpPepMass = (iPrecursorCharge * dMZ) - (iPrecursorCharge - 1.0) * PROTON_MASS;
-
-   if (pScoring->_pepMassInfo.dExpPepMass < g_staticParams.options.dPeptideMassLow
-      || pScoring->_pepMassInfo.dExpPepMass > g_staticParams.options.dPeptideMassHigh)
-   {
-      return false;
-   }
-
-   pScoring->_spectrumInfoInternal.usiChargeState = iPrecursorCharge;
-
-   if (iPrecursorCharge == 1)
-      pScoring->_spectrumInfoInternal.usiMaxFragCharge = 1;
-   else
-   {
-      pScoring->_spectrumInfoInternal.usiMaxFragCharge = iPrecursorCharge - 1;
-
-      if (pScoring->_spectrumInfoInternal.usiMaxFragCharge > g_staticParams.options.iMaxFragmentCharge)
-         pScoring->_spectrumInfoInternal.usiMaxFragCharge = g_staticParams.options.iMaxFragmentCharge;
-   }
-
-   g_massRange.dMinMass = pScoring->_pepMassInfo.dExpPepMass;
-   g_massRange.dMaxMass = pScoring->_pepMassInfo.dExpPepMass;
-   g_massRange.usiMaxFragmentCharge = pScoring->_spectrumInfoInternal.usiMaxFragCharge;
-
-   //preprocess here
-   int i;
-   int x;
-   int y;
-   struct PreprocessStruct pPre;
-
-   pPre.iHighestIon = 0;
-   pPre.dHighestIntensity = 0;
-
-   if (!AdjustMassTol(pScoring))
-   {
-      return false;
-   }
-
-   double dCushion = GetMassCushion(pScoring->_pepMassInfo.dExpPepMass);
-   pScoring->_spectrumInfoInternal.iArraySize = (int)((pScoring->_pepMassInfo.dExpPepMass + dCushion) * g_staticParams.dInverseBinWidth);
-
-   // initialize these temporary arrays before re-using
-   double *pdTmpRawData = ppdTmpRawDataArr[0];
-   double *pdTmpFastXcorrData = ppdTmpFastXcorrDataArr[0];
-   double *pdTmpCorrelationData = ppdTmpCorrelationDataArr[0];
-
-   size_t iTmp = (size_t)(pScoring->_spectrumInfoInternal.iArraySize * sizeof(double));
-   memset(pdTmpRawData, 0, iTmp);
-   memset(pdTmpFastXcorrData, 0, iTmp);
-   memset(pdTmpCorrelationData, 0, iTmp);
-   memset(pdTmpSpectrum, 0, iTmp);
-
-   // Loop through single spectrum and store in pdTmpRawData array
-   double dIon=0,
-          dIntensity=0;
-
-   // set dIntensityCutoff based on either minimum intensity or % of base peak
-   double dIntensityCutoff = g_staticParams.options.dMinIntensity;
-
-   if (g_staticParams.options.dMinPercentageIntensity > 0.0 && g_staticParams.options.dMinPercentageIntensity <= 1.0)
-   {
-      double dBasePeakIntensity = 0.0;
-
-      for (i = 0; i < iNumPeaks; ++i)
-      {
-         if (pdInten[i] > dBasePeakIntensity)
-            dBasePeakIntensity = pdInten[i];
-      }
-
-      dIntensityCutoff = g_staticParams.options.dMinPercentageIntensity * dBasePeakIntensity;
-
-      if (dIntensityCutoff < g_staticParams.options.dMinIntensity)
-         dIntensityCutoff = g_staticParams.options.dMinIntensity;
-   }
-
-   for (i = 0; i < iNumPeaks; ++i)
-   {
-      dIon = pdMass[i];
-      dIntensity = pdInten[i];
-
-      bool bPass = false;
-      if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
-         bPass = true;
-
-      if (bPass)
-      {
-         if (g_staticParams.options.iPrintAScoreProScore)
-         {
-            // Store list of fragment masses and intensities for AScore and ProScore
-            pScoring->vRawFragmentPeakMassIntensity.emplace_back(dIon, dIntensity);
-         }
-
-         if (g_staticParams.iIndexDb)
-            pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
-
-         if (dIon < (pScoring->_pepMassInfo.dExpPepMass + 50.0))
-         {
-            int iBinIon = BIN(dIon);
-
-            dIntensity = sqrt(dIntensity);
-
-            if (iBinIon < g_staticParams.iArraySizeGlobal && pdTmpSpectrum[iBinIon] < dIntensity)  // used in DoSingleSpectrumSearchMultiResults to return matched ions
-                pdTmpSpectrum[iBinIon] = dIntensity;
-
-            if (iBinIon > pPre.iHighestIon)
-               pPre.iHighestIon = iBinIon;
-
-            if ((iBinIon < pScoring->_spectrumInfoInternal.iArraySize)
-                  && (dIntensity > pdTmpRawData[iBinIon]))
-            {
-               if (dIntensity > pdTmpRawData[iBinIon])
-                  pdTmpRawData[iBinIon] = dIntensity;
-
-               if (pdTmpRawData[iBinIon] > pPre.dHighestIntensity)
-                  pPre.dHighestIntensity = pdTmpRawData[iBinIon];
-            }
-         }
-      }
-   }
-
-   pfFastXcorrData = new float[pScoring->_spectrumInfoInternal.iArraySize]();
-
-   if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
-         && (g_staticParams.ionInformation.iIonVal[ION_SERIES_A]
-            || g_staticParams.ionInformation.iIonVal[ION_SERIES_B]
-            || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
-   {
-      try
-      {
-         pfFastXcorrDataNL = new float[pScoring->_spectrumInfoInternal.iArraySize]();
-      }
-      catch (std::bad_alloc& ba)
-      {
-         string strErrorMsg = " Error - new(pfFastXcorrDataNL["
-            + std::to_string(pScoring->_spectrumInfoInternal.iArraySize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-            + "parameters to address mitigate memory use.\n";
-         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-         logerr(strErrorMsg);
-         return false;
-      }
-   }
-
-   // Create data for correlation analysis.
-   // pdTmpRawData intensities are normalized to 100; pdTmpCorrelationData is windowed
-   MakeCorrData(pdTmpRawData, pdTmpCorrelationData, pPre.iHighestIon, pPre.dHighestIntensity);
-
-   // Make fast xcorr spectrum.
-   double dSum = 0.0;
-   int iTmpRange = 2 * g_staticParams.iXcorrProcessingOffset + 1;
-   double dTmp = 1.0 / (iTmpRange - 1.0);
-   double dMinXcorrInten = 0.0;
-
-   dSum = 0.0;
-   for (i = 0; i < g_staticParams.iXcorrProcessingOffset; ++i)
-      dSum += pdTmpCorrelationData[i];
-   for (i = g_staticParams.iXcorrProcessingOffset; i < pScoring->_spectrumInfoInternal.iArraySize + g_staticParams.iXcorrProcessingOffset; ++i)
-   {
-      if (dMinXcorrInten < pdTmpCorrelationData[i])
-         dMinXcorrInten = pdTmpCorrelationData[i];
-
-      if (i < pScoring->_spectrumInfoInternal.iArraySize)
-         dSum += pdTmpCorrelationData[i];
-      if (i >= iTmpRange)
-         dSum -= pdTmpCorrelationData[i - iTmpRange];
-      pdTmpFastXcorrData[i - g_staticParams.iXcorrProcessingOffset] = (dSum - pdTmpCorrelationData[i - g_staticParams.iXcorrProcessingOffset]) * dTmp;
-   }
-
-   pScoring->iMinXcorrHisto = (int)(dMinXcorrInten * 10.0 * 0.005 + 0.5);
-
-   pfFastXcorrData[0] = 0.0;
-   for (i=1; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
-   {
-      double dTmp = pdTmpCorrelationData[i] - pdTmpFastXcorrData[i];
-
-      pfFastXcorrData[i] = (float)dTmp;
-
-      // Add flanking peaks if used
-      if (g_staticParams.ionInformation.iTheoreticalFragmentIons == 0)
-      {
-         int iTmp;
-
-         iTmp = i-1;
-         pfFastXcorrData[i] += (float) ((pdTmpCorrelationData[iTmp] - pdTmpFastXcorrData[iTmp])*0.5);
-
-         iTmp = i+1;
-         if (iTmp < pScoring->_spectrumInfoInternal.iArraySize)
-            pfFastXcorrData[i] += (float) ((pdTmpCorrelationData[iTmp] - pdTmpFastXcorrData[iTmp])*0.5);
-      }
-
-      // If A, B or Y ions and their neutral loss selected, roll in -17/-18 contributions to pfFastXcorrDataNL
-      if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
-            && (g_staticParams.ionInformation.iIonVal[ION_SERIES_A]
-               || g_staticParams.ionInformation.iIonVal[ION_SERIES_B]
-               || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
-      {
-         int iTmp;
-
-         pfFastXcorrDataNL[i] = pfFastXcorrData[i];
-
-         iTmp = i-g_staticParams.precalcMasses.iMinus17;
-         if (iTmp>= 0)
-         {
-            pfFastXcorrDataNL[i] += (float)((pdTmpCorrelationData[iTmp] - pdTmpFastXcorrData[iTmp]) * 0.2);
-         }
-
-         iTmp = i-g_staticParams.precalcMasses.iMinus18;
-         if (iTmp>= 0)
-         {
-            pfFastXcorrDataNL[i] += (float)((pdTmpCorrelationData[iTmp] - pdTmpFastXcorrData[iTmp]) * 0.2);
-         }
-      }
-   }
-
-   pScoring->iFastXcorrDataSize = pScoring->_spectrumInfoInternal.iArraySize/SPARSE_MATRIX_SIZE+1;
-
-   // Using sparse matrix which means we free pScoring->pfFastXcorrData, ->pfFastXcorrDataNL here
-   // If A, B or Y ions and their neutral loss selected, roll in -17/-18 contributions to pfFastXcorrDataNL.
-   if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
-         && (g_staticParams.ionInformation.iIonVal[ION_SERIES_A]
-            || g_staticParams.ionInformation.iIonVal[ION_SERIES_B]
-            || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
-   {
-      try
-      {
-         pScoring->ppfSparseFastXcorrDataNL = new float*[pScoring->iFastXcorrDataSize]();
-      }
-      catch (std::bad_alloc& ba)
-      {
-         string strErrorMsg = " Error - new(pScoring->ppfSparseFastXcorrDataNL["
-            + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-            + "parameters to address mitigate memory use.\n";
-         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-         logerr(strErrorMsg);
-         return false;
-      }
-
-      for (i=1; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
-      {
-         if (pfFastXcorrDataNL[i]>FLOAT_ZERO || pfFastXcorrDataNL[i]<-FLOAT_ZERO)
-         {
-            x=i/SPARSE_MATRIX_SIZE;
-            if (pScoring->ppfSparseFastXcorrDataNL[x]==NULL)
-            {
-               try
-               {
-                  pScoring->ppfSparseFastXcorrDataNL[x] = new float[SPARSE_MATRIX_SIZE]();
-               }
-               catch (std::bad_alloc& ba)
-               {
-                  string strErrorMsg = " Error - new(pScoring->ppfSparseFastXcorrDataNL["
-                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-                     + "parameters to address mitigate memory use.\n";
-                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-                  logerr(strErrorMsg);
-                  return false;
-               }
-               for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
-                  pScoring->ppfSparseFastXcorrDataNL[x][y]=0;
-            }
-            y=i-(x*SPARSE_MATRIX_SIZE);
-            pScoring->ppfSparseFastXcorrDataNL[x][y] = pfFastXcorrDataNL[i];
-         }
-      }
-
-      delete[] pfFastXcorrDataNL;
-      pfFastXcorrDataNL = NULL;
-   }
-
-   //MH: Fill sparse matrix
-   pScoring->ppfSparseFastXcorrData = new float*[pScoring->iFastXcorrDataSize]();
-
-   for (i=1; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
-   {
-      if (pfFastXcorrData[i]>FLOAT_ZERO || pfFastXcorrData[i]<-FLOAT_ZERO)
-      {
-         x=i/SPARSE_MATRIX_SIZE;
-         if (pScoring->ppfSparseFastXcorrData[x]==NULL)
-         {
-            pScoring->ppfSparseFastXcorrData[x] = new float[SPARSE_MATRIX_SIZE]();
-
-            for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
-               pScoring->ppfSparseFastXcorrData[x][y]=0;
-         }
-         y=i-(x*SPARSE_MATRIX_SIZE);
-         pScoring->ppfSparseFastXcorrData[x][y] = pfFastXcorrData[i];
-      }
-   }
-
-   delete[] pfFastXcorrData;
-   pfFastXcorrData = NULL;
-
-   // Create data for sp scoring which is just the binned peaks normalized to max inten 100
-   pfSpScoreData = new float[pScoring->_spectrumInfoInternal.iArraySize]();
-   memset(pfSpScoreData, 0, sizeof(float) * pScoring->_spectrumInfoInternal.iArraySize);
-
-   for (i = 0; i < pScoring->_spectrumInfoInternal.iArraySize; ++i)
-   {
-      pfSpScoreData[i] = (float)(100.0 * pdTmpRawData[i] / pPre.dHighestIntensity);
-   }
-
-   // MH: Fill sparse matrix for SpScore
-   pScoring->iSpScoreData = pScoring->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE + 1;
-
-   pScoring->ppfSparseSpScoreData = new float*[pScoring->iSpScoreData]();
-
-   for (i=0; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
-   {
-      if (pfSpScoreData[i] > FLOAT_ZERO)
-      {
-         x=i/SPARSE_MATRIX_SIZE;
-         if (pScoring->ppfSparseSpScoreData[x]==NULL)
-         {
-            pScoring->ppfSparseSpScoreData[x] = new float[SPARSE_MATRIX_SIZE]();
-            memset(pScoring->ppfSparseSpScoreData[x], 0, sizeof(float) * SPARSE_MATRIX_SIZE);
-         }
-         y=i-(x*SPARSE_MATRIX_SIZE);
-         pScoring->ppfSparseSpScoreData[x][y] = pfSpScoreData[i];
-      }
-   }
-
-   delete[] pfSpScoreData;
-   pfSpScoreData = NULL;
-
-   g_pvQuery.push_back(pScoring);
-
-   return true;
 }
 
 
@@ -2441,4 +2560,78 @@ bool CometPreprocess::PreprocessMS1SingleSpectrum(double* pdMass,
    g_pvQueryMS1.push_back(pScoringMS1);
 
    return true;
+}
+
+
+// Thread-local version of PreprocessMS1SingleSpectrum.
+// Returns a heap-allocated QueryMS1* with pfFastXcorrData filled as a unit vector.
+// Caller owns the returned object and must free pfFastXcorrData and delete pQueryMS1.
+// Does NOT touch g_pvQueryMS1 or any other global mutable state.
+QueryMS1* CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(double* pdMass,
+                                                                  double* pdInten,
+                                                                  int iNumPeaks)
+{
+   // Match the original PreprocessMS1SingleSpectrum: use the largest mass
+   // actually present in the spectrum (capped at dMS1MaxMass) to size the array,
+   // exactly as PreprocessThreadProcMS1 does for library entries.
+   double dLargestMass = pdMass[iNumPeaks - 1];  // expect pdMass array in ascending order
+   if (dLargestMass > g_staticParams.options.dMS1MaxMass)
+      dLargestMass = g_staticParams.options.dMS1MaxMass;
+   int iArraySizeMS1 = BINPREC(dLargestMass) + 1;
+
+   QueryMS1* pQueryMS1 = new QueryMS1();
+   pQueryMS1->iArraySizeMS1 = iArraySizeMS1;
+
+   try
+   {
+      pQueryMS1->pfFastXcorrData = new float[iArraySizeMS1]();
+   }
+   catch (std::bad_alloc&)
+   {
+      delete pQueryMS1;
+      return nullptr;
+   }
+
+   // Bin peaks into the array using sqrt(intensity), matching library preprocessing
+   for (int i = 0; i < iNumPeaks; ++i)
+   {
+      double dMass = pdMass[i];
+
+      if (dMass < g_staticParams.options.dMS1MinMass || dMass > g_staticParams.options.dMS1MaxMass)
+         continue;
+
+      int iBin = BINPREC(dMass);
+      if (iBin >= 0 && iBin < iArraySizeMS1)
+      {
+         float fInten = (float)sqrt(pdInten[i]);
+         if (fInten > pQueryMS1->pfFastXcorrData[iBin])
+            pQueryMS1->pfFastXcorrData[iBin] = fInten;  // keep max intensity per bin
+      }
+   }
+
+   // Normalize to unit vector — must match library normalization
+   double dSumSquares = 0.0;
+   for (int i = 0; i < iArraySizeMS1; ++i)
+   {
+      dSumSquares += (double)pQueryMS1->pfFastXcorrData[i] * (double)pQueryMS1->pfFastXcorrData[i];
+   }
+
+   if (dSumSquares > 0.0)
+   {
+      float fNorm = (float)sqrt(dSumSquares);
+      for (int i = 0; i < iArraySizeMS1; ++i)
+      {
+         pQueryMS1->pfFastXcorrData[i] /= fNorm;
+      }
+   }
+   else
+   {
+      // Empty spectrum after filtering — return null
+      delete[] pQueryMS1->pfFastXcorrData;
+      pQueryMS1->pfFastXcorrData = nullptr;
+      delete pQueryMS1;
+      return nullptr;
+   }
+
+   return pQueryMS1;
 }

--- a/CometSearch/CometPreprocess.h
+++ b/CometSearch/CometPreprocess.h
@@ -85,10 +85,27 @@ public:
                                         double *pdInten,
                                         int iNumPeaks,
                                         double *pdTmpSpectrum);
+
+   // Thread-local version: returns Query* without touching g_pvQuery.
+   // Caller owns the returned Query* and must delete it when done.
+   static Query* PreprocessSingleSpectrumThreadLocal(int iPrecursorCharge,
+                                                     double dMZ,
+                                                     double *pdMass,
+                                                     double *pdInten,
+                                                     int iNumPeaks,
+                                                     double *pdTmpSpectrum);
+
    static bool PreprocessMS1SingleSpectrum(double* pdMass,
                                            double* pdInten,
                                            int iNumPeaks);
+   // Thread-local version: returns QueryMS1* without touching g_pvQueryMS1.
+   // Caller owns the returned QueryMS1* and must delete it when done.
+   static QueryMS1* PreprocessMS1SingleSpectrumThreadLocal(double* pdMass,
+                                                           double* pdInten,
+                                                           int iNumPeaks);
+
    static double GetMassCushion(double dMass);
+
    static void PreloadIons(MSReader& mstReader,
                            Spectrum& spec,
                            bool bNext = false,
@@ -130,6 +147,16 @@ private:
                             double* pdTmpCorrelationData,
                             int iHighestIon,
                             double dHighestIntensity);
+
+   // Shared core of PreprocessSingleSpectrum and PreprocessSingleSpectrumThreadLocal.
+   // Builds a fully preprocessed Query* from the input spectrum data.
+   // Does NOT push the Query* into g_pvQuery.
+   static Query* PreprocessSingleSpectrumCore(int iPrecursorCharge,
+                                              double dMZ,
+                                              double *pdMass,
+                                              double *pdInten,
+                                              int iNumPeaks,
+                                              double *pdTmpSpectrum);
 
    // Private member variables
    static Mutex _maxChargeMutex;

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -94,7 +94,7 @@ bool CometSearch::DeallocateMemory(int maxNumThreads)
 // Task 1.3: Thread-local overload.
 bool CometSearch::RunSearch(Query* pQuery)
 {
-   if (g_staticParams.iIndexDb == 1)  // fragment ion index
+   if (g_staticParams.iDbType == DbType::FI_DB)  // fragment ion index
    {
       if (!g_bPlainPeptideIndexRead)
       {
@@ -108,16 +108,46 @@ bool CometSearch::RunSearch(Query* pQuery)
       SearchFragmentIndex(pQuery, pbDuplFragment);
       delete[] pbDuplFragment;
    }
-   else if (g_staticParams.iIndexDb == 2)  // peptide index
+   else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
-      string strErrorMsg = " Error - peptide index search not supported for thread-local RunSearch(Query*)\n";
-      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-      logerr(strErrorMsg);
-      return false;
+      // Guard: ensure the peptide index has been loaded before searching.
+      // InitializeSingleSpectrumSearch() should have called ReadPeptideIndex(),
+      // but if it didn't (or this is called before init), load it now.
+      if (!g_bPeptideIndexRead)
+      {
+         Threading::LockMutex(g_pvDBIndexMutex);
+         if (!g_bPeptideIndexRead)  // re-check under lock
+         {
+            if (!CometPeptideIndex::ReadPeptideIndex())
+            {
+               Threading::UnlockMutex(g_pvDBIndexMutex);
+               string strErrorMsg = " Error - peptide index could not be read for thread-local RunSearch(Query*)\n";
+               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+               logerr(strErrorMsg);
+               return false;
+            }
+
+            // Also initialize masses from the .idx header so fragment masses
+            // match the static/variable mods used when building the index.
+            if (!InitializeMassesFromPeptideIndex())
+            {
+               Threading::UnlockMutex(g_pvDBIndexMutex);
+               string strErrorMsg = " Error - failed to parse .idx header for mass initialization.\n";
+               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+               logerr(strErrorMsg);
+               return false;
+            }
+         }
+         Threading::UnlockMutex(g_pvDBIndexMutex);
+      }
+
+      bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal]();
+      SearchPeptideIndex(pQuery, pbDuplFragment);
+      delete[] pbDuplFragment;
    }
    else
    {
-      string strErrorMsg = " Error - index search but iIndexDb = " + std::to_string(g_staticParams.iIndexDb) + "\n";
+      string strErrorMsg = " Error - index search but iDbType = " + std::to_string(static_cast<int>(g_staticParams.iDbType)) + "\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
       logerr(strErrorMsg);
       return false;
@@ -133,7 +163,7 @@ bool CometSearch::RunSearch(ThreadPool *tp)
    CometSearch sqSearch;
    size_t iWhichQuery = 0;
 
-   if (g_staticParams.iIndexDb == 1)       // fragment ion index
+   if (g_staticParams.iDbType == DbType::FI_DB)       // fragment ion index
    {
       if (!g_bPlainPeptideIndexRead)
       {
@@ -144,13 +174,13 @@ bool CometSearch::RunSearch(ThreadPool *tp)
 
       sqSearch.SearchFragmentIndex(iWhichQuery, tp);
    }
-   else if (g_staticParams.iIndexDb == 2)  // peptide index
+   else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
       sqSearch.SearchPeptideIndex(tp);
    }
    else
    {
-      string strErrorMsg = " Error - index search but iIndexDb = " + std::to_string(g_staticParams.iIndexDb) + "\n";
+      string strErrorMsg = " Error - index search but iDbType = " + std::to_string(static_cast<int>(g_staticParams.iDbType)) + "\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
       logerr(strErrorMsg);
       return false;
@@ -166,7 +196,7 @@ bool CometSearch::RunSearch(int iPercentStart,
 {
    bool bSucceeded = true;
 
-   if (g_staticParams.iIndexDb == 1)
+   if (g_staticParams.iDbType == DbType::FI_DB)
    {
       CometFragmentIndex sqFI;
       CometSearch sqSearch;
@@ -201,7 +231,7 @@ bool CometSearch::RunSearch(int iPercentStart,
 
       return bSucceeded;
    }
-   else if (g_staticParams.iIndexDb == 2)
+   else if (g_staticParams.iDbType == DbType::PI_DB)
    {
       CometSearch sqSearch;
       sqSearch.SearchPeptideIndex(tp);
@@ -1124,7 +1154,9 @@ void CometSearch::ReadOBO(char *szOBO,
 }
 
 
-bool CometSearch::MapOBO(string strMod, vector<OBOStruct> *vectorPeffOBO, struct PeffModStruct *pData)
+bool CometSearch::MapOBO(string strMod,
+                         vector<OBOStruct> *vectorPeffOBO,
+                         struct PeffModStruct *pData)
 {
    int iPos;
 
@@ -1163,7 +1195,8 @@ bool CometSearch::MapOBO(string strMod, vector<OBOStruct> *vectorPeffOBO, struct
 }
 
 
-void CometSearch::SearchThreadProc(SearchThreadData *pSearchThreadData, ThreadPool* tp)
+void CometSearch::SearchThreadProc(SearchThreadData *pSearchThreadData,
+                                   ThreadPool* tp)
 {
    int i;
 
@@ -1221,7 +1254,8 @@ void CometSearch::SearchThreadProc(SearchThreadData *pSearchThreadData, ThreadPo
 }
 
 
-bool CometSearch::DoSearch(sDBEntry dbe, bool *pbDuplFragment)
+bool CometSearch::DoSearch(sDBEntry dbe,
+                           bool *pbDuplFragment)
 {
    // Standard protein database search.
    if (g_staticParams.options.iWhichReadingFrame == 0)
@@ -1390,7 +1424,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
    size_t lNumPeps = 0;
    unsigned int uiFragmentMass;
 
-   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2];
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
    unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
 
    bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal];
@@ -1744,6 +1778,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
          char cPrevAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cPrevAA;
          char cNextAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cNextAA;
          char szProtein[MAX_PEPTIDE_LEN_P2];
+
          if (cPrevAA == '-')
          {
             iStartPos = 0;
@@ -1752,15 +1787,21 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
          else
          {
             iStartPos = 1;
-            sprintf(szProtein, "%c%s", cPrevAA, szPeptide);
+            snprintf(szProtein, sizeof(szProtein), "%c%s", cPrevAA, szPeptide);
          }
+
          if (cNextAA == '-')
          {
             iEndPos = strlen(szProtein) - 1;
          }
          else
          {
-            sprintf(szProtein, "%s%c", szProtein, cNextAA);
+            size_t iCurLen = strlen(szProtein);
+            if (iCurLen + 1 < sizeof(szProtein))
+            {
+               szProtein[iCurLen] = cNextAA;
+               szProtein[iCurLen + 1] = '\0';
+            }
             iEndPos = strlen(szProtein) - 2;
          }
 
@@ -1793,7 +1834,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
    size_t lNumPeps = 0;
    unsigned int uiFragmentMass;
 
-   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2];
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
    unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
 
    mPeptides.clear();
@@ -2113,7 +2154,12 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          }
          else
          {
-            sprintf(szProtein, "%s%c", szProtein, cNextAA);
+            size_t iCurLen = strlen(szProtein);
+            if (iCurLen + 1 < sizeof(szProtein))
+            {
+               szProtein[iCurLen] = cNextAA;
+               szProtein[iCurLen + 1] = '\0';
+            }
             iEndPos = strlen(szProtein) - 2;
          }
 
@@ -2127,6 +2173,14 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          uiNumScored++;
          if (uiNumScored >= FRAGINDEX_MAX_NUMSCORED)
             break;
+
+         if (g_staticParams.options.iMaxIndexRunTime > 0)
+         {
+            auto tNow = std::chrono::high_resolution_clock::now();
+            auto tElapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(tNow - pQuery->tSearchStart).count();
+            if (tElapsedTime >= g_staticParams.options.iMaxIndexRunTime)
+               break;
+         }
       }
    }
 }
@@ -2152,135 +2206,15 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
 
    if (!g_bPeptideIndexRead)  // save some repeated parsing when being called from DLL
    {
-      // ignore any static masses in params file; only valid ones
-      // are those in database index
-      memset(g_staticParams.staticModifications.pdStaticMods, 0, sizeof(g_staticParams.staticModifications.pdStaticMods));
-
-      bool bFoundStatic = false;
-      bool bFoundVariable = false;
-
-      // read in static and variable mods
-      while (fgets(szBuf, SIZE_BUF, fp))
+      // Parse mass types, static/variable mods, enzyme info from the .idx
+      // header.  ParsePeptideIndexHeader() resets both mass arrays via
+      // AssignMass() before applying static mods, so it is safe to call
+      // regardless of whether InitializeStaticParams() has already run.
+      if (!CometPeptideIndex::ParsePeptideIndexHeader(fp))
       {
-         if (!strncmp(szBuf, "MassType:", 9))
-         {
-            sscanf(szBuf + 10, "%d %d", &g_staticParams.massUtility.bMonoMassesParent, &g_staticParams.massUtility.bMonoMassesFragment);
-         }
-         else if (!strncmp(szBuf, "StaticMod:", 10))
-         {
-            char* tok;
-            char delims[] = " ";
-            int x = 65;
-
-            // FIX:  hack here for setting static mods; need to reset masses ... fix later
-            CometMassSpecUtils::AssignMass(g_staticParams.massUtility.pdAAMassFragment,
-               g_staticParams.massUtility.bMonoMassesFragment,
-               &g_staticParams.massUtility.dOH2fragment);
-
-            bFoundStatic = true;
-            tok = strtok(szBuf + 11, delims);
-            while (tok != NULL)
-            {
-               sscanf(tok, "%lf", &(g_staticParams.staticModifications.pdStaticMods[x]));
-               g_staticParams.massUtility.pdAAMassFragment[x] += g_staticParams.staticModifications.pdStaticMods[x];
-               g_staticParams.massUtility.pdAAMassParent[x] += g_staticParams.staticModifications.pdStaticMods[x];
-               tok = strtok(NULL, delims);
-               x++;
-               if (x == 95)  // 65-90 stores A-Z then next 4 (ascii 91-94) are n/c term peptide, n/c term protein
-                  break;
-            }
-
-            g_staticParams.staticModifications.dAddNterminusPeptide = g_staticParams.staticModifications.pdStaticMods[91];
-            g_staticParams.staticModifications.dAddCterminusPeptide = g_staticParams.staticModifications.pdStaticMods[92];
-            g_staticParams.staticModifications.dAddNterminusProtein = g_staticParams.staticModifications.pdStaticMods[93];
-            g_staticParams.staticModifications.dAddCterminusProtein = g_staticParams.staticModifications.pdStaticMods[94];
-
-            // have to set these here again once static mods are read
-            g_staticParams.precalcMasses.dNtermProton = g_staticParams.staticModifications.dAddNterminusPeptide
-               + PROTON_MASS;
-
-            g_staticParams.precalcMasses.dCtermOH2Proton = g_staticParams.staticModifications.dAddCterminusPeptide
-               + g_staticParams.massUtility.dOH2fragment
-               + PROTON_MASS;
-
-            g_staticParams.precalcMasses.dOH2ProtonCtermNterm = g_staticParams.massUtility.dOH2parent
-               + PROTON_MASS
-               + g_staticParams.staticModifications.dAddCterminusPeptide
-               + g_staticParams.staticModifications.dAddNterminusPeptide;
-         }
-         else if (!strncmp(szBuf, "DecoySearch:", 12))
-         {
-            sscanf(szBuf, "DecoySearch: %d", &(g_staticParams.options.iDecoySearch));
-         }
-         else if (!strncmp(szBuf, "Enzyme:", 7))
-         {
-            sscanf(szBuf, "Enzyme: %s [%d %s %s]", g_staticParams.enzymeInformation.szSearchEnzymeName,
-               &(g_staticParams.enzymeInformation.iSearchEnzymeOffSet),
-               g_staticParams.enzymeInformation.szSearchEnzymeBreakAA,
-               g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA);
-         }
-         else if (!strncmp(szBuf, "Enzyme2:", 8))
-         {
-            sscanf(szBuf, "Enzyme2: %s [%d %s %s]", g_staticParams.enzymeInformation.szSearchEnzyme2Name,
-               &(g_staticParams.enzymeInformation.iSearchEnzyme2OffSet),
-               g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA,
-               g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA);
-         }
-         else if (!strncmp(szBuf, "VariableMod:", 12))
-         {
-            string strMods = szBuf + 13;
-
-            istringstream iss(strMods);
-
-            int iNumMods = 0;
-
-            bFoundVariable = true;
-
-            do
-            {
-               string subStr;
-
-               iss >> subStr;  // parse each word which is a colon delimited triplet pair for modmass:neutralloss:modchars
-               std::replace(subStr.begin(), subStr.end(), ':', ' ');
-               int iRet = sscanf(subStr.c_str(), "%s %lf %lf %lf",
-                  g_staticParams.variableModParameters.varModList[iNumMods].szVarModChar,
-                  &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
-                  &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss),
-                  &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss2));
-
-               if (iRet != 4)
-               {
-                  string strErrorMsg = " Error parsing mod entry: " + subStr + ".\n";
-                  logerr(strErrorMsg);
-                  std::fclose(fp);
-                  return false;
-               }
-
-               if (g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss != 0.0)
-                  g_staticParams.variableModParameters.bUseFragmentNeutralLoss = true;
-
-               iNumMods++;
-
-               if (iNumMods == VMODS)
-                  break;
-
-            } while (iss);
-
-            break;
-         }
-      }
-
-      if (!(bFoundStatic && bFoundVariable))
-      {
-         string strErrorMsg = " Error with index database format. Mods not parsed ("
-            + std::to_string(bFoundStatic) + " " + std::to_string(bFoundVariable) + ".\n";
-         logerr(strErrorMsg);
          std::fclose(fp);
          return false;
       }
-
-      // peptide index searches will always set this to true
-      g_staticParams.variableModParameters.bVarModSearch = true;
 
       if (g_staticParams.options.iPrintAScoreProScore)
       {
@@ -2411,19 +2345,19 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
 
    while ((int)(sDBI.dPepMass * 10) <= iEnd10)
    {
-      /*
-            printf("OK index pep ");
-            for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
-            {
-               printf("%c", sDBI.szPeptide[x]);
-               if (sDBI.pcVarModSites[x] != 0)
-                  printf("[%0.3f]", g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[x]-1].dVarModMass);
-            }
-            printf(", mass %f, ", sDBI.dPepMass); fflush(stdout);
-            for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
-               printf("%d", sDBI.pcVarModSites[x]);
-            printf(", prot %ld\n", sDBI.lIndexProteinFilePosition);
-      */
+/*
+      printf("OK index pep ");
+      for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
+      {
+         printf("%c", sDBI.szPeptide[x]);
+         if (sDBI.pcVarModSites[x] != 0)
+            printf("[%0.3f]", g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[x]-1].dVarModMass);
+      }
+      printf(", mass %f, ", sDBI.dPepMass); fflush(stdout);
+      for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
+         printf("%d", sDBI.pcVarModSites[x]);
+      printf(", prot %ld\n", sDBI.lIndexProteinFilePosition);
+*/
 
       if (sDBI.dPepMass > g_massRange.dMaxMass)
          break;
@@ -2457,29 +2391,620 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
       }
    }
 
-   /*
-      for (vector<Query*>::iterator it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
-      {
-         int iNumMatchedPeptides = (*it)->iMatchPeptideCount;
-         if (iNumMatchedPeptides > g_staticParams.options.iNumStored)
-            iNumMatchedPeptides = g_staticParams.options.iNumStored;
+/*
+   for (vector<Query*>::iterator it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
+   {
+      int iNumMatchedPeptides = (*it)->iMatchPeptideCount;
+      if (iNumMatchedPeptides > g_staticParams.options.iNumStored)
+         iNumMatchedPeptides = g_staticParams.options.iNumStored;
 
-         for (int x = 0; x < iNumMatchedPeptides; x++)
-         {
-            printf("OK %d scan %d, pep %s, xcorr %f, mass %f, matchcount %d, prot %s\n", x,
-               (*it)->_spectrumInfoInternal.iScanNumber,
-               (*it)->_pResults[x].szPeptide,
-               (*it)->_pResults[x].fXcorr,
-               (*it)->_pResults[x].dPepMass,
-               (*it)->iMatchPeptideCount,
-               (*it)->_pResults[x].strSingleSearchProtein.c_str()); fflush(stdout);
-         }
+      for (int x = 0; x < iNumMatchedPeptides; x++)
+      {
+         printf("OK %d scan %d, pep %s, xcorr %f, mass %f, matchcount %d\n", x,
+            (*it)->_spectrumInfoInternal.iScanNumber,
+            (*it)->_pResults[x].szPeptide,
+            (*it)->_pResults[x].fXcorr,
+            (*it)->_pResults[x].dPepMass,
+            (*it)->iMatchPeptideCount; fflush(stdout);
       }
-   */
+   }
+*/
 
    delete[] lReadIndex;
    std::fclose(fp);
    return true;
+}
+
+
+// Thread-local overload: searches a caller-owned Query* against the
+// read-only g_pvDBIndex.  Does not access g_pvQuery.
+// pbDuplFragment is a thread-local scratch buffer of size g_staticParams.iArraySizeGlobal.
+void CometSearch::SearchPeptideIndex(Query* pQuery,
+                                     bool* pbDuplFragment)
+{
+   if (!g_bPeptideIndexRead || g_pvDBIndex.empty())
+      return;
+
+   double dMassTolLow = pQuery->_pepMassInfo.dPeptideMassToleranceMinus;
+   double dMassTolHigh = pQuery->_pepMassInfo.dPeptideMassTolerancePlus;
+
+   // Binary search: find first entry with dPepMass >= dMassTolLow
+   size_t iStart = 0;
+   size_t iEnd = g_pvDBIndex.size();
+
+   while (iStart < iEnd)
+   {
+      size_t iMid = iStart + (iEnd - iStart) / 2;
+      if (g_pvDBIndex[iMid].dPepMass < dMassTolLow)
+         iStart = iMid + 1;
+      else
+         iEnd = iMid;
+   }
+
+   struct sDBEntry dbe;
+
+   // Iterate through candidates within mass tolerance
+   for (size_t i = iStart; i < g_pvDBIndex.size(); ++i)
+   {
+      if (g_pvDBIndex[i].dPepMass > dMassTolHigh)
+         break;
+
+      // Verify mass match (handles isotope offsets)
+      if (!CheckMassMatch(pQuery, g_pvDBIndex[i].dPepMass))
+         continue;
+
+      dbe.lProteinFilePosition = g_pvDBIndex[i].lIndexProteinFilePosition;
+      AnalyzePeptideIndex(pQuery, g_pvDBIndex[i], pbDuplFragment, &dbe);
+   }
+}
+
+
+// Thread-local overload of AnalyzePeptideIndex: scores a single peptide index
+// entry against a caller-owned Query*. Does not access g_pvQuery.
+void CometSearch::AnalyzePeptideIndex(Query* pQuery,
+                                      DBIndex sDBI,
+                                      bool* pbDuplFragment,
+                                      struct sDBEntry* dbe)
+{
+   int iLenPeptide = (int)strlen(sDBI.szPeptide);
+   int iLenMinus1 = iLenPeptide - 1;
+   int iStartPos;
+   int iEndPos;
+
+   int piVarModSites[MAX_PEPTIDE_LEN_P2];
+   int iFoundVariableMod = 0;
+
+   double pdAAforward[MAX_PEPTIDE_LEN];
+   double pdAAreverse[MAX_PEPTIDE_LEN];
+
+   // Use VMODS+2 for 4th dimension to match batch path
+   // Peptide index will apply up to VMODS, fragment ion index goes to FRAGINDEXVMODS
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
+   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
+
+   char szProtein[MAX_PEPTIDE_LEN_P2];
+
+   // Convert pcVarModSites (char) -> piVarModSites (int) element-by-element
+   memset(piVarModSites, 0, sizeof(int) * MAX_PEPTIDE_LEN_P2);
+   for (int i = 0; i < iLenPeptide + 2; ++i)
+   {
+      piVarModSites[i] = (int)sDBI.pcVarModSites[i];
+      if (piVarModSites[i] != 0)
+         iFoundVariableMod = 1;
+   }
+
+   double dBion = g_staticParams.precalcMasses.dNtermProton;
+   double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
+
+   // n-term variable mod
+   if (piVarModSites[iLenPeptide] > 0)
+      dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iLenPeptide] - 1].dVarModMass;
+
+   // c-term variable mod
+   if (piVarModSites[iLenPeptide + 1] > 0)
+      dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iLenPeptide + 1] - 1].dVarModMass;
+
+   // Build protein context string with flanking AAs
+   int iPos = 0;
+   if (sDBI.cPrevAA != '-')
+   {
+      szProtein[0] = sDBI.cPrevAA;
+      iPos = 1;
+   }
+   iStartPos = iPos;
+
+   memcpy(szProtein + iPos, sDBI.szPeptide, iLenPeptide);
+   iPos += iLenPeptide;
+   iEndPos = iPos - 1;
+
+   if (sDBI.cNextAA != '-')
+   {
+      szProtein[iPos] = sDBI.cNextAA;
+      iPos++;
+   }
+   szProtein[iPos] = '\0';
+
+   if (g_staticParams.iDbType == DbType::PI_DB)
+   {
+      // Protein n-term / c-term static mod adjustments
+      if (sDBI.cPrevAA == '-')
+         dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+      if (sDBI.cNextAA == '-')
+         dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+   }
+
+   dbe->strSeq = szProtein;
+
+   // Determine if this peptide is a decoy based on its protein name.
+   // In the .idx file, decoy peptides are stored with their protein names
+   // prefixed by g_staticParams.szDecoyPrefix.
+   bool bDecoyPep = false;
+   if (g_staticParams.options.iDecoySearch)
+   {
+      comet_fileoffset_t lProtIdx = sDBI.lIndexProteinFilePosition;
+      if (lProtIdx >= 0 && lProtIdx < (comet_fileoffset_t)g_pvProteinsList.size()
+         && !g_pvProteinsList[lProtIdx].empty())
+      {
+         // Check the first protein in the list for the decoy prefix
+         comet_fileoffset_t lProtFilePos = g_pvProteinsList[lProtIdx][0];
+         auto it = g_pvProteinNames.find(lProtFilePos);
+         if (it != g_pvProteinNames.end())
+         {
+            if (strncmp(it->second.szProt, g_staticParams.szDecoyPrefix, strlen(g_staticParams.szDecoyPrefix)) == 0)
+               bDecoyPep = true;
+         }
+      }
+   }
+
+   // Track fragment neutral loss positions (matches batch path)
+   int iPositionNLB[VMODS];
+   int iPositionNLY[VMODS];
+
+   if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+   {
+      for (int i = 0; i < VMODS; ++i)
+      {
+         iPositionNLB[i] = 999;
+         iPositionNLY[i] = -1;
+      }
+
+      for (int i = 0; i < iLenMinus1; ++i)
+      {
+         if (sDBI.pcVarModSites[i] > 0)
+         {
+            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            {
+               iPositionNLB[sDBI.pcVarModSites[i] - 1] = i;
+               break;
+            }
+         }
+      }
+
+      for (int i = iLenMinus1; i >= 0; --i)
+      {
+         if (sDBI.pcVarModSites[i] > 0)
+         {
+            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            {
+               iPositionNLY[sDBI.pcVarModSites[i] - 1] = i;
+               break;
+            }
+         }
+      }
+   }
+
+   // Generate forward and reverse ion ladders
+   for (int i = 0; i < iLenMinus1; ++i)
+   {
+      int iPosReverse = iLenMinus1 - i;
+
+      dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[i]];
+      if (piVarModSites[i] > 0)
+      {
+         dBion += g_staticParams.variableModParameters.varModList[piVarModSites[i] - 1].dVarModMass;
+         iFoundVariableMod = 1;
+
+         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+            && g_staticParams.variableModParameters.varModList[piVarModSites[i] - 1].dNeutralLoss != 0.0)
+         {
+            iFoundVariableMod = 2;
+         }
+      }
+
+      dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[iPosReverse]];
+      if (piVarModSites[iPosReverse] > 0)
+      {
+         dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosReverse] - 1].dVarModMass;
+         iFoundVariableMod = 1;
+
+         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+            && g_staticParams.variableModParameters.varModList[piVarModSites[iPosReverse] - 1].dNeutralLoss != 0.0)
+         {
+            iFoundVariableMod = 2;
+         }
+      }
+
+      pdAAforward[i] = dBion;
+      pdAAreverse[i] = dYion;
+   }
+
+   // Build binned ion masses - two-pass approach matching batch path
+   // First pass: clear
+   memset(pbDuplFragment, 0, sizeof(bool) * g_staticParams.iArraySizeGlobal);
+   memset(uiBinnedIonMasses, 0, sizeof(uiBinnedIonMasses));
+   if (g_staticParams.iPrecursorNLSize > 0)
+      memset(uiBinnedPrecursorNL, 0, sizeof(uiBinnedPrecursorNL));
+
+   for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+   {
+      for (int ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
+      {
+         int iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
+
+         for (int ctLen = 0; ctLen < iLenMinus1; ++ctLen)
+         {
+            double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, pdAAforward, pdAAreverse);
+            int iVal = BIN(dFragMass);
+
+            if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+            {
+               pbDuplFragment[iVal] = false;
+               uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = 0;
+
+               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+               {
+                  for (int x = 0; x < VMODS; ++x)
+                  {
+                     for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                     {
+                        if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                           continue;
+                        else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                           continue;
+
+                        if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])
+                           || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x]))
+                        {
+                           double dNewMass;
+                           if (iWhichNL == 0)
+                              dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
+                           else
+                              dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
+
+                           iVal = BIN(dNewMass);
+                           if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+                           {
+                              pbDuplFragment[iVal] = false;
+                              iFoundVariableMod = 2;
+                           }
+                        }
+                        uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = 0;
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   // Initialize precursor NL - first pass
+   for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
+   {
+      for (int ctCharge = pQuery->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; --ctCharge)
+      {
+         double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
+         int iVal = BIN(dNLMass);
+         if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
+         {
+            pbDuplFragment[iVal] = false;
+            uiBinnedPrecursorNL[ctNL][ctCharge] = 0;
+         }
+      }
+   }
+
+   // Second pass: set binned ion masses
+   for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+   {
+      for (int ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
+      {
+         int iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
+
+         for (int ctLen = 0; ctLen < iLenMinus1; ++ctLen)
+         {
+            double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, pdAAforward, pdAAreverse);
+            int iVal = BIN(dFragMass);
+
+            if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+            {
+               uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
+               pbDuplFragment[iVal] = true;
+
+               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+               {
+                  for (int x = 0; x < VMODS; ++x)
+                  {
+                     for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                     {
+                        if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                           continue;
+                        else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                           continue;
+
+                        if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])
+                           || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x]))
+                        {
+                           double dNewMass;
+                           if (iWhichNL == 0)
+                              dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
+                           else
+                              dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
+
+                           iVal = BIN(dNewMass);
+                           if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+                           {
+                              uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
+                              pbDuplFragment[iVal] = true;
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   // Precursor NL - second pass
+   for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
+   {
+      for (int ctCharge = pQuery->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; --ctCharge)
+      {
+         double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
+         int iVal = BIN(dNLMass);
+         if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+         {
+            uiBinnedPrecursorNL[ctNL][ctCharge] = iVal;
+            pbDuplFragment[iVal] = true;
+         }
+      }
+   }
+
+   // Score the peptide - bDecoyPep tells XcorrScore/StorePeptideI whether
+   // to store into target or decoy results on pQuery
+   XcorrScoreI(szProtein, iStartPos, iEndPos, iFoundVariableMod, sDBI.dPepMass, bDecoyPep,
+      pQuery, iLenPeptide, piVarModSites, dbe, uiBinnedIonMasses, uiBinnedPrecursorNL, 0);
+
+   if (g_staticParams.options.iDecoySearch)
+   {
+      char szDecoyPeptide[MAX_PEPTIDE_LEN];
+      int piVarModSitesDecoy[MAX_PEPTIDE_LEN_P2];
+      double pdAAforwardDecoy[MAX_PEPTIDE_LEN];
+      double pdAAreverseDecoy[MAX_PEPTIDE_LEN];
+      unsigned int uiBinnedIonMassesDecoy[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
+      unsigned int uiBinnedPrecursorNLDecoy[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
+      int iFoundVariableModDecoy = 0;
+
+      // Reverse the peptide sequence, keeping the terminal residue fixed
+      // based on enzyme offset (same logic as batch path)
+      if (g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 1)
+      {
+         // Last residue stays the same:  ABCDEK -> EDCBAK
+         for (int i = iLenPeptide - 2; i >= 0; --i)
+         {
+            szDecoyPeptide[iLenPeptide - 2 - i] = sDBI.szPeptide[i];
+            piVarModSitesDecoy[iLenPeptide - 2 - i] = piVarModSites[i];
+         }
+         szDecoyPeptide[iLenPeptide - 1] = sDBI.szPeptide[iLenPeptide - 1];
+         piVarModSitesDecoy[iLenPeptide - 1] = piVarModSites[iLenPeptide - 1];
+      }
+      else
+      {
+         // First residue stays the same:  ABCDEK -> AKEDCB
+         szDecoyPeptide[0] = sDBI.szPeptide[0];
+         piVarModSitesDecoy[0] = piVarModSites[0];
+         for (int i = iLenPeptide - 1; i >= 1; --i)
+         {
+            szDecoyPeptide[iLenPeptide - i] = sDBI.szPeptide[i];
+            piVarModSitesDecoy[iLenPeptide - i] = piVarModSites[i];
+         }
+      }
+      szDecoyPeptide[iLenPeptide] = '\0';
+
+      // Copy terminal mod sites
+      piVarModSitesDecoy[iLenPeptide] = piVarModSites[iLenPeptide];         // N-term
+      piVarModSitesDecoy[iLenPeptide + 1] = piVarModSites[iLenPeptide + 1]; // C-term
+
+      // Build decoy ion ladders
+      double dBionDecoy = g_staticParams.precalcMasses.dNtermProton;
+      double dYionDecoy = g_staticParams.precalcMasses.dCtermOH2Proton;
+
+      if (piVarModSitesDecoy[iLenPeptide] > 0)
+      {
+         dBionDecoy += g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[iLenPeptide] - 1].dVarModMass;
+         iFoundVariableModDecoy = 1;
+      }
+      if (piVarModSitesDecoy[iLenPeptide + 1] > 0)
+      {
+         dYionDecoy += g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[iLenPeptide + 1] - 1].dVarModMass;
+         iFoundVariableModDecoy = 1;
+      }
+
+      if (sDBI.cPrevAA == '-')
+         dBionDecoy += g_staticParams.staticModifications.dAddNterminusProtein;
+      if (sDBI.cNextAA == '-')
+         dYionDecoy += g_staticParams.staticModifications.dAddCterminusProtein;
+
+      // Track fragment neutral loss positions for decoy
+      int iPositionNLBDecoy[VMODS];
+      int iPositionNLYDecoy[VMODS];
+
+      if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+      {
+         for (int i = 0; i < VMODS; ++i)
+         {
+            iPositionNLBDecoy[i] = 999;
+            iPositionNLYDecoy[i] = -1;
+         }
+
+         for (int i = 0; i < iLenMinus1; ++i)
+         {
+            if (piVarModSitesDecoy[i] > 0)
+            {
+               if (g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLBDecoy[piVarModSitesDecoy[i] - 1] = i;
+                  break;
+               }
+            }
+         }
+
+         for (int i = iLenMinus1; i >= 0; --i)
+         {
+            if (piVarModSitesDecoy[i] > 0)
+            {
+               if (g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLYDecoy[piVarModSitesDecoy[i] - 1] = i;
+                  break;
+               }
+            }
+         }
+      }
+
+      for (int i = 0; i < iLenMinus1; ++i)
+      {
+         int iPosReverse = iLenMinus1 - i;
+
+         dBionDecoy += g_staticParams.massUtility.pdAAMassFragment[(int)szDecoyPeptide[i]];
+         if (piVarModSitesDecoy[i] > 0)
+         {
+            dBionDecoy += g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[i] - 1].dVarModMass;
+            iFoundVariableModDecoy = 1;
+
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+               && g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[i] - 1].dNeutralLoss != 0.0)
+            {
+               iFoundVariableModDecoy = 2;
+            }
+         }
+
+         dYionDecoy += g_staticParams.massUtility.pdAAMassFragment[(int)szDecoyPeptide[iPosReverse]];
+         if (piVarModSitesDecoy[iPosReverse] > 0)
+         {
+            dYionDecoy += g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[iPosReverse] - 1].dVarModMass;
+            iFoundVariableModDecoy = 1;
+
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+               && g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[iPosReverse] - 1].dNeutralLoss != 0.0)
+            {
+               iFoundVariableModDecoy = 2;
+            }
+         }
+
+         pdAAforwardDecoy[i] = dBionDecoy;
+         pdAAreverseDecoy[i] = dYionDecoy;
+      }
+
+      // Build binned ion masses for decoy (single-pass; memset covers the clear)
+      memset(pbDuplFragment, 0, sizeof(bool) * g_staticParams.iArraySizeGlobal);
+      memset(uiBinnedIonMassesDecoy, 0, sizeof(uiBinnedIonMassesDecoy));
+      if (g_staticParams.iPrecursorNLSize > 0)
+         memset(uiBinnedPrecursorNLDecoy, 0, sizeof(uiBinnedPrecursorNLDecoy));
+
+      for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+      {
+         for (int ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
+         {
+            int iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
+
+            for (int ctLen = 0; ctLen < iLenMinus1; ++ctLen)
+            {
+               double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, pdAAforwardDecoy, pdAAreverseDecoy);
+               int iVal = BIN(dFragMass);
+
+               if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+               {
+                  uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][0] = iVal;
+                  pbDuplFragment[iVal] = true;
+
+                  if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                  {
+                     for (int x = 0; x < VMODS; ++x)
+                     {
+                        for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                        {
+                           if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                              continue;
+                           else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                              continue;
+
+                           if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLBDecoy[x])
+                              || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLYDecoy[x]))
+                           {
+                              double dNewMass;
+                              if (iWhichNL == 0)
+                                 dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
+                              else
+                                 dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
+
+                              iVal = BIN(dNewMass);
+                              if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+                              {
+                                 uiBinnedIonMassesDecoy[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
+                                 pbDuplFragment[iVal] = true;
+                                 iFoundVariableModDecoy = 2;
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+      // Precursor NL for decoy
+      for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
+      {
+         for (int ctZ = pQuery->_spectrumInfoInternal.usiChargeState; ctZ >= 1; --ctZ)
+         {
+            double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctZ * PROTON_MASS) / ctZ;
+            int iVal = BIN(dNLMass);
+            if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+            {
+               uiBinnedPrecursorNLDecoy[ctNL][ctZ] = iVal;
+               pbDuplFragment[iVal] = true;
+            }
+         }
+      }
+
+      // Build decoy protein context string (reuse szProtein layout but with decoy peptide)
+      char szDecoyProtein[MAX_PEPTIDE_LEN_P2];
+      int iDecoyStartPos, iDecoyEndPos;
+      int iDecoyPos = 0;
+
+      if (sDBI.cPrevAA != '-')
+      {
+         szDecoyProtein[0] = sDBI.cPrevAA;
+         iDecoyPos = 1;
+      }
+      iDecoyStartPos = iDecoyPos;
+
+      memcpy(szDecoyProtein + iDecoyPos, szDecoyPeptide, iLenPeptide);
+      iDecoyPos += iLenPeptide;
+      iDecoyEndPos = iDecoyPos - 1;
+
+      if (sDBI.cNextAA != '-')
+      {
+         szDecoyProtein[iDecoyPos] = sDBI.cNextAA;
+         iDecoyPos++;
+      }
+      szDecoyProtein[iDecoyPos] = '\0';
+
+      // Score the decoy peptide
+      XcorrScoreI(szDecoyProtein, iDecoyStartPos, iDecoyEndPos, iFoundVariableModDecoy, sDBI.dPepMass, true,
+         pQuery, iLenPeptide, piVarModSitesDecoy, dbe, uiBinnedIonMassesDecoy, uiBinnedPrecursorNLDecoy, 0);
+   }
 }
 
 
@@ -2575,12 +3100,14 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
             double dBion = g_staticParams.precalcMasses.dNtermProton;
             double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
 
-            /* n/c-term protein mods not supported
-                        if (iStartPos == 0)
-                           dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-                        if (iEndPos == iLenProteinMinus1)
-                           dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-            */
+            if (g_staticParams.iDbType == DbType::PI_DB)
+            {
+               // Protein n-term / c-term static mod adjustments
+               if (sDBI.cPrevAA == '-')
+                  dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+               if (sDBI.cNextAA == '-')
+                  dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+            }
 
             // variable N-term peptide mod
             if (piVarModSites[iLenPeptide] > 0)
@@ -3085,9 +3612,9 @@ void CometSearch::SearchMS1Library(size_t iWhichMS1Query,
 // iNtermPeptideOnly==2 specifies clipped methionine sequence due to the
 //                      PEFF variant becoming the clipped methionine
 bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
-   char* szProteinSeq,
-   int iNtermPeptideOnly,
-   bool* pbDuplFragment)
+                                    char* szProteinSeq,
+                                    int iNtermPeptideOnly,
+                                    bool* pbDuplFragment)
 {
    int iLenPeptide = 0;
    int iLenProtein;
@@ -3281,8 +3808,8 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 
                strncpy(sEntry.szPeptide, szProteinSeq + iStartPos, iLenPeptide);
                sEntry.szPeptide[iLenPeptide] = '\0';
-               sEntry.cPrevAA = (iStartPos > 0) ? szProteinSeq[iStartPos - 1] : '-';
-               sEntry.cNextAA = (iEndPos < iProteinSeqLengthMinus1) ? szProteinSeq[iEndPos + 1] : '-';
+               sEntry.cPrevAA = (iStartPos == iFirstResiduePosition) ? '-' : szProteinSeq[iStartPos - 1];
+               sEntry.cNextAA = (iEndPos == iProteinSeqLengthMinus1) ? '-' : szProteinSeq[iEndPos + 1] ;
                sEntry.siVarModProteinFilter = siVarModProteinFilter;
 
                // little sanity check here to not include peptides with '*' in them
@@ -3838,9 +4365,8 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 // Each analyzed peptide must either contain the variant or be flanked
 // by the variant enabling new enzyme-digested peptide
 void CometSearch::SearchForVariants(struct sDBEntry dbe,
-   char* szProteinSeq,
-   bool* pbDuplFragment)
-
+                                    char* szProteinSeq,
+                                    bool* pbDuplFragment)
 {
    int iLen = (int)strlen(szProteinSeq);
 
@@ -3982,9 +4508,9 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
 
 
 int CometSearch::WithinMassTolerance(double dCalcPepMass,
-   char* szProteinSeq,
-   int iStartPos,
-   int iEndPos)
+                                     char* szProteinSeq,
+                                     int iStartPos,
+                                     int iEndPos)
 {
    int iPepLen = iEndPos - iStartPos + 1;
 
@@ -4024,9 +4550,9 @@ int CometSearch::WithinMassTolerance(double dCalcPepMass,
 // This function will return true if unmodified peptide mass + any combination of
 // PEFF mod is within mass tolerance of any peptide query
 bool CometSearch::WithinMassTolerancePeff(double dCalcPepMass,
-   vector<PeffPositionStruct>* vPeffArray,
-   int iStartPos,
-   int iEndPos)
+                                          vector<PeffPositionStruct>* vPeffArray,
+                                          int iStartPos,
+                                          int iEndPos)
 {
    int i;
 
@@ -4085,8 +4611,8 @@ bool CometSearch::WithinMassTolerancePeff(double dCalcPepMass,
 
 // Check enzyme termini.
 bool CometSearch::CheckEnzymeTermini(const char* szProteinSeq,
-   int iStartPos,
-   int iEndPos) const
+                                     int iStartPos,
+                                     int iEndPos) const
 {
    if (!g_staticParams.enzymeInformation.bNoEnzymeSelected || !g_staticParams.enzymeInformation.bNoEnzyme2Selected)
    {
@@ -4191,7 +4717,7 @@ bool CometSearch::CheckEnzymeTermini(const char* szProteinSeq,
 
 
 bool CometSearch::CheckEnzymeStartTermini(const char* szProteinSeq,
-   int iStartPos) const
+                                         int iStartPos) const
 {
    if (g_staticParams.options.bClipNtermAA)
       iStartPos -= 1;
@@ -4221,7 +4747,7 @@ bool CometSearch::CheckEnzymeStartTermini(const char* szProteinSeq,
 
 
 bool CometSearch::CheckEnzymeEndTermini(const char* szProteinSeq,
-   int iEndPos) const
+                                        int iEndPos) const
 {
    if (!g_staticParams.enzymeInformation.bNoEnzymeSelected && !g_staticParams.enzymeInformation.bNoEnzyme2Selected)
    {
@@ -4248,11 +4774,10 @@ bool CometSearch::CheckEnzymeEndTermini(const char* szProteinSeq,
 
 
 int CometSearch::BinarySearchPeffStrMod(int start,
-   int end,
-   string strMod,
-   vector<OBOStruct>& vectorPeffOBO)
+                                        int end,
+                                        string strMod,
+                                        vector<OBOStruct>& vectorPeffOBO)
 {
-
    // Termination condition: start index greater than end index.
    if (start > end || start == (int)vectorPeffOBO.size())
       return -1;
@@ -4272,8 +4797,8 @@ int CometSearch::BinarySearchPeffStrMod(int start,
 
 // Performance: Use std::lower_bound for binary search
 int CometSearch::BinarySearchMass(int start,
-   int end,
-   double dCalcPepMass) const
+                                  int end,
+                                  double dCalcPepMass) const
 {
    auto it = std::lower_bound(
       g_pvQuery.begin() + start,
@@ -4295,9 +4820,9 @@ int CometSearch::BinarySearchMass(int start,
 
 
 size_t CometSearch::BinarySearchIndexMass(size_t start,
-   size_t end,
-   double dQueryMass,
-   unsigned int* uiFragmentMass)
+                                          size_t end,
+                                          double dQueryMass,
+                                          unsigned int* uiFragmentMass)
 {
    // dQueryMass is the lower bound tolerance mass of input spectrum.
 
@@ -4337,7 +4862,7 @@ size_t CometSearch::BinarySearchIndexMass(size_t start,
 
 
 bool CometSearch::CheckMassMatch(size_t iWhichQuery,
-   double dCalcPepMass)
+                                 double dCalcPepMass)
 {
    Query* pQuery = g_pvQuery.at(iWhichQuery);
 
@@ -4503,8 +5028,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
 
 // For nucleotide search, translate from DNA to amino acid.
 bool CometSearch::TranslateNA2AA(int* frame,
-   int iDirection,
-   char* szDNASequence)
+                                 int iDirection,
+                                 char* szDNASequence)
 {
    int i, ii = 0;
    int iSeqLength = (int)strlen(szDNASequence);
@@ -4586,8 +5111,8 @@ bool CometSearch::TranslateNA2AA(int* frame,
 
 // GET amino acid from DNA triplets, direction=+/-1.
 char CometSearch::GetAA(int i,
-   int iDirection,
-   char* szDNASequence)
+                        int iDirection,
+                        char* szDNASequence)
 {
    int iBase1 = i;
    int iBase2 = i + iDirection;
@@ -4690,21 +5215,21 @@ char CometSearch::GetAA(int i,
 
 // Compares sequence to MSMS spectrum by matching ion intensities.
 void CometSearch::XcorrScore(char* szProteinSeq,
-   int iStartResidue,        // needed for decoy peptide; otherwise just duplicate of iStartPos
-   int iEndResidue,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
-   double dCalcPepMass,
-   bool bDecoyPep,
-   int iWhichQuery,
-   int iLenPeptide,
-   int* piVarModSites,
-   struct sDBEntry* dbe)
+                             int iStartResidue,        // needed for decoy peptide; otherwise just duplicate of iStartPos
+                             int iEndResidue,
+                             int iStartPos,
+                             int iEndPos,
+                             int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
+                             double dCalcPepMass,
+                             bool bDecoyPep,
+                             int iWhichQuery,
+                             int iLenPeptide,
+                             int* piVarModSites,
+                             struct sDBEntry* dbe)
 {
-   int  ctLen,
-      ctIonSeries,
-      ctCharge;
+   int ctLen,
+       ctIonSeries,
+       ctCharge;
    double dXcorr;
    int iLenPeptideMinus1 = iLenPeptide - 1;
 
@@ -4871,7 +5396,7 @@ void CometSearch::XcorrScore(char* szProteinSeq,
    {
       // no need to check duplicates if fragment ion indexed database search (internal decoys not supported yet)
       // and !g_staticParams.options.bTreatSameIL and no internal decoys
-      if (g_staticParams.iIndexDb == 1 && !g_staticParams.options.bTreatSameIL)
+      if (g_staticParams.iDbType == DbType::FI_DB && !g_staticParams.options.bTreatSameIL)
       {
          StorePeptide(iWhichQuery, iStartResidue, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
             dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
@@ -4890,22 +5415,22 @@ void CometSearch::XcorrScore(char* szProteinSeq,
 
 // Compares sequence to MSMS spectrum by matching ion intensities.
 void CometSearch::XcorrScoreI(char* szProteinSeq,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
-   double dCalcPepMass,
-   bool bDecoyPep,
-   size_t iWhichQuery,
-   int iLenPeptide,
-   int* piVarModSites,
-   struct sDBEntry* dbe,
-   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2],
-   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
-   int iNumMatchedFragmentIons)
+                              int iStartPos,
+                              int iEndPos,
+                              int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
+                              double dCalcPepMass,
+                              bool bDecoyPep,
+                              size_t iWhichQuery,
+                              int iLenPeptide,
+                              int* piVarModSites,
+                              struct sDBEntry* dbe,
+                              unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2],
+                              unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
+                              int iNumMatchedFragmentIons)
 {
-   int  ctLen,
-      ctIonSeries,
-      ctCharge;
+   int ctLen,
+       ctIonSeries,
+       ctCharge;
    double dXcorr = 0.0;
    int iLenPeptideMinus1 = iLenPeptide - 1;
 
@@ -4937,8 +5462,11 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
 
             if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
             {
-               for (int ii = 0; ii < FRAGINDEX_VMODS; ++ii)
+               for (int ii = 0; ii < VMODS; ++ii)
                {
+                  if (g_staticParams.iDbType == DbType::FI_DB && ii >= FRAGINDEX_VMODS)
+                     break;
+
                   for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                   {
                      if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss == 0.0)
@@ -5028,16 +5556,16 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
 
 
 void CometSearch::StorePeptide(size_t iWhichQuery,
-   int iStartResidue,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,
-   char* szProteinSeq,
-   double dCalcPepMass,
-   double dXcorr,
-   bool bDecoyPep,
-   int* piVarModSites,
-   struct sDBEntry* dbe)
+                               int iStartResidue,
+                               int iStartPos,
+                               int iEndPos,
+                               int iFoundVariableMod,
+                               char* szProteinSeq,
+                               double dCalcPepMass,
+                               double dXcorr,
+                               bool bDecoyPep,
+                               int* piVarModSites,
+                               struct sDBEntry* dbe)
 {
    int i;
    int iLenPeptide;
@@ -5461,15 +5989,15 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
 
 void CometSearch::StorePeptideI(size_t iWhichQuery,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,
-   char* szProteinSeq,
-   double dCalcPepMass,
-   double dXcorr,
-   bool bDecoyPep,
-   int* piVarModSites,
-   struct sDBEntry* dbe)
+                                int iStartPos,
+                                int iEndPos,
+                                int iFoundVariableMod,
+                                char* szProteinSeq,
+                                double dCalcPepMass,
+                                double dXcorr,
+                                bool bDecoyPep,
+                                int* piVarModSites,
+                                struct sDBEntry* dbe)
 {
    int iLenPeptide = iEndPos - iStartPos + 1;
    int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
@@ -5579,16 +6107,16 @@ void CometSearch::StorePeptideI(size_t iWhichQuery,
 
 
 int CometSearch::CheckDuplicate(int iWhichQuery,
-   int iStartResidue,
-   int iEndResidue,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,
-   double dCalcPepMass,
-   char* szProteinSeq,
-   bool bDecoyPep,
-   int* piVarModSites,
-   struct sDBEntry* dbe)
+                                int iStartResidue,
+                                int iEndResidue,
+                                int iStartPos,
+                                int iEndPos,
+                                int iFoundVariableMod,
+                                double dCalcPepMass,
+                                char* szProteinSeq,
+                                bool bDecoyPep,
+                                int* piVarModSites,
+                                struct sDBEntry* dbe)
 {
    int i;
    int iLenPeptide = iEndPos - iStartPos + 1;
@@ -5852,8 +6380,8 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
 
 
 void CometSearch::SubtractVarMods(int* piVarModCounts,
-   int cResidue,
-   int iResiduePosition)
+                                  int cResidue,
+                                  int iResiduePosition)
 {
    int i;
    for (i = 0; i < VMODS; ++i)
@@ -5889,8 +6417,8 @@ void CometSearch::SubtractVarMods(int* piVarModCounts,
 
 // track # of variable mod AA residues in peptide; note that n- and c-term mods are not tracked here
 void CometSearch::CountVarMods(int* piVarModCounts,
-   int cResidue,
-   int iResiduePosition)
+                               int cResidue,
+                               int iResiduePosition)
 {
    for (int i = 0; i < VMODS; ++i)
    {
@@ -5924,9 +6452,9 @@ void CometSearch::CountVarMods(int* piVarModCounts,
 
 // return true if there are any possible variable mods (including PEFF mods)
 bool CometSearch::HasVariableMod(int* pVarModCounts,
-   int iStartPos,
-   int iEndPos,
-   struct sDBEntry* dbe)
+                                 int iStartPos,
+                                 int iEndPos,
+                                 struct sDBEntry* dbe)
 {
    int i;
 
@@ -6037,12 +6565,12 @@ bool CometSearch::HasVariableMod(int* pVarModCounts,
 
 
 void CometSearch::VariableModSearch(char* szProteinSeq,
-   int piVarModCounts[],
-   int iStartPos,
-   int iEndPos,
-   int iClipNtermMetOffset, // normal =0, n-term met clipped = 1; used to address PEFF mod position
-   bool* pbDuplFragment,
-   struct sDBEntry* dbe)
+                                    int piVarModCounts[],
+                                    int iStartPos,
+                                    int iEndPos,
+                                    int iClipNtermMetOffset, // normal =0, n-term met clipped = 1; used to address PEFF mod position
+                                    bool* pbDuplFragment,
+                                    struct sDBEntry* dbe)
 {
    int i,
       ii,
@@ -6864,13 +7392,13 @@ double CometSearch::TotalVarModMass(int* pVarModCounts)
 
 // false=exit; true=continue
 bool CometSearch::PermuteMods(char* szProteinSeq,
-   int iWhichQuery,
-   int iWhichMod,
-   int iClipNtermMetOffset,
-   bool* pbDuplFragment,
-   bool* bDoPeffAnalysis,
-   vector <PeffPositionStruct>* vPeffArray,
-   struct sDBEntry* dbe)
+                              int iWhichQuery,
+                              int iWhichMod,
+                              int iClipNtermMetOffset,
+                              bool* pbDuplFragment,
+                              bool* bDoPeffAnalysis,
+                              vector <PeffPositionStruct>* vPeffArray,
+                              struct sDBEntry* dbe)
 {
    int iModIndex;
 
@@ -7133,12 +7661,12 @@ void CometSearch::inittwiddle(int m, int n, int* p)
 // always need to return true so permutations of variable mods continues
 // except when lMaxIterations is hit
 bool CometSearch::MergeVarMods(char* szProteinSeq,
-   int iWhichQuery,
-   int iClipNtermMetOffset,
-   bool* pbDuplFragment,
-   bool* bDoPeffAnalysis,
-   vector <PeffPositionStruct>* vPeffArray,
-   struct sDBEntry* dbe)
+                               int iWhichQuery,
+                               int iClipNtermMetOffset,
+                               bool* pbDuplFragment,
+                               bool* bDoPeffAnalysis,
+                               vector <PeffPositionStruct>* vPeffArray,
+                               struct sDBEntry* dbe)
 {
    int piVarModSites[MAX_PEPTIDE_LEN_P2];
    int piVarModCharIdx[VMODS];
@@ -7531,12 +8059,12 @@ bool CometSearch::MergeVarMods(char* szProteinSeq,
 
 
 bool CometSearch::CalcVarModIons(char* szProteinSeq,
-   int iWhichQuery,
-   bool* pbDuplFragment,
-   int* piVarModSites,
-   double dCalcPepMass,
-   int iLenPeptide,
-   struct sDBEntry* dbe)
+                                 int iWhichQuery,
+                                 bool* pbDuplFragment,
+                                 int* piVarModSites,
+                                 double dCalcPepMass,
+                                 int iLenPeptide,
+                                 struct sDBEntry* dbe)
 {
    int piVarModSitesDecoy[MAX_PEPTIDE_LEN_P2];
    char szDecoyPeptide[MAX_PEPTIDE_LEN_P2];  // allow for prev/next AA in string
@@ -8185,7 +8713,7 @@ bool CometSearch::CalcVarModIons(char* szProteinSeq,
 
 // Task 1.2: Thread-local overload accepting Query* directly.
 bool CometSearch::CheckMassMatch(Query* pQuery,
-   double dCalcPepMass)
+                                 double dCalcPepMass)
 {
    int iMassOffsetsSize = (int)g_staticParams.vectorMassOffsets.size();
 
@@ -8329,37 +8857,69 @@ bool CometSearch::CheckMassMatch(Query* pQuery,
 
 
 // Task 1.2: Thread-local XcorrScoreI overload accepting Query* directly.
+// This function handles both DbType::FI_DB and DbType::PI_DB searches.
+// For FI_DB: uses ppfSparseFastXcorrData only, gates storage on iNumMatchedFragmentIons.
+// For PI_DB: uses ppfSparseFastXcorrDataNL for 1+ a/b/y ions, gates storage on dXcorr only.
 void CometSearch::XcorrScoreI(char* szProteinSeq,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,
-   double dCalcPepMass,
-   bool bDecoyPep,
-   Query* pQuery,
-   int iLenPeptide,
-   int* piVarModSites,
-   struct sDBEntry* dbe,
-   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2],
-   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
-   int iNumMatchedFragmentIons)
+                              int iStartPos,
+                              int iEndPos,
+                              int iFoundVariableMod,
+                              double dCalcPepMass,
+                              bool bDecoyPep,
+                              Query* pQuery,
+                              int iLenPeptide,
+                              int* piVarModSites,
+                              struct sDBEntry* dbe,
+                              unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2],
+                              unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
+                              int iNumMatchedFragmentIons)
 {
-   int  ctLen,
-      ctIonSeries,
-      ctCharge;
+   int ctLen,
+       ctIonSeries,
+       ctCharge;
    double dXcorr = 0.0;
    int iLenPeptideMinus1 = iLenPeptide - 1;
+
+   bool bPeptideIndex = (g_staticParams.iDbType == DbType::PI_DB);
 
    // iMax is largest x-value allowed as iMax+1 is allocated and we're 0-index
    int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
 
    int bin, x, y;
 
-   float** ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
+   float** ppSparseFastXcorrData;
+
+   int iWhichIonSeries;
+   bool bUseWaterAmmoniaNLPeaks = false;
 
    for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
    {
       for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
       {
+         iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
+
+         // For PI_DB, use water/ammonia NL spectrum data for singly-charged a/b/y ions
+         // to match the batch XcorrScore() behavior. FI_DB always uses ppfSparseFastXcorrData.
+         if (bPeptideIndex)
+         {
+            if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
+               && (iWhichIonSeries == ION_SERIES_A || iWhichIonSeries == ION_SERIES_B || iWhichIonSeries == ION_SERIES_Y))
+            {
+               bUseWaterAmmoniaNLPeaks = true;
+            }
+            else
+               bUseWaterAmmoniaNLPeaks = false;
+
+            if (ctCharge == 1 && bUseWaterAmmoniaNLPeaks)
+               ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrDataNL;
+            else
+               ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
+         }
+         else
+         {
+            ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
+         }
+
          for (ctLen = 0; ctLen < iLenPeptideMinus1; ++ctLen)
          {
             //MH: newer sparse matrix converts bin to sparse matrix bin
@@ -8375,8 +8935,11 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
 
             if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
             {
-               for (int ii = 0; ii < FRAGINDEX_VMODS; ++ii)
+               for (int ii = 0; ii < VMODS; ++ii)
                {
+                  if (g_staticParams.iDbType == DbType::FI_DB && ii >= FRAGINDEX_VMODS)
+                     break;
+
                   for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                   {
                      if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss == 0.0)
@@ -8401,6 +8964,7 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
    }
 
    // precursor NL
+   ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
    for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
    {
       for (int ctZ = pQuery->_spectrumInfoInternal.usiChargeState; ctZ >= 1; --ctZ)
@@ -8453,10 +9017,32 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
       pQuery->uiHistogramCount += 1;
    }
 
-   if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
+   // FI_DB: gate on matched fragment ion count (pre-screened candidates)
+   // PI_DB: gate on xcorr and minimum xcorr threshold (all mass-matched candidates scored)
+   if (g_staticParams.iDbType == DbType::FI_DB)
    {
-      StorePeptideI(pQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
-         dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
+      if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
+      {
+         StorePeptideI(pQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
+            dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
+      }
+   }
+   else // PI_DB
+   {
+      double dLowestXcorrScore;
+
+      if (bDecoyPep && g_staticParams.options.iDecoySearch == 2)
+         dLowestXcorrScore = pQuery->dLowestDecoyXcorrScore;
+      else
+         dLowestXcorrScore = pQuery->dLowestXcorrScore;
+
+      if (dXcorr >= g_staticParams.options.dMinimumXcorr
+         && dXcorr + 0.00005 >= dLowestXcorrScore
+         && iLenPeptide <= g_staticParams.options.peptideLengthRange.iEnd)
+      {
+         StorePeptideI(pQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
+            dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
+      }
    }
 
    Threading::UnlockMutex(pQuery->accessMutex);
@@ -8465,15 +9051,15 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
 
 // Task 1.2: Thread-local StorePeptideI overload accepting Query* directly.
 void CometSearch::StorePeptideI(Query* pQuery,
-   int iStartPos,
-   int iEndPos,
-   int iFoundVariableMod,
-   char* szProteinSeq,
-   double dCalcPepMass,
-   double dXcorr,
-   bool bDecoyPep,
-   int* piVarModSites,
-   struct sDBEntry* dbe)
+                                int iStartPos,
+                                int iEndPos,
+                                int iFoundVariableMod,
+                                char* szProteinSeq,
+                                double dCalcPepMass,
+                                double dXcorr,
+                                bool bDecoyPep,
+                                int* piVarModSites,
+                                struct sDBEntry* dbe)
 {
    int iLenPeptide = iEndPos - iStartPos + 1;
    int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
@@ -8500,6 +9086,7 @@ void CometSearch::StorePeptideI(Query* pQuery,
    }
 
    pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr = (float)dXcorr;
+   pQuery->_pResults[siLowestXcorrScoreIndex].bClippedM = false;
 
    if (iStartPos == 0)
       pQuery->_pResults[siLowestXcorrScoreIndex].cPrevAA = '-';
@@ -8534,6 +9121,14 @@ void CometSearch::StorePeptideI(Query* pQuery,
       else
       {
          memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, piVarModSites, iSizepiVarModSites);
+
+         for (int i = 0; i < iLenPeptide + 2; ++i)
+         {
+            if (piVarModSites[i] > 0)
+               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[piVarModSites[i] - 1].dVarModMass;
+            else
+               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = 0.0;
+         }
 
          int iVal;
          for (int i = 0; i < iLenPeptide + 2; ++i)
@@ -8577,4 +9172,33 @@ void CometSearch::StorePeptideI(Query* pQuery,
    }
 
    pQuery->siLowestXcorrScoreIndex = siLowestXcorrScoreIndex;
+}
+
+
+// Reads the .idx file header to initialise fragment/parent masses and
+// modification parameters.  Called from InitializeSingleSpectrumSearch()
+// after ReadPeptideIndex() has loaded the peptide data, so that mass arrays
+// reflect the exact static/variable mods used when the index was built.
+bool CometSearch::InitializeMassesFromPeptideIndex()
+{
+   FILE* fp;
+
+   if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
+   {
+      string strErrorMsg = " Error - cannot open peptide index file \""
+         + std::string(g_staticParams.databaseInfo.szDatabase)
+         + "\" for mass initialisation.\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   if (!CometPeptideIndex::ParsePeptideIndexHeader(fp))
+   {
+      std::fclose(fp);
+      return false;
+   }
+
+   std::fclose(fp);
+   return true;
 }

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -14,6 +14,7 @@
 
 #include "Common.h"
 #include "CometSearch.h"
+#include "CometFragmentIndexReader.h"
 
 
 #define BINARYSEARCHCUTOFF 20                // do linear search through FI if # entries is this or less
@@ -90,10 +91,45 @@ bool CometSearch::DeallocateMemory(int maxNumThreads)
 }
 
 
+// Task 1.3: Thread-local overload.
+bool CometSearch::RunSearch(Query* pQuery)
+{
+   if (g_staticParams.iIndexDb == 1)  // fragment ion index
+   {
+      if (!g_bPlainPeptideIndexRead)
+      {
+         string strErrorMsg = " Error - fragment index not yet built for thread-local RunSearch(Query*)\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
+
+      bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal]();
+      SearchFragmentIndex(pQuery, pbDuplFragment);
+      delete[] pbDuplFragment;
+   }
+   else if (g_staticParams.iIndexDb == 2)  // peptide index
+   {
+      string strErrorMsg = " Error - peptide index search not supported for thread-local RunSearch(Query*)\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+   else
+   {
+      string strErrorMsg = " Error - index search but iIndexDb = " + std::to_string(g_staticParams.iIndexDb) + "\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   return true;
+}
+
+
 // called by DoSingleSpectrumSearchMultiResults
 bool CometSearch::RunSearch(ThreadPool *tp)
 {
-   CometFragmentIndex sqFI;
    CometSearch sqSearch;
    size_t iWhichQuery = 0;
 
@@ -101,6 +137,7 @@ bool CometSearch::RunSearch(ThreadPool *tp)
    {
       if (!g_bPlainPeptideIndexRead)
       {
+         CometFragmentIndex sqFI;
          sqFI.ReadPlainPeptideIndex();
          sqFI.CreateFragmentIndex(tp);
       }
@@ -146,7 +183,9 @@ bool CometSearch::RunSearch(int iPercentStart,
 
       for (size_t iWhichQuery = 0; iWhichQuery < iEnd; ++iWhichQuery)
       {
-         pSearchThreadPool->doJob(std::bind(sqSearch.SearchFragmentIndex, iWhichQuery, pSearchThreadPool));
+         pSearchThreadPool->doJob(std::bind(
+            static_cast<void(*)(size_t, ThreadPool*)>(&CometSearch::SearchFragmentIndex),
+            iWhichQuery, pSearchThreadPool));
       }
 
       pSearchThreadPool->wait_on_threads();
@@ -698,7 +737,7 @@ bool CometSearch::RunSearch(int iPercentStart,
                            getline(ssVariants, strVariantEntry, ')');
  
                            //handle possible '?' in the position field; need to check that strVariantEntry looks like "(number"
-                           if (strVariantEntry[0] == '(' && isdigit(strVariantEntry[1]))
+                           if (strVariantEntry[0]=='(' && isdigit(strVariantEntry[1]))
                            {
                               // turn '|' to space
                               std::string::iterator it;
@@ -711,6 +750,7 @@ bool CometSearch::RunSearch(int iPercentStart,
                               // split "8 10 C" into "8" and "10" and "C"
                               strVariant.clear();
                               iPosA = -1;
+                              iPosB = -1;
                               std::stringstream converter(strVariantEntry);
                               converter >> iPosA >> iPosB >> strVariant >> strTag;
  
@@ -728,14 +768,14 @@ bool CometSearch::RunSearch(int iPercentStart,
                                  if (g_staticParams.options.bVerboseOutput)
                                  {
                                     string strErrorMsg = " Warning:  " + dbe.strName + ", VariantComplex=("
-                                        + std::to_string(iPosA) + "|" + std::to_string(iPosB) + "|" + strVariant + ") ignored.\n" ;
+                                       + std::to_string(iPosA) + "|" + std::to_string(iPosB) + "|" + strVariant + ") ignored.\n" ;
                                     logout(strErrorMsg);
                                  }
                               }
                               else
                               {
                                  struct PeffVariantComplexStruct pData;
- 
+
                                  pData.iPositionA = iPosA - 1;   // represent PEFF variant position in 0 array index coordinates
                                  pData.iPositionB = iPosB - 1;
                                  pData.sResidues = strVariant;
@@ -931,6 +971,76 @@ bool CometSearch::RunMS1Search(ThreadPool* tp,
 }
 
 
+// Thread-local RunMS1Search overload: compares a caller-owned QueryMS1* against
+// the read-only g_vSpecLib entries within the RT window. Populates the output
+// scores vector with up to topN best matches. Zero shared mutable state.
+bool CometSearch::RunMS1Search(QueryMS1* pQueryMS1,
+                               const int topN,
+                               double dRT,
+                               double dMaxMS1RTDiff,
+                               const double dMaxSpecLibRT,
+                               const double dMaxQueryRT,
+                               vector<CometScoresMS1>& scores)
+{
+   if (pQueryMS1 == nullptr || pQueryMS1->pfFastXcorrData == nullptr)
+      return false;
+
+   scores.clear();
+
+   // Use the aligner to adjust the query RT if alignment data is available
+   // For now, use the raw RT ratio to estimate the corresponding library RT
+   double dScaledRT = dRT;
+   if (dMaxQueryRT > 0.0 && dMaxSpecLibRT > 0.0)
+      dScaledRT = dRT * (dMaxSpecLibRT / dMaxQueryRT);
+
+   float fBestDotProduct = -1.0f;
+   int iBestLibIdx = -1;
+
+   size_t iNumLibEntries = g_vSpecLib.size();
+   unsigned int uiQueryArraySize = pQueryMS1->iArraySizeMS1;
+
+   for (size_t i = 0; i < iNumLibEntries; ++i)
+   {
+      const SpecLibStruct& libEntry = g_vSpecLib[i];
+
+      // Check RT window
+      double dLibRT = (double)libEntry.fRTime;
+      if (fabs(dScaledRT - dLibRT) > dMaxMS1RTDiff)
+         continue;
+
+      // Check array size compatibility
+      if (libEntry.pfUnitVector == nullptr)
+         continue;
+
+      unsigned int uiLibArraySize = libEntry.uiArraySizeMS1;
+      unsigned int uiMinSize = (uiQueryArraySize < uiLibArraySize) ? uiQueryArraySize : uiLibArraySize;
+
+      // Compute dot product between query unit vector and library unit vector
+      double dDotProduct = 0.0;
+      for (unsigned int j = 0; j < uiMinSize; ++j)
+         dDotProduct += (double)pQueryMS1->pfFastXcorrData[j] * (double)libEntry.pfUnitVector[j];
+
+      if ((float)dDotProduct > fBestDotProduct)
+      {
+         fBestDotProduct = (float)dDotProduct;
+         iBestLibIdx = (int)i;
+      }
+   }
+
+   // For topN=1, just return the single best match
+   if (iBestLibIdx >= 0)
+   {
+      CometScoresMS1 result;
+      result.fDotProduct = fBestDotProduct;
+      result.fRTime = g_vSpecLib[iBestLibIdx].fRTime;
+      result.iScanNumber = (int)g_vSpecLib[iBestLibIdx].iLibEntry;
+      scores.push_back(result);
+   }
+
+   return true;
+}
+
+
 void CometSearch::ReadOBO(char *szOBO,
                           vector<OBOStruct> *vectorPeffOBO)
 {
@@ -1069,8 +1179,8 @@ void CometSearch::SearchThreadProc(SearchThreadData *pSearchThreadData, ThreadPo
        {
            if (_pbSearchMemoryPool[i] == false)
            {
-               _pbSearchMemoryPool[i] = true;
-               break;
+              _pbSearchMemoryPool[i] = true;
+              break;
            }
        }
 
@@ -1487,7 +1597,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
             {
                if (i > iStartPos)
                {
-                  for (int x = 0 ; x < FRAGINDEX_VMODS; ++x)
+                  for (int x = 0; x < FRAGINDEX_VMODS; ++x)
                   {
                      iCountNLB[x][iPosForward] = iCountNLB[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i
                      iCountNLY[x][iPosForward] = iCountNLY[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i (R to L in sequence)
@@ -1506,7 +1616,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
                iFoundVariableMod = 1;
 
                if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                     && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                {
                   iFoundVariableMod = 2;
 
@@ -1532,7 +1642,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
                iFoundVariableMod = 1;
 
                if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                     && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                {
                   iFoundVariableMod = 2;
 
@@ -1593,7 +1703,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
                                  continue;
 
                               if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                 || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                               {
                                  int iScaleFactor;
 
@@ -1660,7 +1770,7 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
          dbe.lProteinFilePosition = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).lIndexProteinFilePosition;
 
          XcorrScoreI(szProtein, iStartPos, iEndPos, iFoundVariableMod, dCalcPepMass, false, iWhichQuery,
-               iLenPeptide, piVarModSites, &dbe, uiBinnedIonMasses, uiBinnedPrecursorNL, ix->second);
+            iLenPeptide, piVarModSites, &dbe, uiBinnedIonMasses, uiBinnedPrecursorNL, ix->second);
 
          uiNumScored++;
          if (uiNumScored >= FRAGINDEX_MAX_NUMSCORED)
@@ -1672,11 +1782,361 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
 }
 
 
+// Task 1.1: Thread-local overload.
+void CometSearch::SearchFragmentIndex(Query* pQuery,
+                                      bool* pbDuplFragment)
+{
+   double pdAAforward[MAX_PEPTIDE_LEN];
+   double pdAAreverse[MAX_PEPTIDE_LEN];
+
+   std::map<comet_fileoffset_t, int> mPeptides;   // which peptide (fileoffset, and # matched fragments)
+   size_t lNumPeps = 0;
+   unsigned int uiFragmentMass;
+
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2];
+   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
+
+   mPeptides.clear();
+
+   // Walk through the binned peaks in the spectrum and map them to the fragment index
+   // to count all peptides that contain each fragment peak.
+   for (auto it2 = pQuery->vfRawFragmentPeakMass.begin();
+      it2 != pQuery->vfRawFragmentPeakMass.end(); ++it2)
+   {
+      for (int iChg = 1; iChg <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++iChg)
+      {
+         uiFragmentMass = BIN((*it2) * iChg - (iChg - 1.0));
+
+         if (uiFragmentMass < g_massRange.uiMaxFragmentArrayIndex)
+         {
+            lNumPeps = (size_t)g_iCountFragmentIndex[uiFragmentMass];
+
+            if (lNumPeps > 0)
+            {
+               size_t iFirst;
+
+               if (lNumPeps <= BINARYSEARCHCUTOFF)
+                  iFirst = 0;
+               else
+               {
+                  iFirst = BinarySearchIndexMass(0, lNumPeps,
+                     pQuery->_pepMassInfo.dPeptideMassToleranceMinus, &uiFragmentMass);
+               }
+
+               for (size_t ix = iFirst; ix < lNumPeps; ++ix)
+               {
+                  int iTmp = g_iFragmentIndex[uiFragmentMass][ix];
+                  double dCalcPepMass = g_vFragmentPeptides[iTmp].dPepMass;
+
+                  if (dCalcPepMass >= pQuery->_pepMassInfo.dPeptideMassToleranceMinus
+                     && dCalcPepMass <= pQuery->_pepMassInfo.dPeptideMassTolerancePlus)
+                  {
+                     if (CheckMassMatch(pQuery, dCalcPepMass))
+                        mPeptides[g_iFragmentIndex[uiFragmentMass][ix]] += 1;
+                  }
+                  else if (dCalcPepMass > pQuery->_pepMassInfo.dPeptideMassTolerancePlus)
+                     break;
+               }
+            }
+         }
+      }
+   }
+
+   // copy mPeptides map to a vector of pairs and sort in
+   // descending order of matched fragment ions
+   std::vector<std::pair<comet_fileoffset_t, int>> vPeptides;
+   for (auto ix = mPeptides.begin(); ix != mPeptides.end(); ++ix)
+   {
+      if (ix->second >= g_staticParams.options.iFragIndexMinIonsScore)
+         vPeptides.push_back(*ix);
+   }
+
+   mPeptides.clear();
+   sort(vPeptides.begin(), vPeptides.end(), [=](const std::pair<comet_fileoffset_t, int>& a, const std::pair<comet_fileoffset_t, int>& b) { return a.second > b.second; });
+
+   int iLenPeptide;
+   int iWhichIonSeries;
+   int ctCharge;
+   int ctIonSeries;
+   int ctLen;
+   int iLenMinus1;
+   char szPeptide[MAX_PEPTIDE_LEN];
+   int piVarModSites[MAX_PEPTIDE_LEN_P2];
+   int iPositionNLB[FRAGINDEX_VMODS];
+   int iPositionNLY[FRAGINDEX_VMODS];
+   int iCountNLB[FRAGINDEX_VMODS][MAX_PEPTIDE_LEN];
+   int iCountNLY[FRAGINDEX_VMODS][MAX_PEPTIDE_LEN];
+   int iStartPos = 0;
+   int iEndPos = 0;
+   unsigned int uiNumScored = 0;
+
+   for (auto ix = vPeptides.begin(); ix != vPeptides.end(); ++ix)
+   {
+      if (ix->second >= g_staticParams.options.iFragIndexMinIonsScore)
+      {
+         int iFoundVariableMod = 0;
+
+         strcpy(szPeptide, g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).sPeptide.c_str());
+         iLenPeptide = (int)strlen(szPeptide);
+
+         ModificationNumber modNum;
+         char* mods = NULL;
+         int modSeqIdx;
+         int modNumIdx = g_vFragmentPeptides[ix->first].modNumIdx;
+         size_t iWhichPeptide = g_vFragmentPeptides[ix->first].iWhichPeptide;
+         string modSeq;
+         double dCalcPepMass = g_vFragmentPeptides[ix->first].dPepMass;
+
+         iEndPos = iLenMinus1 = iLenPeptide - 1;
+
+         memset(piVarModSites, 0, sizeof(int) * (iLenPeptide + 2));
+
+         if (modNumIdx != -1)  // set modified peptide info
+         {
+            modNum = MOD_NUMBERS.at(modNumIdx);
+            mods = modNum.modifications;
+            modSeqIdx = PEPTIDE_MOD_SEQ_IDXS[iWhichPeptide];
+            modSeq = MOD_SEQS.at(modSeqIdx);
+
+            int j = 0;
+            for (int k = 0; k <= iEndPos; ++k)
+            {
+               if (szPeptide[k] == modSeq[j])
+               {
+                  if (mods[j] != -1)
+                  {
+                     piVarModSites[k] = 1 + (int)mods[j];
+                  }
+                  j++;
+               }
+            }
+         }
+
+         double dBion = g_staticParams.precalcMasses.dNtermProton;
+         double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
+
+         // set terminal mods
+         if (g_vFragmentPeptides[ix->first].cNtermMod > -1)
+         {
+            piVarModSites[iLenPeptide] = g_vFragmentPeptides[ix->first].cNtermMod + 1;
+            dBion += g_staticParams.variableModParameters.varModList[g_vFragmentPeptides[ix->first].cNtermMod].dVarModMass;
+            iFoundVariableMod = 1;
+         }
+         if (g_vFragmentPeptides[ix->first].cCtermMod > -1)
+         {
+            piVarModSites[iLenPeptide + 1] = g_vFragmentPeptides[ix->first].cCtermMod + 1;
+            dYion += g_staticParams.variableModParameters.varModList[g_vFragmentPeptides[ix->first].cCtermMod].dVarModMass;
+            iFoundVariableMod = 1;
+         }
+
+         //FIX: set fragment neutral loss correctly
+         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+         {
+            memset(iCountNLB, 0, sizeof(iCountNLB));
+            memset(iCountNLY, 0, sizeof(iCountNLY));
+
+            for (int i = 0; i < FRAGINDEX_VMODS; ++i)
+            {
+               iPositionNLB[i] = 999;    // default to greater than last residue position
+               iPositionNLY[i] = -1;     // default to less that first residue position
+            }
+         }
+
+         // Generate pdAAforward for szPeptide
+         for (int i = 0; i < iLenMinus1; ++i)
+         {
+            int iPosForward = i;
+            int iPosReverse = iLenMinus1 - i;
+
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+            {
+               if (i > iStartPos)
+               {
+                  for (int x = 0; x < FRAGINDEX_VMODS; ++x)
+                  {
+                     iCountNLB[x][iPosForward] = iCountNLB[x][iPosForward - 1];
+                     iCountNLY[x][iPosForward] = iCountNLY[x][iPosForward - 1];
+                  }
+               }
+            }
+
+            dBion += g_staticParams.massUtility.pdAAMassFragment[(int)szPeptide[i]];
+
+            if (piVarModSites[iPosForward] > 0)
+            {
+               int iMod = piVarModSites[iPosForward] - 1;
+
+               dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosForward] - 1].dVarModMass;
+
+               iFoundVariableMod = 1;
+
+               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+               {
+                  iFoundVariableMod = 2;
+
+                  if (iPositionNLB[iMod] == 999)
+                     iPositionNLB[iMod] = iPosForward;
+
+                  if (g_staticParams.options.bScaleFragmentNL)
+                     iCountNLB[iMod][iPosForward] += 1;
+                  else
+                     iCountNLB[iMod][iPosForward] = 1;
+               }
+            }
+
+            dYion += g_staticParams.massUtility.pdAAMassFragment[(int)szPeptide[iPosReverse]];
+            if (piVarModSites[iPosReverse] > 0)
+            {
+               int iPosReverseModSite = iPosReverse;
+
+               int iMod = piVarModSites[iPosReverseModSite] - 1;
+
+               dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosReverse] - 1].dVarModMass;
+
+               iFoundVariableMod = 1;
+
+               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
+                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+               {
+                  iFoundVariableMod = 2;
+
+                  if (iPositionNLY[iMod] == -1)
+                     iPositionNLY[iMod] = iPosReverseModSite;
+
+                  if (g_staticParams.options.bScaleFragmentNL)
+                     iCountNLY[iMod][iPosForward] += 1;
+                  else
+                     iCountNLY[iMod][iPosForward] = 1;
+               }
+            }
+
+            pdAAforward[iPosForward] = dBion;
+            pdAAreverse[iPosForward] = dYion;
+         }
+
+         int iMaxFragmentCharge = pQuery->_spectrumInfoInternal.usiMaxFragCharge;
+         if (iMaxFragmentCharge > 2)   // only use up to 2+ fragments for the fragment index query
+            iMaxFragmentCharge = 2;
+
+         // Now get the set of binned fragment ions once to compare this peptide against all matching spectra.
+         // First initialize pbDuplFragment and uiBinnedIonMasses
+
+         memset(pbDuplFragment, 0, sizeof(bool) * g_staticParams.iArraySizeGlobal);
+         memset(uiBinnedIonMasses, 0, sizeof(uiBinnedIonMasses));
+         if (g_staticParams.iPrecursorNLSize > 0)
+            memset(uiBinnedPrecursorNL, 0, sizeof(uiBinnedPrecursorNL));
+
+         // set pbDuplFragment[bin] to true for each fragment ion bin
+         for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+         {
+            for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
+            {
+               iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
+
+               for (ctLen = 0; ctLen < iLenMinus1; ++ctLen)
+               {
+                  double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, pdAAforward, pdAAreverse);
+                  int iVal = BIN(dFragMass);
+
+                  if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+                  {
+                     uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
+                     pbDuplFragment[iVal] = true;
+
+                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                     {
+                        for (int x = 0; x < FRAGINDEX_VMODS; ++x)
+                        {
+                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                           {
+                              if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
+                                 continue;
+                              else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
+                                 continue;
+
+                              if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])
+                                 || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x]))
+                              {
+                                 int iScaleFactor;
+
+                                 if (iWhichIonSeries <= 2)
+                                    iScaleFactor = iCountNLB[x][ctLen];
+                                 else
+                                    iScaleFactor = iCountNLY[x][ctLen];
+
+                                 double dNewMass;
+
+                                 if (iWhichNL == 0)
+                                    dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
+                                 else
+                                    dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
+
+                                 if (dNewMass >= 0.0)
+                                 {
+                                    iVal = BIN(dNewMass);
+
+                                    if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
+                                    {
+                                       uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
+                                       pbDuplFragment[iVal] = true;
+                                       iFoundVariableMod = 2;
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+
+         struct sDBEntry dbe;
+
+         char cPrevAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cPrevAA;
+         char cNextAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cNextAA;
+         char szProtein[MAX_PEPTIDE_LEN_P2];
+         if (cPrevAA == '-')
+         {
+            iStartPos = 0;
+            strcpy(szProtein, szPeptide);
+         }
+         else
+         {
+            iStartPos = 1;
+            sprintf(szProtein, "%c%s", cPrevAA, szPeptide);
+         }
+         if (cNextAA == '-')
+         {
+            iEndPos = strlen(szProtein) - 1;
+         }
+         else
+         {
+            sprintf(szProtein, "%s%c", szProtein, cNextAA);
+            iEndPos = strlen(szProtein) - 2;
+         }
+
+         dbe.strName = "";
+         dbe.strSeq = szProtein;
+         dbe.lProteinFilePosition = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).lIndexProteinFilePosition;
+
+         XcorrScoreI(szProtein, iStartPos, iEndPos, iFoundVariableMod, dCalcPepMass, false, pQuery,
+            iLenPeptide, piVarModSites, &dbe, uiBinnedIonMasses, uiBinnedPrecursorNL, ix->second);
+
+         uiNumScored++;
+         if (uiNumScored >= FRAGINDEX_MAX_NUMSCORED)
+            break;
+      }
+   }
+}
+
+
 bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
 {
    comet_fileoffset_t lEndOfStruct;
    char szBuf[SIZE_BUF];
-   FILE *fp;
+   FILE* fp;
    size_t tTmp;
 
    CometPostAnalysis cpa;
@@ -1783,14 +2243,14 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
                iss >> subStr;  // parse each word which is a colon delimited triplet pair for modmass:neutralloss:modchars
                std::replace(subStr.begin(), subStr.end(), ':', ' ');
                int iRet = sscanf(subStr.c_str(), "%s %lf %lf %lf",
-                     g_staticParams.variableModParameters.varModList[iNumMods].szVarModChar,
-                     &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
-                     &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss),
-                     &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss2));
+                  g_staticParams.variableModParameters.varModList[iNumMods].szVarModChar,
+                  &(g_staticParams.variableModParameters.varModList[iNumMods].dVarModMass),
+                  &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss),
+                  &(g_staticParams.variableModParameters.varModList[iNumMods].dNeutralLoss2));
 
                if (iRet != 4)
                {
-                  string strErrorMsg =  " Error parsing mod entry: " + subStr + ".\n";
+                  string strErrorMsg = " Error parsing mod entry: " + subStr + ".\n";
                   logerr(strErrorMsg);
                   std::fclose(fp);
                   return false;
@@ -1826,9 +2286,9 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
       {
          static CometSearchManager g_cometSearchManager;            // (or use an existing instance if available)
          g_cometSearchManager.SetAScoreOptions(g_AScoreOptions);    // Call as a member function
-//       g_cometSearchManager.PrintAScoreOptions(g_AScoreOptions);  // Call as a member function
+         //       g_cometSearchManager.PrintAScoreOptions(g_AScoreOptions);  // Call as a member function
 
-         // Create the AScoreDllInterface using the factory function
+                  // Create the AScoreDllInterface using the factory function
          g_AScoreInterface = CreateAScoreDllInterface();
          if (!g_AScoreInterface)
          {
@@ -1919,13 +2379,13 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
    if (iEnd > iMaxMass)
       iEnd = iMaxMass;
 
-   int iStart10 = (int)(g_massRange.dMinMass*10.0 - 0.5);  // lReadIndex is at 0.1 resolution for index value so scale iStart/iEnd to be same
-   int iEnd10 = (int)(g_massRange.dMaxMass*10.0 + 0.5);
+   int iStart10 = (int)(g_massRange.dMinMass * 10.0 - 0.5);  // lReadIndex is at 0.1 resolution for index value so scale iStart/iEnd to be same
+   int iEnd10 = (int)(g_massRange.dMaxMass * 10.0 + 0.5);
 
-   if (iStart10 < iMinMass*10)
-      iStart10 = iMinMass*10;
-   if (iEnd10 > iMaxMass*10)
-      iEnd10 = iMaxMass*10;
+   if (iStart10 < iMinMass * 10)
+      iStart10 = iMinMass * 10;
+   if (iEnd10 > iMaxMass * 10)
+      iEnd10 = iMaxMass * 10;
 
    struct DBIndex sDBI;
    sDBEntry dbe;
@@ -1951,19 +2411,19 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
 
    while ((int)(sDBI.dPepMass * 10) <= iEnd10)
    {
-/*
-      printf("OK index pep ");
-      for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
-      {
-         printf("%c", sDBI.szPeptide[x]);
-         if (sDBI.pcVarModSites[x] != 0)
-            printf("[%0.3f]", g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[x]-1].dVarModMass);
-      }
-      printf(", mass %f, ", sDBI.dPepMass); fflush(stdout);
-      for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
-         printf("%d", sDBI.pcVarModSites[x]);
-      printf(", prot %ld\n", sDBI.lIndexProteinFilePosition);
-*/
+      /*
+            printf("OK index pep ");
+            for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
+            {
+               printf("%c", sDBI.szPeptide[x]);
+               if (sDBI.pcVarModSites[x] != 0)
+                  printf("[%0.3f]", g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[x]-1].dVarModMass);
+            }
+            printf(", mass %f, ", sDBI.dPepMass); fflush(stdout);
+            for (unsigned int x=0; x<strlen(sDBI.szPeptide); x++)
+               printf("%d", sDBI.pcVarModSites[x]);
+            printf(", prot %ld\n", sDBI.lIndexProteinFilePosition);
+      */
 
       if (sDBI.dPepMass > g_massRange.dMaxMass)
          break;
@@ -1997,27 +2457,27 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
       }
    }
 
-/*
-   for (vector<Query*>::iterator it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
-   {
-      int iNumMatchedPeptides = (*it)->iMatchPeptideCount;
-      if (iNumMatchedPeptides > g_staticParams.options.iNumStored)
-         iNumMatchedPeptides = g_staticParams.options.iNumStored;
-
-      for (int x = 0; x < iNumMatchedPeptides; x++)
+   /*
+      for (vector<Query*>::iterator it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
       {
-         printf("OK %d scan %d, pep %s, xcorr %f, mass %f, matchcount %d, prot %s\n", x,
-            (*it)->_spectrumInfoInternal.iScanNumber,
-            (*it)->_pResults[x].szPeptide,
-            (*it)->_pResults[x].fXcorr,
-            (*it)->_pResults[x].dPepMass,
-            (*it)->iMatchPeptideCount,
-            (*it)->_pResults[x].strSingleSearchProtein.c_str()); fflush(stdout);
-      }
-   }
-*/
+         int iNumMatchedPeptides = (*it)->iMatchPeptideCount;
+         if (iNumMatchedPeptides > g_staticParams.options.iNumStored)
+            iNumMatchedPeptides = g_staticParams.options.iNumStored;
 
-   delete [] lReadIndex;
+         for (int x = 0; x < iNumMatchedPeptides; x++)
+         {
+            printf("OK %d scan %d, pep %s, xcorr %f, mass %f, matchcount %d, prot %s\n", x,
+               (*it)->_spectrumInfoInternal.iScanNumber,
+               (*it)->_pResults[x].szPeptide,
+               (*it)->_pResults[x].fXcorr,
+               (*it)->_pResults[x].dPepMass,
+               (*it)->iMatchPeptideCount,
+               (*it)->_pResults[x].strSingleSearchProtein.c_str()); fflush(stdout);
+         }
+      }
+   */
+
+   delete[] lReadIndex;
    std::fclose(fp);
    return true;
 }
@@ -2025,8 +2485,8 @@ bool CometSearch::SearchPeptideIndex(ThreadPool* tp)
 
 void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                                       DBIndex sDBI,
-                                      bool *pbDuplFragment,
-                                      struct sDBEntry *dbe)
+                                      bool* pbDuplFragment,
+                                      struct sDBEntry* dbe)
 {
    int iWhichIonSeries;
    int ctIonSeries;
@@ -2053,13 +2513,13 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
    {
       int i;
 
-      for (i=0; i<VMODS; i++)
+      for (i = 0; i < VMODS; i++)
       {
          iPositionNLB[i] = 999;    // default to greater than last residue position
          iPositionNLY[i] = -1;     // default to less that first residue position
       }
 
-      for (i=0; i<iEndPos; i++)
+      for (i = 0; i < iEndPos; i++)
       {
          if (sDBI.pcVarModSites[i] > 0)
          {
@@ -2071,7 +2531,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          }
       }
 
-      for (i=iEndPos; i>=0; i--)
+      for (i = iEndPos; i >= 0; i--)
       {
          if (sDBI.pcVarModSites[i] > 0)
          {
@@ -2115,12 +2575,12 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
             double dBion = g_staticParams.precalcMasses.dNtermProton;
             double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
 
-/* n/c-term protein mods not supported
-            if (iStartPos == 0)
-               dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-            if (iEndPos == iLenProteinMinus1)
-               dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-*/
+            /* n/c-term protein mods not supported
+                        if (iStartPos == 0)
+                           dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+                        if (iEndPos == iLenProteinMinus1)
+                           dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+            */
 
             // variable N-term peptide mod
             if (piVarModSites[iLenPeptide] > 0)
@@ -2137,7 +2597,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
             }
 
             // Generate pdAAforward for sDBI.szPeptide
-            for (int i=iStartPos; i<iEndPos; i++)
+            for (int i = iStartPos; i < iEndPos; i++)
             {
                int iPos = i - iStartPos;
                int iPos2 = iEndPos - i + iStartPos;
@@ -2145,14 +2605,14 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[i]];
                if (piVarModSites[iPos] > 0)
                {
-                  dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos]-1].dVarModMass;
+                  dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos] - 1].dVarModMass;
                   iFoundVariableMod = 1;
                }
 
                dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[iPos2]];
                if (piVarModSites[iPos2] > 0)
                {
-                  dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos2]-1].dVarModMass;
+                  dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos2] - 1].dVarModMass;
                   iFoundVariableMod = 1;
                }
 
@@ -2162,13 +2622,13 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
             // Now get the set of binned fragment ions once to compare this peptide against all matching spectra.
             // First initialize pbDuplFragment and _uiBinnedIonMasses
-            for (ctCharge=1; ctCharge<=g_massRange.usiMaxFragmentCharge; ctCharge++)
+            for (ctCharge = 1; ctCharge <= g_massRange.usiMaxFragmentCharge; ctCharge++)
             {
-               for (ctIonSeries=0; ctIonSeries<g_staticParams.ionInformation.iNumIonSeriesUsed; ctIonSeries++)
+               for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ctIonSeries++)
                {
                   iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
 
-                  for (ctLen=0; ctLen<iLenMinus1; ctLen++)
+                  for (ctLen = 0; ctLen < iLenMinus1; ctLen++)
                   {
                      double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse);
 
@@ -2182,7 +2642,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                         // initialize fragmentNL
                         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                         {
-                           for (int x=0; x<VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
+                           for (int x = 0; x < VMODS; x++)  // should be within this if() because only looking for NL masses from each mod
                            {
                               for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                               {
@@ -2192,14 +2652,14 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                                     continue;
 
                                  if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
                                     double dNewMass;
 
                                     if (iWhichNL == 0)
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss/ctCharge;
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
                                     else
-                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2/ctCharge;
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
 
                                     iVal = BIN(dNewMass);
 
@@ -2218,11 +2678,11 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                }
             }
 
-            for (int ctNL=0; ctNL<g_staticParams.iPrecursorNLSize; ctNL++)
+            for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ctNL++)
             {
-               for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+               for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                {
-                  double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                  double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                   int iVal = BIN(dNLMass);
 
                   if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
@@ -2233,15 +2693,15 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                }
             }
 
-            for (ctCharge=1; ctCharge<=g_massRange.usiMaxFragmentCharge; ctCharge++)
+            for (ctCharge = 1; ctCharge <= g_massRange.usiMaxFragmentCharge; ctCharge++)
             {
-               for (ctIonSeries=0; ctIonSeries<g_staticParams.ionInformation.iNumIonSeriesUsed; ctIonSeries++)
+               for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ctIonSeries++)
                {
                   iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
 
                   // As both _pdAAforward and _pdAAreverse are increasing, loop through
                   // iLenPeptide-1 to complete set of internal fragment ions.
-                  for (ctLen=0; ctLen<iLenMinus1; ctLen++)
+                  for (ctLen = 0; ctLen < iLenMinus1; ctLen++)
                   {
                      double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, _pdAAforward, _pdAAreverse);
                      int iVal = BIN(dFragMass);
@@ -2253,7 +2713,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
                         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                         {
-                           for (int x=0; x<VMODS; x++)
+                           for (int x = 0; x < VMODS; x++)
                            {
                               for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                               {
@@ -2263,14 +2723,14 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                                     continue;
 
                                  if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
                                     double dNewMass;
 
                                     if (iWhichNL == 0)
-                                      dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss/ctCharge;
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
                                     else
-                                      dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2/ctCharge;
+                                       dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
 
                                     iVal = BIN(dNewMass);
 
@@ -2293,7 +2753,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
             {
                for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                {
-                  double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                  double dNLMass = (sDBI.dPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                   int iVal = BIN(dNLMass);
 
                   if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
@@ -2341,13 +2801,13 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                dBion = g_staticParams.precalcMasses.dNtermProton;
                dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
 
-/* n/c-term protein mods not supported
-               // use same protein terminal static mods as target peptide
-               if (_varModInfo.iStartPos == 0)
-                  dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-               if (_varModInfo.iEndPos == iLenProteinMinus1)
-                  dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-*/
+               /* n/c-term protein mods not supported
+                              // use same protein terminal static mods as target peptide
+                              if (_varModInfo.iStartPos == 0)
+                                 dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+                              if (_varModInfo.iEndPos == iLenProteinMinus1)
+                                 dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+               */
 
                // variable N-term
                if (piVarModSitesDecoy[iLenPeptide] > 0)
@@ -2416,7 +2876,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                                        continue;
 
                                     if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
                                        double dNewMass;
 
@@ -2486,10 +2946,10 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                                        continue;
 
                                     if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
                                        double dNewMass;
- 
+
                                        if (iWhichNL == 0)
                                           dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
                                        else
@@ -2625,9 +3085,9 @@ void CometSearch::SearchMS1Library(size_t iWhichMS1Query,
 // iNtermPeptideOnly==2 specifies clipped methionine sequence due to the
 //                      PEFF variant becoming the clipped methionine
 bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
-                                    char *szProteinSeq,
-                                    int iNtermPeptideOnly,
-                                    bool *pbDuplFragment)
+   char* szProteinSeq,
+   int iNtermPeptideOnly,
+   bool* pbDuplFragment)
 {
    int iLenPeptide = 0;
    int iLenProtein;
@@ -2651,7 +3111,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
    int iPeffRequiredVariantPositionB = _proteinInfo.iPeffOrigResiduePosition + _proteinInfo.iPeffNewResidueCount;
 
    // if not a deletion, adjust the position by 1
-   if (_proteinInfo.iPeffNewResidueCount>0)
+   if (_proteinInfo.iPeffNewResidueCount > 0)
       iPeffRequiredVariantPositionB--;
 
    // Edge case where PEFF variant is simply a truncation of the c-terminal amino acids
@@ -2672,7 +3132,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
       sort(dbe.vectorPeffVariantSimple.begin(), dbe.vectorPeffVariantSimple.end());
 
    if (dbe.vectorPeffVariantComplex.size() > 0) // sort peffVariantComplexStruct by iPositionA
-     sort(dbe.vectorPeffVariantComplex.begin(), dbe.vectorPeffVariantComplex.end());
+      sort(dbe.vectorPeffVariantComplex.begin(), dbe.vectorPeffVariantComplex.end());
 
    memset(piVarModCounts, 0, sizeof(piVarModCounts));
 
@@ -2722,19 +3182,19 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
       }
    }
 
-/*
-   printf("\nOK prot %s, ", dbe.strName.c_str());
-   for (int i = 0; i < FRAGINDEX_VMODS; ++i)
-   {
-      printf("%d", pbVarModProteinFilter[i]);
-   }
-   printf("  ");
-   for (int i = 0; i < FRAGINDEX_VMODS; ++i)
-   {
-      printf("%d", cometbitcheck(siVarModProteinFilter, i)==0?0:1);
-   }
-   printf("\n");
-*/
+   /*
+      printf("\nOK prot %s, ", dbe.strName.c_str());
+      for (int i = 0; i < FRAGINDEX_VMODS; ++i)
+      {
+         printf("%d", pbVarModProteinFilter[i]);
+      }
+      printf("  ");
+      for (int i = 0; i < FRAGINDEX_VMODS; ++i)
+      {
+         printf("%d", cometbitcheck(siVarModProteinFilter, i)==0?0:1);
+      }
+      printf("\n");
+   */
 
    // Quick clip n-term & PEFF variant check. Start summing amino acid mass at
    // the start variant position and work backwards.  If the mass is larger than
@@ -2747,7 +3207,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
    // If iNtermPeptideOnly==2 then we want to skip this if() and continue analyzing
    // the first peptide as this denotes variant was substituted to first M which
    // was clipped off.
-   if (iNtermPeptideOnly==1 && iPeffRequiredVariantPosition >= 0)
+   if (iNtermPeptideOnly == 1 && iPeffRequiredVariantPosition >= 0)
    {
       double dMass;
 
@@ -2773,7 +3233,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
          return true;
    }
 
-   iProteinSeqLengthMinus1 = iLenProtein-1;
+   iProteinSeqLengthMinus1 = iLenProtein - 1;
 
    iEndPos = iStartPos;
 
@@ -2797,21 +3257,21 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
    while (iStartPos < iLenProtein)
    {
       // Check to see if peptide is within global min/mass range for all queries.
-      iLenPeptide = iEndPos-iStartPos+1;
+      iLenPeptide = iEndPos - iStartPos + 1;
 
       if (iLenPeptide <= g_staticParams.options.peptideLengthRange.iEnd)
       {
          if ((g_staticParams.options.bCreatePeptideIndex && !g_staticParams.variableModParameters.iRequireVarMod)
-               || g_staticParams.options.bCreateFragmentIndex)
+            || g_staticParams.options.bCreateFragmentIndex)
          {
             int iPepLen = iEndPos - iStartPos + 1;
 
             // ignore mass check here for indexing; modifications added later
             // could put peptide into mass range so just use peptide length
             if (iPepLen >= g_staticParams.options.peptideLengthRange.iStart
-                && iPepLen <= g_staticParams.options.peptideLengthRange.iEnd
-                && CheckEnzymeTermini(szProteinSeq, iStartPos, iEndPos)
-                && dCalcPepMass < g_massRange.dMaxMass)
+               && iPepLen <= g_staticParams.options.peptideLengthRange.iEnd
+               && CheckEnzymeTermini(szProteinSeq, iStartPos, iEndPos)
+               && dCalcPepMass < g_massRange.dMaxMass)
             {
                Threading::LockMutex(g_pvDBIndexMutex);
 
@@ -2820,7 +3280,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                sEntry.dPepMass = dCalcPepMass;  //MH+ mass
 
                strncpy(sEntry.szPeptide, szProteinSeq + iStartPos, iLenPeptide);
-               sEntry.szPeptide[iLenPeptide]='\0';
+               sEntry.szPeptide[iLenPeptide] = '\0';
                sEntry.cPrevAA = (iStartPos > 0) ? szProteinSeq[iStartPos - 1] : '-';
                sEntry.cNextAA = (iEndPos < iProteinSeqLengthMinus1) ? szProteinSeq[iEndPos + 1] : '-';
                sEntry.siVarModProteinFilter = siVarModProteinFilter;
@@ -2833,7 +3293,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                   memset(sEntry.pcVarModSites, 0, sizeof(char) * (iLenPeptide + 2));
 
                   if (g_staticParams.options.bCreateFragmentIndex
-                        || (g_staticParams.options.bCreatePeptideIndex && dCalcPepMass >= g_massRange.dMinMass && dCalcPepMass <= g_massRange.dMaxMass))
+                     || (g_staticParams.options.bCreatePeptideIndex && dCalcPepMass >= g_massRange.dMinMass && dCalcPepMass <= g_massRange.dMaxMass))
                   {
                      try
                      {
@@ -2892,7 +3352,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                            // With trypsin as example, preceding residue changed to '*':  S.LSTR.C to *.LSTR.C
                            // Know new end termini is already cleavage site so see if orig residue was K or R (not followed by P)
                            // Just want to make sure change to * will generate a new cleavage site that wouldn't otherwise exist
-                           if (szProteinSeq[iStartPos-1] == '*')
+                           if (szProteinSeq[iStartPos - 1] == '*')
                            {
                               //if (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, _proteinInfo.cPeffOrigResidue))
                               if (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, _proteinInfo.sPeffOrigResidues[0]))
@@ -2939,11 +3399,11 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                            {
                               bPass = true;
                            }
-                        
+
                            // A substitution to '*' at iEndPos+1 will always create a cleavage site. Just need to confirm
                            // original sequence wasn't already cleavage site before this substitution in order to report.
                            // K.LSTY.* should be reported but not K.LSTK.* unless orig flanking residue was a P
-                           else if (szProteinSeq[iEndPos+1] == '*')
+                           else if (szProteinSeq[iEndPos + 1] == '*')
                            {
                               if (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iEndPos]))
                               {
@@ -2964,7 +3424,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                               bPass = true;
                            }
                            // Do not want L.DSTC.D to L.DSTC.* to be reported unless last residue in pep is NoBreakAA
-                           else if (szProteinSeq[iEndPos+1] == '*')
+                           else if (szProteinSeq[iEndPos + 1] == '*')
                            {
                               //if (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, _proteinInfo.cPeffOrigResidue))
                               if (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, _proteinInfo.sPeffOrigResidues[0]))
@@ -3021,7 +3481,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                            iPosForward = i - iStartPos;
                            iPosReverse = iEndPos - iPosForward;
 
-                           if (i<iEndPos)
+                           if (i < iEndPos)
                            {
                               dBion += g_staticParams.massUtility.pdAAMassFragment[(int)szProteinSeq[i]];
                               _pdAAforward[iPosForward] = dBion;
@@ -3098,9 +3558,9 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                         // Precursor NL peaks added here
                         for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
                         {
-                           for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+                           for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                            {
-                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                               int iVal = BIN(dNLMass);
 
                               if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
@@ -3113,10 +3573,10 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                      }
 
                      if (bFirstTimeThroughLoopForPeptide)
-                         bFirstTimeThroughLoopForPeptide = false;
+                        bFirstTimeThroughLoopForPeptide = false;
 
                      XcorrScore(szProteinSeq, iStartPos, iEndPos, iStartPos, iEndPos, iFoundVariableMod,
-                           dCalcPepMass, false, iWhichQuery, iLenPeptide, piVarModSites, &dbe);
+                        dCalcPepMass, false, iWhichQuery, iLenPeptide, piVarModSites, &dbe);
 
                      // Also take care of decoy here.
                      if (g_staticParams.options.iDecoySearch)
@@ -3130,32 +3590,32 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                         double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
 
                         // Store flanking residues from original sequence.
-                        if (iStartPos==0)
-                           szDecoyPeptide[0]='-';
+                        if (iStartPos == 0)
+                           szDecoyPeptide[0] = '-';
                         else
-                           szDecoyPeptide[0]=szProteinSeq[iStartPos-1];
+                           szDecoyPeptide[0] = szProteinSeq[iStartPos - 1];
 
                         if (iEndPos == iProteinSeqLengthMinus1)
-                           szDecoyPeptide[iLenPeptide+1]='-';
+                           szDecoyPeptide[iLenPeptide + 1] = '-';
                         else
-                           szDecoyPeptide[iLenPeptide+1]=szProteinSeq[iEndPos+1];
-                        szDecoyPeptide[iLenPeptide+2]='\0';
+                           szDecoyPeptide[iLenPeptide + 1] = szProteinSeq[iEndPos + 1];
+                        szDecoyPeptide[iLenPeptide + 2] = '\0';
 
-                        if (g_staticParams.enzymeInformation.iSearchEnzymeOffSet==1)
+                        if (g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 1)
                         {
                            // Last residue stays the same:  change ABCDEK to EDCBAK.
-                           for (i=iEndPos-1; i>=iStartPos; i--)
-                              szDecoyPeptide[iEndPos-i] = szProteinSeq[i];
+                           for (i = iEndPos - 1; i >= iStartPos; i--)
+                              szDecoyPeptide[iEndPos - i] = szProteinSeq[i];
 
-                           szDecoyPeptide[iEndPos-iStartPos+1]=szProteinSeq[iEndPos];  // Last residue stays same.
+                           szDecoyPeptide[iEndPos - iStartPos + 1] = szProteinSeq[iEndPos];  // Last residue stays same.
                         }
                         else
                         {
                            // First residue stays the same:  change ABCDEK to AKEDCB.
-                           for (i=iEndPos; i>=iStartPos+1; i--)
-                              szDecoyPeptide[iEndPos-i+2] = szProteinSeq[i];
+                           for (i = iEndPos; i >= iStartPos + 1; i--)
+                              szDecoyPeptide[iEndPos - i + 2] = szProteinSeq[i];
 
-                           szDecoyPeptide[1]=szProteinSeq[iStartPos];  // First residue stays same.
+                           szDecoyPeptide[1] = szProteinSeq[iStartPos];  // First residue stays same.
                         }
 
                         // Now given szDecoyPeptide, calculate pdAAforwardDecoy and pdAAreverseDecoy.
@@ -3173,7 +3633,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                         int iPosReverse;
 
                         iDecoyStartPos = 1;
-                        iDecoyEndPos = (int)strlen(szDecoyPeptide)-2;
+                        iDecoyEndPos = (int)strlen(szDecoyPeptide) - 2;
 
                         for (i = iDecoyStartPos; i < iDecoyEndPos; ++i)
                         {
@@ -3210,9 +3670,9 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 
                         for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
                         {
-                           for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+                           for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                            {
-                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                               int iVal = BIN(dNLMass);
 
                               if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
@@ -3251,9 +3711,9 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                         // Precursor NL peaks added here
                         for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
                         {
-                           for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+                           for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                            {
-                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                              double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                               int iVal = BIN(dNLMass);
 
                               if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
@@ -3265,7 +3725,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                         }
 
                         XcorrScore(szDecoyPeptide, iStartPos, iEndPos, 1, iLenPeptide, iFoundVariableModDecoy,
-                              dCalcPepMass, true, iWhichQuery, iLenPeptide, piVarModSites, &dbe);
+                           dCalcPepMass, true, iWhichQuery, iLenPeptide, piVarModSites, &dbe);
                      }
                   }
                   iWhichQuery++;
@@ -3291,7 +3751,7 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
          }
       }
       // Increment start, reset end.
-      else if (dCalcPepMass > g_massRange.dMaxMass || iEndPos==iProteinSeqLengthMinus1 || iLenPeptide == g_staticParams.options.peptideLengthRange.iEnd)
+      else if (dCalcPepMass > g_massRange.dMaxMass || iEndPos == iProteinSeqLengthMinus1 || iLenPeptide == g_staticParams.options.peptideLengthRange.iEnd)
       {
          // Run variable mod search before incrementing iStartPos.
          if (g_staticParams.variableModParameters.bVarModSearch && !g_staticParams.options.bCreateFragmentIndex)
@@ -3336,11 +3796,11 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
          iStartPos++;          // Increment start of peptide.
 
          // Skip any more processing because outside of range of variant
-         if (iPeffRequiredVariantPosition>=0 && iStartPos > iPeffRequiredVariantPositionB+1)
+         if (iPeffRequiredVariantPosition >= 0 && iStartPos > iPeffRequiredVariantPositionB + 1)
             return true;
 
          if (g_massRange.bNarrowMassRange)
-         {  
+         {
             // Peptide is still potentially larger than input mass so need to delete AA from the end.
             while (dCalcPepMass >= g_massRange.dMinMass && iEndPos > iStartPos)
             {
@@ -3378,8 +3838,8 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
 // Each analyzed peptide must either contain the variant or be flanked
 // by the variant enabling new enzyme-digested peptide
 void CometSearch::SearchForVariants(struct sDBEntry dbe,
-                                    char *szProteinSeq,
-                                    bool *pbDuplFragment)
+   char* szProteinSeq,
+   bool* pbDuplFragment)
 
 {
    int iLen = (int)strlen(szProteinSeq);
@@ -3401,7 +3861,7 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
             {
                // Log a warning message here that the variant change didn't change the residue?
                string strErrorMsg = " Warning: protein " + dbe.strName + " has variant '" + std::to_string(cResidue)
-                     + "' at position " + std::to_string(iPosition) + " with the same original AA residue.\n";
+                  + "' at position " + std::to_string(iPosition) + " with the same original AA residue.\n";
                logout(strErrorMsg);
             }
          }
@@ -3409,7 +3869,7 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
          {
             char cOrigResidue;
 
-            cOrigResidue  = szProteinSeq[iPosition];
+            cOrigResidue = szProteinSeq[iPosition];
 
             // Place variant in protein
             szProteinSeq[iPosition] = cResidue;
@@ -3462,26 +3922,26 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
          // capture the original sequence being removed/changed
          string sOriginalResidues;
          for (int a = iPositionA; a <= iPositionB; ++a)
-            sOriginalResidues+=szProteinSeq[a];
-  
+            sOriginalResidues += szProteinSeq[a];
+
          // make sure there's an actual AA change
-         if (sResidues.compare(sOriginalResidues)==0)
+         if (sResidues.compare(sOriginalResidues) == 0)
          {
             if (g_staticParams.options.bVerboseOutput)
             {
                // Log a warning message here that the variant change didn't change the residue?
                string strErrorMsg = " Warning: protein " + dbe.strName + " has variant '" + sResidues
-                     + "' between positions " + std::to_string(iPositionA) + "and " + std::to_string(iPositionB) + " with the same original AA residue(s).\n";
+                  + "' between positions " + std::to_string(iPositionA) + "and " + std::to_string(iPositionB) + " with the same original AA residue(s).\n";
                logout(strErrorMsg);
             }
          }
          else
          {
             // Place variant in protein
-            string sVariantSeq = dbe.strSeq.substr(0,iPositionA);
+            string sVariantSeq = dbe.strSeq.substr(0, iPositionA);
             sVariantSeq += sResidues;
             sVariantSeq += dbe.strSeq.substr(iPositionB + 1);
-         
+
             _proteinInfo.iPeffOrigResiduePosition = iPositionA;
             _proteinInfo.sPeffOrigResidues = sOriginalResidues;
             _proteinInfo.iPeffNewResidueCount = (int)sResidues.size();
@@ -3489,7 +3949,7 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
             int iLenChange = (int)sResidues.size() - (int)sOriginalResidues.size();
             _proteinInfo.iTmpProteinSeqLength += iLenChange;
 
-            SearchForPeptides(dbe, (char *)sVariantSeq.c_str(), 0, pbDuplFragment);
+            SearchForPeptides(dbe, (char*)sVariantSeq.c_str(), 0, pbDuplFragment);
 
             if (g_staticParams.options.bClipNtermMet && sVariantSeq[0] == 'M')
             {
@@ -3522,17 +3982,17 @@ void CometSearch::SearchForVariants(struct sDBEntry dbe,
 
 
 int CometSearch::WithinMassTolerance(double dCalcPepMass,
-                                     char* szProteinSeq,
-                                     int iStartPos,
-                                     int iEndPos)
+   char* szProteinSeq,
+   int iStartPos,
+   int iEndPos)
 {
    int iPepLen = iEndPos - iStartPos + 1;
 
    if (dCalcPepMass >= g_massRange.dMinMass
-         && dCalcPepMass <= g_massRange.dMaxMass
-         && iPepLen >= g_staticParams.options.peptideLengthRange.iStart
-         && iPepLen <= g_staticParams.options.peptideLengthRange.iEnd
-         && CheckEnzymeTermini(szProteinSeq, iStartPos, iEndPos))
+      && dCalcPepMass <= g_massRange.dMaxMass
+      && iPepLen >= g_staticParams.options.peptideLengthRange.iStart
+      && iPepLen <= g_staticParams.options.peptideLengthRange.iEnd
+      && CheckEnzymeTermini(szProteinSeq, iStartPos, iEndPos))
    {
       // if creating indexed database, only care of peptide is within global mass range
       if (g_staticParams.options.bCreatePeptideIndex || g_staticParams.options.bCreateFragmentIndex)
@@ -3548,7 +4008,7 @@ int CometSearch::WithinMassTolerance(double dCalcPepMass,
 
       // Seek back to first peptide entry that matches mass tolerance in case binary
       // search doesn't hit the first entry.
-      while (iPos>0 && g_pvQuery.at(iPos)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
+      while (iPos > 0 && g_pvQuery.at(iPos)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
          iPos--;
 
       if (iPos != -1)
@@ -3564,25 +4024,25 @@ int CometSearch::WithinMassTolerance(double dCalcPepMass,
 // This function will return true if unmodified peptide mass + any combination of
 // PEFF mod is within mass tolerance of any peptide query
 bool CometSearch::WithinMassTolerancePeff(double dCalcPepMass,
-                                          vector<PeffPositionStruct>* vPeffArray,
-                                          int iStartPos,
-                                          int iEndPos)
+   vector<PeffPositionStruct>* vPeffArray,
+   int iStartPos,
+   int iEndPos)
 {
    int i;
 
-/*
-   // Print out list of PEFF mods
-   for (i = 0; i < (int)(*vPeffArray).size(); ++i)
-   {
-      printf("*** OK  %d.  position %d\n", i, (*vPeffArray).at(i).iPosition);
-      for (int ii = 0; ii < (int)(*vPeffArray).at(i).vectorWhichPeff.size(); ++ii)
+   /*
+      // Print out list of PEFF mods
+      for (i = 0; i < (int)(*vPeffArray).size(); ++i)
       {
-         printf(" ... %f %f\n",
-               (*vPeffArray).at(i).vectorMassDiffMono.at(ii),
-               (*vPeffArray).at(i).vectorMassDiffAvg.at(ii));
+         printf("*** OK  %d.  position %d\n", i, (*vPeffArray).at(i).iPosition);
+         for (int ii = 0; ii < (int)(*vPeffArray).at(i).vectorWhichPeff.size(); ++ii)
+         {
+            printf(" ... %f %f\n",
+                  (*vPeffArray).at(i).vectorMassDiffMono.at(ii),
+                  (*vPeffArray).at(i).vectorMassDiffAvg.at(ii));
+         }
       }
-   }
-*/
+   */
 
    // number of residues with a PEFF mod
    int n = (int)(*vPeffArray).size();
@@ -3606,11 +4066,11 @@ bool CometSearch::WithinMassTolerancePeff(double dCalcPepMass,
             // of any entry.  If so, simply return true here and will repeat the PEFF permutations later.
 
             // Do a binary search on list of input queries to find matching mass.
-            int iPos=BinarySearchMass(0, (int)g_pvQuery.size(), dCalcPepMass + dMassAddition);
+            int iPos = BinarySearchMass(0, (int)g_pvQuery.size(), dCalcPepMass + dMassAddition);
 
             // Seek back to first peptide entry that matches mass tolerance in case binary
             // search doesn't hit the first entry.
-            while (iPos>0 && g_pvQuery.at(iPos)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
+            while (iPos > 0 && g_pvQuery.at(iPos)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
                iPos--;
 
             if (iPos != -1)
@@ -3625,39 +4085,39 @@ bool CometSearch::WithinMassTolerancePeff(double dCalcPepMass,
 
 // Check enzyme termini.
 bool CometSearch::CheckEnzymeTermini(const char* szProteinSeq,
-                                     int iStartPos,
-                                     int iEndPos) const
+   int iStartPos,
+   int iEndPos) const
 {
    if (!g_staticParams.enzymeInformation.bNoEnzymeSelected || !g_staticParams.enzymeInformation.bNoEnzyme2Selected)
    {
-      bool bBeginCleavage=0;
-      bool bEndCleavage=0;
+      bool bBeginCleavage = 0;
+      bool bEndCleavage = 0;
       bool bBreakPoint;
-      int iCountInternalCleavageSites=0;
+      int iCountInternalCleavageSites = 0;
 
-      bBeginCleavage = (iStartPos==0
-            || szProteinSeq[iStartPos-1]=='*'
-            || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
-               && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
+      bBeginCleavage = (iStartPos == 0
+         || szProteinSeq[iStartPos - 1] == '*'
+         || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
+            && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
 
-      bEndCleavage = (iEndPos==(int)(_proteinInfo.iTmpProteinSeqLength - 1)
-            || szProteinSeq[iEndPos+1]=='*'
-            || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
-               && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
+      bEndCleavage = (iEndPos == (int)(_proteinInfo.iTmpProteinSeqLength - 1)
+         || szProteinSeq[iEndPos + 1] == '*'
+         || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
+            && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
 
       if (!bBeginCleavage && !g_staticParams.enzymeInformation.bNoEnzyme2Selected) // check second enzyme
       {
-         bBeginCleavage = (iStartPos==0
-               || szProteinSeq[iStartPos-1]=='*'
-               || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
-                  && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
+         bBeginCleavage = (iStartPos == 0
+            || szProteinSeq[iStartPos - 1] == '*'
+            || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
+               && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
       }
       if (!bEndCleavage && !g_staticParams.enzymeInformation.bNoEnzyme2Selected)   // check second enzyme
       {
-         bEndCleavage = (iEndPos==(int)(_proteinInfo.iTmpProteinSeqLength - 1)
-               || szProteinSeq[iEndPos+1]=='*'
-               || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
-                  && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
+         bEndCleavage = (iEndPos == (int)(_proteinInfo.iTmpProteinSeqLength - 1)
+            || szProteinSeq[iEndPos + 1] == '*'
+            || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
+               && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
       }
 
       if (g_staticParams.options.iEnzymeTermini == ENZYME_DOUBLE_TERMINI)      // Check full enzyme search.
@@ -3715,7 +4175,7 @@ bool CometSearch::CheckEnzymeTermini(const char* szProteinSeq,
          if (bBreakPoint)
          {
             if ((g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 1 && i != iEndPos)  // Ignore last residue.
-                  || (g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 0 && i != iStartPos))  // Ignore first residue.
+               || (g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 0 && i != iStartPos))  // Ignore first residue.
             {
                iCountInternalCleavageSites++;
 
@@ -3730,27 +4190,27 @@ bool CometSearch::CheckEnzymeTermini(const char* szProteinSeq,
 }
 
 
-bool CometSearch::CheckEnzymeStartTermini(const char *szProteinSeq,
-                                          int iStartPos) const
+bool CometSearch::CheckEnzymeStartTermini(const char* szProteinSeq,
+   int iStartPos) const
 {
    if (g_staticParams.options.bClipNtermAA)
       iStartPos -= 1;
 
    if (!g_staticParams.enzymeInformation.bNoEnzymeSelected && !g_staticParams.enzymeInformation.bNoEnzyme2Selected)
    {
-      bool bBeginCleavage=0;
+      bool bBeginCleavage = 0;
 
-      bBeginCleavage = (iStartPos==0
-            || szProteinSeq[iStartPos-1]=='*'
-            || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
-               && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
+      bBeginCleavage = (iStartPos == 0
+         || szProteinSeq[iStartPos - 1] == '*'
+         || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
+            && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
 
       if (!bBeginCleavage && !g_staticParams.enzymeInformation.bNoEnzyme2Selected) // check second enzyme
       {
-         bBeginCleavage = (iStartPos==0
-               || szProteinSeq[iStartPos-1]=='*'
-               || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
-                  && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
+         bBeginCleavage = (iStartPos == 0
+            || szProteinSeq[iStartPos - 1] == '*'
+            || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iStartPos - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
+               && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iStartPos - 1 + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
       }
 
       return bBeginCleavage;
@@ -3760,24 +4220,24 @@ bool CometSearch::CheckEnzymeStartTermini(const char *szProteinSeq,
 }
 
 
-bool CometSearch::CheckEnzymeEndTermini(const char *szProteinSeq,
-                                        int iEndPos) const
+bool CometSearch::CheckEnzymeEndTermini(const char* szProteinSeq,
+   int iEndPos) const
 {
    if (!g_staticParams.enzymeInformation.bNoEnzymeSelected && !g_staticParams.enzymeInformation.bNoEnzyme2Selected)
    {
-      bool bEndCleavage=0;
+      bool bEndCleavage = 0;
 
-      bEndCleavage = (iEndPos==(int)(_proteinInfo.iTmpProteinSeqLength - 1)
-            || szProteinSeq[iEndPos+1]=='*'
-            || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
-               && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
+      bEndCleavage = (iEndPos == (int)(_proteinInfo.iTmpProteinSeqLength - 1)
+         || szProteinSeq[iEndPos + 1] == '*'
+         || (strchr(g_staticParams.enzymeInformation.szSearchEnzymeBreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzymeOffSet])
+            && !strchr(g_staticParams.enzymeInformation.szSearchEnzymeNoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzymeOffSet])));
 
       if (!bEndCleavage && !g_staticParams.enzymeInformation.bNoEnzyme2Selected)   // check second enzyme
       {
-         bEndCleavage = (iEndPos==(int)(_proteinInfo.iTmpProteinSeqLength - 1)
-               || szProteinSeq[iEndPos+1]=='*'
-               || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
-                  && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
+         bEndCleavage = (iEndPos == (int)(_proteinInfo.iTmpProteinSeqLength - 1)
+            || szProteinSeq[iEndPos + 1] == '*'
+            || (strchr(g_staticParams.enzymeInformation.szSearchEnzyme2BreakAA, szProteinSeq[iEndPos + 1 - g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])
+               && !strchr(g_staticParams.enzymeInformation.szSearchEnzyme2NoBreakAA, szProteinSeq[iEndPos + g_staticParams.enzymeInformation.iSearchEnzyme2OffSet])));
       }
 
       return bEndCleavage;
@@ -3788,9 +4248,9 @@ bool CometSearch::CheckEnzymeEndTermini(const char *szProteinSeq,
 
 
 int CometSearch::BinarySearchPeffStrMod(int start,
-                                        int end,
-                                        string strMod,
-                                        vector<OBOStruct>& vectorPeffOBO)
+   int end,
+   string strMod,
+   vector<OBOStruct>& vectorPeffOBO)
 {
 
    // Termination condition: start index greater than end index.
@@ -3812,8 +4272,8 @@ int CometSearch::BinarySearchPeffStrMod(int start,
 
 // Performance: Use std::lower_bound for binary search
 int CometSearch::BinarySearchMass(int start,
-                                  int end,
-                                  double dCalcPepMass) const
+   int end,
+   double dCalcPepMass) const
 {
    auto it = std::lower_bound(
       g_pvQuery.begin() + start,
@@ -3835,9 +4295,9 @@ int CometSearch::BinarySearchMass(int start,
 
 
 size_t CometSearch::BinarySearchIndexMass(size_t start,
-                                          size_t end,
-                                          double dQueryMass,
-                                          unsigned int *uiFragmentMass)
+   size_t end,
+   double dQueryMass,
+   unsigned int* uiFragmentMass)
 {
    // dQueryMass is the lower bound tolerance mass of input spectrum.
 
@@ -3877,7 +4337,7 @@ size_t CometSearch::BinarySearchIndexMass(size_t start,
 
 
 bool CometSearch::CheckMassMatch(size_t iWhichQuery,
-                                 double dCalcPepMass)
+   double dCalcPepMass)
 {
    Query* pQuery = g_pvQuery.at(iWhichQuery);
 
@@ -3886,7 +4346,7 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
    // this first check sees if calculated pepmass is within the low/high mass
    // range (including isotope offsets) of query.
    if ((dCalcPepMass >= pQuery->_pepMassInfo.dPeptideMassToleranceMinus)
-         && (dCalcPepMass <= pQuery->_pepMassInfo.dPeptideMassTolerancePlus))
+      && (dCalcPepMass <= pQuery->_pepMassInfo.dPeptideMassTolerancePlus))
    {
       if (g_staticParams.tolerances.iIsotopeError == 0 && iMassOffsetsSize == 0)
          return true;
@@ -3917,8 +4377,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
             {
                for (int x = 0; x <= iMaxIsotope; ++x)
                {
-                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x*C13_DIFF
-                             && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x*C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * C13_DIFF
+                     && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                   {
                      return true;
                   }
@@ -3937,8 +4397,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
                {
                   for (int x = 0; x <= iMaxIsotope; ++x)
                   {
-                     if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x*C13_DIFF
-                                && dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x*C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                     if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x * C13_DIFF
+                        && dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                      {
                         return true;
                      }
@@ -3954,8 +4414,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
             {
                for (int x = -2; x <= 2; ++x)
                {
-                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x*4.0070995
-                             && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x*4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * 4.0070995
+                     && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * 4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                   {
                      return true;
                   }
@@ -3985,8 +4445,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
 
             for (int x = 0; x <= iMaxIsotope; ++x)
             {
-               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x*C13_DIFF
-                          && dCalcPepMass + x*C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x * C13_DIFF
+                  && dCalcPepMass + x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                {
                   return true;
                }
@@ -4002,8 +4462,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
 
                for (int x = 0; x <= iMaxIsotope; ++x)
                {
-                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass - x*C13_DIFF
-                             && dCalcPepMass - x*C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass - x * C13_DIFF
+                     && dCalcPepMass - x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                   {
                      return true;
                   }
@@ -4016,8 +4476,8 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
          {
             for (int x = -2; x <= 2; ++x)
             {
-               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x*4.0070995
-                          && dCalcPepMass + x*4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x * 4.0070995
+                  && dCalcPepMass + x * 4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
                {
                   return true;
                }
@@ -4042,23 +4502,23 @@ bool CometSearch::CheckMassMatch(size_t iWhichQuery,
 
 
 // For nucleotide search, translate from DNA to amino acid.
-bool CometSearch::TranslateNA2AA(int *frame,
-                                 int iDirection,
-                                 char *szDNASequence)
+bool CometSearch::TranslateNA2AA(int* frame,
+   int iDirection,
+   char* szDNASequence)
 {
-   int i, ii=0;
+   int i, ii = 0;
    int iSeqLength = (int)strlen(szDNASequence);
 
    if (iDirection == 1)  // Forward reading frame.
    {
       i = (*frame);
-      while ((i+2) < iSeqLength)
+      while ((i + 2) < iSeqLength)
       {
          if (ii >= _proteinInfo.iAllocatedProtSeqLength)
          {
-            char *pTmp;
+            char* pTmp;
 
-            pTmp=(char *)realloc(_proteinInfo.pszProteinSeq, ii + 100);
+            pTmp = (char*)realloc(_proteinInfo.pszProteinSeq, ii + 100);
             if (pTmp == NULL)
             {
                string strErrorMsg = " Error realloc(szProteinSeq) ... size=" + std::to_string(ii) + "\n\
@@ -4071,10 +4531,10 @@ bool CometSearch::TranslateNA2AA(int *frame,
             }
 
             _proteinInfo.pszProteinSeq = pTmp;
-            _proteinInfo.iAllocatedProtSeqLength=ii+99;
+            _proteinInfo.iAllocatedProtSeqLength = ii + 99;
          }
 
-         *(_proteinInfo.pszProteinSeq+ii) = GetAA(i, 1, szDNASequence);
+         *(_proteinInfo.pszProteinSeq + ii) = GetAA(i, 1, szDNASequence);
          i += 3;
          ii++;
       }
@@ -4088,9 +4548,9 @@ bool CometSearch::TranslateNA2AA(int *frame,
       {
          if (ii >= _proteinInfo.iAllocatedProtSeqLength)
          {
-            char *pTmp;
+            char* pTmp;
 
-            pTmp=(char *)realloc(_proteinInfo.pszProteinSeq, ii + 100);
+            pTmp = (char*)realloc(_proteinInfo.pszProteinSeq, ii + 100);
             if (pTmp == NULL)
             {
                string strErrorMsg = " Error realloc(szProteinSeq) ... size=" + std::to_string(ii) + "\n\
@@ -4103,7 +4563,7 @@ bool CometSearch::TranslateNA2AA(int *frame,
             }
 
             _proteinInfo.pszProteinSeq = pTmp;
-            _proteinInfo.iAllocatedProtSeqLength = ii+99;
+            _proteinInfo.iAllocatedProtSeqLength = ii + 99;
          }
 
          *(_proteinInfo.pszProteinSeq + ii) = GetAA(i, -1, szDNASequence);
@@ -4111,7 +4571,7 @@ bool CometSearch::TranslateNA2AA(int *frame,
          ii++;
       }
       _proteinInfo.iProteinSeqLength = ii;
-      _proteinInfo.pszProteinSeq[ii]='\0';
+      _proteinInfo.pszProteinSeq[ii] = '\0';
    }
 
    //_proteinInfo.cPeffOrigResidue = '\0';
@@ -4126,99 +4586,99 @@ bool CometSearch::TranslateNA2AA(int *frame,
 
 // GET amino acid from DNA triplets, direction=+/-1.
 char CometSearch::GetAA(int i,
-                        int iDirection,
-                        char *szDNASequence)
+   int iDirection,
+   char* szDNASequence)
 {
    int iBase1 = i;
    int iBase2 = i + iDirection;
-   int iBase3 = i + iDirection*2;
+   int iBase3 = i + iDirection * 2;
 
-   if (szDNASequence[iBase1]=='G')
+   if (szDNASequence[iBase1] == 'G')
    {
-      if (szDNASequence[iBase2]=='T')
+      if (szDNASequence[iBase2] == 'T')
          return ('V');
-      else if (szDNASequence[iBase2]=='C')
+      else if (szDNASequence[iBase2] == 'C')
          return ('A');
-      else if (szDNASequence[iBase2]=='G')
+      else if (szDNASequence[iBase2] == 'G')
          return ('G');
-      else if (szDNASequence[iBase2]=='A')
+      else if (szDNASequence[iBase2] == 'A')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('D');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('E');
       }
    }
 
-   else if (szDNASequence[iBase1]=='C')
+   else if (szDNASequence[iBase1] == 'C')
    {
-      if (szDNASequence[iBase2]=='T')
+      if (szDNASequence[iBase2] == 'T')
          return ('L');
-      else if (szDNASequence[iBase2]=='C')
+      else if (szDNASequence[iBase2] == 'C')
          return ('P');
-      else if (szDNASequence[iBase2]=='G')
+      else if (szDNASequence[iBase2] == 'G')
          return ('R');
-      else if (szDNASequence[iBase2]=='A')
+      else if (szDNASequence[iBase2] == 'A')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('H');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('Q');
       }
    }
 
-   else if (szDNASequence[iBase1]=='T')
+   else if (szDNASequence[iBase1] == 'T')
    {
-      if (szDNASequence[iBase2]=='C')
+      if (szDNASequence[iBase2] == 'C')
          return ('S');
-      else if (szDNASequence[iBase2]=='T')
+      else if (szDNASequence[iBase2] == 'T')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('F');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('L');
       }
-      else if (szDNASequence[iBase2]=='A')
+      else if (szDNASequence[iBase2] == 'A')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('Y');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('@');
       }
-      else if (szDNASequence[iBase2]=='G')
+      else if (szDNASequence[iBase2] == 'G')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('C');
-         else if (szDNASequence[iBase3]=='A')
+         else if (szDNASequence[iBase3] == 'A')
             return ('@');
-         else if (szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'G')
             return ('W');
       }
    }
 
-   else if (szDNASequence[iBase1]=='A')
+   else if (szDNASequence[iBase1] == 'A')
    {
-      if (szDNASequence[iBase2]=='C')
+      if (szDNASequence[iBase2] == 'C')
          return ('T');
-      else if (szDNASequence[iBase2]=='T')
+      else if (szDNASequence[iBase2] == 'T')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C' || szDNASequence[iBase3]=='A')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C' || szDNASequence[iBase3] == 'A')
             return ('I');
-         else if (szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'G')
             return ('M');
       }
-      else if (szDNASequence[iBase2]=='A')
+      else if (szDNASequence[iBase2] == 'A')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('N');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('K');
       }
-      else if (szDNASequence[iBase2]=='G')
+      else if (szDNASequence[iBase2] == 'G')
       {
-         if (szDNASequence[iBase3]=='T' || szDNASequence[iBase3]=='C')
+         if (szDNASequence[iBase3] == 'T' || szDNASequence[iBase3] == 'C')
             return ('S');
-         else if (szDNASequence[iBase3]=='A' || szDNASequence[iBase3]=='G')
+         else if (szDNASequence[iBase3] == 'A' || szDNASequence[iBase3] == 'G')
             return ('R');
       }
    }
@@ -4229,22 +4689,22 @@ char CometSearch::GetAA(int i,
 
 
 // Compares sequence to MSMS spectrum by matching ion intensities.
-void CometSearch::XcorrScore(char *szProteinSeq,
-                             int iStartResidue,        // needed for decoy peptide; otherwise just duplicate of iStartPos
-                             int iEndResidue,
-                             int iStartPos,
-                             int iEndPos,
-                             int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
-                             double dCalcPepMass,
-                             bool bDecoyPep,
-                             int iWhichQuery,
-                             int iLenPeptide,
-                             int *piVarModSites,
-                             struct sDBEntry *dbe)
+void CometSearch::XcorrScore(char* szProteinSeq,
+   int iStartResidue,        // needed for decoy peptide; otherwise just duplicate of iStartPos
+   int iEndResidue,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
+   double dCalcPepMass,
+   bool bDecoyPep,
+   int iWhichQuery,
+   int iLenPeptide,
+   int* piVarModSites,
+   struct sDBEntry* dbe)
 {
    int  ctLen,
-        ctIonSeries,
-        ctCharge;
+      ctIonSeries,
+      ctCharge;
    double dXcorr;
    int iLenPeptideMinus1 = iLenPeptide - 1;
 
@@ -4268,14 +4728,14 @@ void CometSearch::XcorrScore(char *szProteinSeq,
    bool bUseWaterAmmoniaNLPeaks = false;
    Query* pQuery = g_pvQuery.at(iWhichQuery);
 
-   float **ppSparseFastXcorrData;              // use this if bSparseMatrix
+   float** ppSparseFastXcorrData;              // use this if bSparseMatrix
 
    dXcorr = 0.0;
 
    // iMax is largest x-value allowed as iMax+1 is allocated and we're 0-index
-   int iMax = pQuery->_spectrumInfoInternal.iArraySize/SPARSE_MATRIX_SIZE;
+   int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
 
-   int bin,x,y;
+   int bin, x, y;
 
    for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
    {
@@ -4284,7 +4744,7 @@ void CometSearch::XcorrScore(char *szProteinSeq,
          iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
 
          if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
-               && (iWhichIonSeries==ION_SERIES_A || iWhichIonSeries==ION_SERIES_B || iWhichIonSeries==ION_SERIES_Y))
+            && (iWhichIonSeries == ION_SERIES_A || iWhichIonSeries == ION_SERIES_B || iWhichIonSeries == ION_SERIES_Y))
          {
             bUseWaterAmmoniaNLPeaks = true;
          }
@@ -4303,17 +4763,17 @@ void CometSearch::XcorrScore(char *szProteinSeq,
          for (ctLen = 0; ctLen < iLenPeptideMinus1; ++ctLen)
          {
             //MH: newer sparse matrix converts bin to sparse matrix bin
-            bin = *(*(*(*(*p_uiBinnedIonMasses + ctCharge) + ctIonSeries)  +ctLen) + 0);
+            bin = *(*(*(*(*p_uiBinnedIonMasses + ctCharge) + ctIonSeries) + ctLen) + 0);
 
             x = bin / SPARSE_MATRIX_SIZE;
 
-            if (!(bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL)) // x should never be > iMax so this is just a safety check
+            if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
             {
-               y = bin - (x*SPARSE_MATRIX_SIZE);
+               y = bin - (x * SPARSE_MATRIX_SIZE);
                dXcorr += ppSparseFastXcorrData[x][y];
             }
 
-            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod==2)
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
             {
                for (int ii = 0; ii < VMODS; ++ii)
                {
@@ -4326,13 +4786,13 @@ void CometSearch::XcorrScore(char *szProteinSeq,
 
                      //x+1 here as 0 is the base fragment ion series
                      // *(*(*(*(*p_uiBinnedIonMasses + ctCharge)+ctIonSeries)+ctLen)+NL) gives uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][NL].
-                     bin = *(*(*(*(*p_uiBinnedIonMasses + ctCharge) + ctIonSeries)  +ctLen) + ii + 1 + iWhichNL);
+                     bin = *(*(*(*(*p_uiBinnedIonMasses + ctCharge) + ctIonSeries) + ctLen) + ii + 1 + iWhichNL);
 
                      x = bin / SPARSE_MATRIX_SIZE;
 
-                     if (!(bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL)) // x should never be > iMax so this is just a safety check
+                     if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
                      {
-                        y = bin - (x*SPARSE_MATRIX_SIZE);
+                        y = bin - (x * SPARSE_MATRIX_SIZE);
                         dXcorr += ppSparseFastXcorrData[x][y];
                      }
                   }
@@ -4352,10 +4812,10 @@ void CometSearch::XcorrScore(char *szProteinSeq,
 
          x = bin / SPARSE_MATRIX_SIZE;
 
-         if (bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL) // x should never be > iMax so this is just a safety check
+         if (bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL) // x should never be > iMax so this is just a safety check
             continue;
 
-         y = bin - (x*SPARSE_MATRIX_SIZE);
+         y = bin - (x * SPARSE_MATRIX_SIZE);
 
          dXcorr += ppSparseFastXcorrData[x][y];
       }
@@ -4363,7 +4823,7 @@ void CometSearch::XcorrScore(char *szProteinSeq,
 
    dXcorr *= 0.005;  // Scale intensities to 50 and divide score by 1E4.
 
-   dXcorr = std::round(dXcorr* 1000.0) / 1000.0;  // round to 3 decimal points
+   dXcorr = std::round(dXcorr * 1000.0) / 1000.0;  // round to 3 decimal points
 
    Threading::LockMutex(pQuery->accessMutex);
 
@@ -4374,9 +4834,9 @@ void CometSearch::XcorrScore(char *szProteinSeq,
       pQuery->_uliNumMatchedPeptides++;
 
    if (g_staticParams.options.bPrintExpectScore
-         || g_staticParams.options.bOutputPepXMLFile
-         || g_staticParams.options.bOutputPercolatorFile
-         || g_staticParams.options.bOutputTxtFile)
+      || g_staticParams.options.bOutputPepXMLFile
+      || g_staticParams.options.bOutputPercolatorFile
+      || g_staticParams.options.bOutputTxtFile)
    {
       int iTmp;
 
@@ -4417,7 +4877,7 @@ void CometSearch::XcorrScore(char *szProteinSeq,
             dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
       }
       else if (!CheckDuplicate(iWhichQuery, iStartResidue, iEndResidue, iStartPos, iEndPos, iFoundVariableMod, dCalcPepMass,
-            szProteinSeq, bDecoyPep, piVarModSites, dbe))
+         szProteinSeq, bDecoyPep, piVarModSites, dbe))
       {
          StorePeptide(iWhichQuery, iStartResidue, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
             dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
@@ -4429,34 +4889,34 @@ void CometSearch::XcorrScore(char *szProteinSeq,
 
 
 // Compares sequence to MSMS spectrum by matching ion intensities.
-void CometSearch::XcorrScoreI(char *szProteinSeq,
-                             int iStartPos,
-                             int iEndPos,
-                             int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
-                             double dCalcPepMass,
-                             bool bDecoyPep,
-                             size_t iWhichQuery,
-                             int iLenPeptide,
-                             int *piVarModSites,
-                             struct sDBEntry *dbe,
-                             unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2],
-                             unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
-                             int iNumMatchedFragmentIons)
+void CometSearch::XcorrScoreI(char* szProteinSeq,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
+   double dCalcPepMass,
+   bool bDecoyPep,
+   size_t iWhichQuery,
+   int iLenPeptide,
+   int* piVarModSites,
+   struct sDBEntry* dbe,
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2],
+   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
+   int iNumMatchedFragmentIons)
 {
    int  ctLen,
-        ctIonSeries,
-        ctCharge;
+      ctIonSeries,
+      ctCharge;
    double dXcorr = 0.0;
    int iLenPeptideMinus1 = iLenPeptide - 1;
 
    Query* pQuery = g_pvQuery.at(iWhichQuery);
 
    // iMax is largest x-value allowed as iMax+1 is allocated and we're 0-index
-   int iMax = pQuery->_spectrumInfoInternal.iArraySize/SPARSE_MATRIX_SIZE;
+   int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
 
-   int bin,x,y;
+   int bin, x, y;
 
-   float **ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
+   float** ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
 
    for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
    {
@@ -4469,13 +4929,13 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
 
             x = bin / SPARSE_MATRIX_SIZE;
 
-            if (!(bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL)) // x should never be > iMax so this is just a safety check
+            if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
             {
-               y = bin - (x*SPARSE_MATRIX_SIZE);
+               y = bin - (x * SPARSE_MATRIX_SIZE);
                dXcorr += ppSparseFastXcorrData[x][y];
             }
 
-            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod==2)
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
             {
                for (int ii = 0; ii < FRAGINDEX_VMODS; ++ii)
                {
@@ -4492,9 +4952,9 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
 
                      x = bin / SPARSE_MATRIX_SIZE;
 
-                     if (!(bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL)) // x should never be > iMax so this is just a safety check
+                     if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
                      {
-                        y = bin - (x*SPARSE_MATRIX_SIZE);
+                        y = bin - (x * SPARSE_MATRIX_SIZE);
                         dXcorr += ppSparseFastXcorrData[x][y];
                      }
                   }
@@ -4513,10 +4973,10 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
 
          x = bin / SPARSE_MATRIX_SIZE;
 
-         if (bin <= 0 || x>iMax || ppSparseFastXcorrData[x]==NULL) // x should never be > iMax so this is just a safety check
+         if (bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL) // x should never be > iMax so this is just a safety check
             continue;
 
-         y = bin - (x*SPARSE_MATRIX_SIZE);
+         y = bin - (x * SPARSE_MATRIX_SIZE);
 
          dXcorr += ppSparseFastXcorrData[x][y];
       }
@@ -4524,7 +4984,7 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
 
    dXcorr *= 0.005;  // Scale intensities to 50 and divide score by 1E4.
 
-   dXcorr= std::round(dXcorr * 1000.0) / 1000.0;  // round to 3 decimal points
+   dXcorr = std::round(dXcorr * 1000.0) / 1000.0;  // round to 3 decimal points
 
    Threading::LockMutex(pQuery->accessMutex);
 
@@ -4535,9 +4995,9 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
       pQuery->_uliNumMatchedPeptides++;
 
    if (g_staticParams.options.bPrintExpectScore
-         || g_staticParams.options.bOutputPepXMLFile
-         || g_staticParams.options.bOutputPercolatorFile
-         || g_staticParams.options.bOutputTxtFile)
+      || g_staticParams.options.bOutputPepXMLFile
+      || g_staticParams.options.bOutputPercolatorFile
+      || g_staticParams.options.bOutputTxtFile)
    {
       int iTmp;
 
@@ -4560,7 +5020,7 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
    if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
    {
       StorePeptideI(iWhichQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
-            dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
+         dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
    }
 
    Threading::UnlockMutex(pQuery->accessMutex);
@@ -4568,16 +5028,16 @@ void CometSearch::XcorrScoreI(char *szProteinSeq,
 
 
 void CometSearch::StorePeptide(size_t iWhichQuery,
-                               int iStartResidue,
-                               int iStartPos,
-                               int iEndPos,
-                               int iFoundVariableMod,
-                               char *szProteinSeq,
-                               double dCalcPepMass,
-                               double dXcorr,
-                               bool bDecoyPep,
-                               int *piVarModSites,
-                               struct sDBEntry *dbe)
+   int iStartResidue,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,
+   char* szProteinSeq,
+   double dCalcPepMass,
+   double dXcorr,
+   bool bDecoyPep,
+   int* piVarModSites,
+   struct sDBEntry* dbe)
 {
    int i;
    int iLenPeptide;
@@ -4590,7 +5050,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
    iLenPeptide = iEndPos - iStartPos + 1;
    iLenPeptide2 = iLenPeptide + 2;
 
-   if (g_staticParams.options.iDecoySearch==2 && bDecoyPep)  // store separate decoys
+   if (g_staticParams.options.iDecoySearch == 2 && bDecoyPep)  // store separate decoys
    {
       short siLowestDecoyXcorrScoreIndex = 0;
 
@@ -4602,7 +5062,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
          {
             siLowestDecoyXcorrScoreIndex = siA;
          }
-         else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr ==  pQuery->_pDecoys[siA].fXcorr
+         else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr == pQuery->_pDecoys[siA].fXcorr
             && pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr >= g_staticParams.options.dMinimumXcorr)
          {
             // if current lowest score is the same as current siA peptide,
@@ -4647,11 +5107,11 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
                   // should not have gotten here; duplicate unmodified peptide would get
                   // flagged in CheckDuplicates
                   printf("\n Error in StorePeptides (decoys). %s stored twice:  %d %lf, %d %lf\n",
-                        pQuery->_pDecoys[siA].szPeptide,
-                        siA,
-                        pQuery->_pDecoys[siA].fXcorr,
-                        siLowestDecoyXcorrScoreIndex,
-                        pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr);
+                     pQuery->_pDecoys[siA].szPeptide,
+                     siA,
+                     pQuery->_pDecoys[siA].fXcorr,
+                     siLowestDecoyXcorrScoreIndex,
+                     pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr);
 
                   exit(1);
                }
@@ -4662,8 +5122,8 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
       pQuery->iDecoyMatchPeptideCount++;
       pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].usiLenPeptide = iLenPeptide;
 
-      memcpy(pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].szPeptide, szProteinSeq+iStartPos, iLenPeptide*sizeof(char));
-      pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].szPeptide[iLenPeptide]='\0';
+      memcpy(pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].szPeptide, szProteinSeq + iStartPos, iLenPeptide * sizeof(char));
+      pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].szPeptide[iLenPeptide] = '\0';
       pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].dPepMass = dCalcPepMass;
 
       if (pQuery->_spectrumInfoInternal.usiChargeState > 2)
@@ -4702,8 +5162,8 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
       // store PEFF info; +1 and -1 to account for PEFF in flanking positions
       if (_proteinInfo.iPeffOrigResiduePosition != NO_PEFF_VARIANT
-            && (iStartPos-1 <= _proteinInfo.iPeffOrigResiduePosition+_proteinInfo.iPeffNewResidueCount-1) 
-            && (_proteinInfo.iPeffOrigResiduePosition <= iEndPos+1))
+         && (iStartPos - 1 <= _proteinInfo.iPeffOrigResiduePosition + _proteinInfo.iPeffNewResidueCount - 1)
+         && (_proteinInfo.iPeffOrigResiduePosition <= iEndPos + 1))
       {
          pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].iPeffOrigResiduePosition = _proteinInfo.iPeffOrigResiduePosition - iStartPos;
          pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].sPeffOrigResidues = _proteinInfo.sPeffOrigResidues;
@@ -4748,7 +5208,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
                if (iVal > 0)
                {
-                  pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal-1].dVarModMass;
+                  pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal - 1].dVarModMass;
 
                   if (g_staticParams.options.iPrintAScoreProScore == -1
                      || (g_staticParams.options.iPrintAScoreProScore > 0 && iVal == g_AScoreOptions.getSymbol() - '0'))
@@ -4780,7 +5240,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
       pQuery->dLowestDecoyXcorrScore = pQuery->_pDecoys[0].fXcorr;
       siLowestDecoyXcorrScoreIndex = 0;
 
-      for (i = 1 ; i < g_staticParams.options.iNumStored; ++i)
+      for (i = 1; i < g_staticParams.options.iNumStored; ++i)
       {
          if (pQuery->_pDecoys[i].fXcorr < pQuery->dLowestDecoyXcorrScore)
          {
@@ -4803,8 +5263,8 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
          {
             siLowestXcorrScoreIndex = siA;
          }
-         else if (pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr ==  pQuery->_pResults[siA].fXcorr
-               && pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr >= g_staticParams.options.dMinimumXcorr)
+         else if (pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr == pQuery->_pResults[siA].fXcorr
+            && pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr >= g_staticParams.options.dMinimumXcorr)
          {
             // if current lowest score is the same as current siA peptide,
             // determine if need to point to siA peptide as the one to replace
@@ -4849,11 +5309,11 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
                   // should not have gotten here; duplicate unmodified peptide would get
                   // flagged in CheckDuplicates
                   printf("\n Error in StorePeptides. %s stored twice:  %d %lf, %d %lf\n",
-                        pQuery->_pResults[siA].szPeptide,
-                        siA,
-                        pQuery->_pResults[siA].fXcorr,
-                        siLowestXcorrScoreIndex,
-                        pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr);
+                     pQuery->_pResults[siA].szPeptide,
+                     siA,
+                     pQuery->_pResults[siA].fXcorr,
+                     siLowestXcorrScoreIndex,
+                     pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr);
 
                   exit(1);
                }
@@ -4864,8 +5324,8 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
       pQuery->iMatchPeptideCount++;
       pQuery->_pResults[siLowestXcorrScoreIndex].usiLenPeptide = iLenPeptide;
 
-      memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide, szProteinSeq+iStartPos, iLenPeptide*sizeof(char));
-      pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide[iLenPeptide]='\0';
+      memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide, szProteinSeq + iStartPos, iLenPeptide * sizeof(char));
+      pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide[iLenPeptide] = '\0';
       pQuery->_pResults[siLowestXcorrScoreIndex].dPepMass = dCalcPepMass;
 
       if (pQuery->_spectrumInfoInternal.usiChargeState > 2)
@@ -4900,8 +5360,8 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
       // store PEFF info; +1 and -1 to account for PEFF in flanking positions
       if (_proteinInfo.iPeffOrigResiduePosition != NO_PEFF_VARIANT
-            && (iStartPos-1 <= _proteinInfo.iPeffOrigResiduePosition+_proteinInfo.iPeffNewResidueCount-1)
-            && (_proteinInfo.iPeffOrigResiduePosition <= iEndPos+1))
+         && (iStartPos - 1 <= _proteinInfo.iPeffOrigResiduePosition + _proteinInfo.iPeffNewResidueCount - 1)
+         && (_proteinInfo.iPeffOrigResiduePosition <= iEndPos + 1))
       {
          pQuery->_pResults[siLowestXcorrScoreIndex].iPeffOrigResiduePosition = _proteinInfo.iPeffOrigResiduePosition - iStartPos;
          //pQuery->_pResults[siLowestXcorrScoreIndex].cPeffOrigResidue = _proteinInfo.cPeffOrigResidue;
@@ -4934,6 +5394,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
       else
          pQuery->_pResults[siLowestXcorrScoreIndex].pWhichProtein.push_back(pTmp);
 
+
       if (g_staticParams.variableModParameters.bVarModSearch)
       {
          if (!iFoundVariableMod)  // Normal peptide in variable mod search.
@@ -4953,7 +5414,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
                if (iVal > 0)
                {
-                  pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal-1].dVarModMass;
+                  pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal - 1].dVarModMass;
 
                   if (g_staticParams.options.iPrintAScoreProScore == -1
                      || (g_staticParams.options.iPrintAScoreProScore > 0 && iVal == g_AScoreOptions.getSymbol() - '0'))
@@ -4985,7 +5446,7 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
       pQuery->dLowestXcorrScore = pQuery->_pResults[0].fXcorr;
       siLowestXcorrScoreIndex = 0;
 
-      for (i = 1 ; i < g_staticParams.options.iNumStored; ++i)
+      for (i = 1; i < g_staticParams.options.iNumStored; ++i)
       {
          if (pQuery->_pResults[i].fXcorr < pQuery->dLowestXcorrScore)
          {
@@ -5000,15 +5461,15 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
 
 void CometSearch::StorePeptideI(size_t iWhichQuery,
-                                int iStartPos,
-                                int iEndPos,
-                                int iFoundVariableMod,
-                                char* szProteinSeq,
-                                double dCalcPepMass,
-                                double dXcorr,
-                                bool bDecoyPep,
-                                int* piVarModSites,
-                                struct sDBEntry* dbe)
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,
+   char* szProteinSeq,
+   double dCalcPepMass,
+   double dXcorr,
+   bool bDecoyPep,
+   int* piVarModSites,
+   struct sDBEntry* dbe)
 {
    int iLenPeptide = iEndPos - iStartPos + 1;
    int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
@@ -5102,7 +5563,7 @@ void CometSearch::StorePeptideI(size_t iWhichQuery,
 
    // Get new lowest score.
    pQuery->dLowestXcorrScore = pQuery->_pResults[0].fXcorr;
-   siLowestXcorrScoreIndex=0;
+   siLowestXcorrScoreIndex = 0;
 
    for (int i = g_staticParams.options.iNumStored - 1; i > 0; --i)
    {
@@ -5118,21 +5579,21 @@ void CometSearch::StorePeptideI(size_t iWhichQuery,
 
 
 int CometSearch::CheckDuplicate(int iWhichQuery,
-                                int iStartResidue,
-                                int iEndResidue,
-                                int iStartPos,
-                                int iEndPos,
-                                int iFoundVariableMod,
-                                double dCalcPepMass,
-                                char *szProteinSeq,
-                                bool bDecoyPep,
-                                int *piVarModSites,
-                                struct sDBEntry *dbe)
+   int iStartResidue,
+   int iEndResidue,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,
+   double dCalcPepMass,
+   char* szProteinSeq,
+   bool bDecoyPep,
+   int* piVarModSites,
+   struct sDBEntry* dbe)
 {
    int i;
    int iLenPeptide = iEndPos - iStartPos + 1;
    int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
-   int bIsDuplicate=0;
+   int bIsDuplicate = 0;
    Query* pQuery = g_pvQuery.at(iWhichQuery);
 
    if (g_staticParams.options.iDecoySearch == 2 && bDecoyPep)
@@ -5142,7 +5603,7 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
          // Quick check of peptide sequence length first.
          if (iLenPeptide == pQuery->_pDecoys[i].usiLenPeptide && isEqual(dCalcPepMass, pQuery->_pDecoys[i].dPepMass))
          {
-            if (!memcmp(pQuery->_pDecoys[i].szPeptide, szProteinSeq + iStartPos, sizeof(char)*(pQuery->_pDecoys[i].usiLenPeptide)))
+            if (!memcmp(pQuery->_pDecoys[i].szPeptide, szProteinSeq + iStartPos, sizeof(char) * (pQuery->_pDecoys[i].usiLenPeptide)))
             {
                bIsDuplicate = 1;
             }
@@ -5150,12 +5611,12 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
             {
                bIsDuplicate = 1;
 
-               for (int ii=iStartPos; ii<=iEndPos; ii++ )
+               for (int ii = iStartPos; ii <= iEndPos; ii++)
                {
-                  if (pQuery->_pDecoys[i].szPeptide[ii-iStartPos] != szProteinSeq[ii])
+                  if (pQuery->_pDecoys[i].szPeptide[ii - iStartPos] != szProteinSeq[ii])
                   {
-                     if ((pQuery->_pDecoys[i].szPeptide[ii-iStartPos]!='I' && pQuery->_pDecoys[i].szPeptide[ii-iStartPos]!='L')
-                           || (szProteinSeq[ii] != 'I' && szProteinSeq[ii] != 'L'))
+                     if ((pQuery->_pDecoys[i].szPeptide[ii - iStartPos] != 'I' && pQuery->_pDecoys[i].szPeptide[ii - iStartPos] != 'L')
+                        || (szProteinSeq[ii] != 'I' && szProteinSeq[ii] != 'L'))
                      {
                         bIsDuplicate = 0;
                         break;
@@ -5174,7 +5635,7 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
                   {
                      iVal = pQuery->_pDecoys[i].piVarModSites[ii];
 
-                     if ( (iVal>0 && piVarModSites[ii]<=0) || (iVal<0 && piVarModSites[ii]>=0) )
+                     if ((iVal > 0 && piVarModSites[ii] <= 0) || (iVal < 0 && piVarModSites[ii] >= 0))
                      {
                         bIsDuplicate = 0;
                         break;
@@ -5202,10 +5663,10 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
                }
                else
                {
-                  if (!memcmp(piVarModSites, pQuery->_pDecoys[i].piVarModSites, (sizeof(int)*(pQuery->_pDecoys[i].usiLenPeptide + 2))))
+                  if (!memcmp(piVarModSites, pQuery->_pDecoys[i].piVarModSites, (sizeof(int) * (pQuery->_pDecoys[i].usiLenPeptide + 2))))
                      bIsDuplicate = 1;
                   else
-                    bIsDuplicate = 0;
+                     bIsDuplicate = 0;
                }
             }
 
@@ -5239,12 +5700,12 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
                // if duplicate, check to see if need to replace stored protein info 
                // with protein that's earlier in database
                if (pQuery->_pDecoys[i].lProteinFilePosition > dbe->lProteinFilePosition)
-               {     
+               {
                   pQuery->_pDecoys[i].lProteinFilePosition = dbe->lProteinFilePosition;
 
                   // also if IL equivalence set, go ahead and copy peptide from first sequence
                   memcpy(pQuery->_pDecoys[i].szPeptide, szProteinSeq + iStartPos, (pQuery->_pDecoys[i].usiLenPeptide * sizeof(char)));
-                  pQuery->_pDecoys[i].szPeptide[pQuery->_pDecoys[i].usiLenPeptide]='\0';
+                  pQuery->_pDecoys[i].szPeptide[pQuery->_pDecoys[i].usiLenPeptide] = '\0';
                }
 
                pQuery->iDecoyMatchPeptideCount++;
@@ -5261,7 +5722,7 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
          // Quick check of peptide sequence length.
          if (iLenPeptide == pQuery->_pResults[i].usiLenPeptide && isEqual(dCalcPepMass, pQuery->_pResults[i].dPepMass))
          {
-            if (!memcmp(pQuery->_pResults[i].szPeptide, szProteinSeq + iStartPos, sizeof(char)*(pQuery->_pResults[i].usiLenPeptide)))
+            if (!memcmp(pQuery->_pResults[i].szPeptide, szProteinSeq + iStartPos, sizeof(char) * (pQuery->_pResults[i].usiLenPeptide)))
             {
                bIsDuplicate = 1;
             }
@@ -5269,12 +5730,12 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
             {
                bIsDuplicate = 1;
 
-               for (int ii=iStartPos; ii<=iEndPos; ii++ )
+               for (int ii = iStartPos; ii <= iEndPos; ii++)
                {
-                  if (pQuery->_pResults[i].szPeptide[ii-iStartPos] != szProteinSeq[ii])
+                  if (pQuery->_pResults[i].szPeptide[ii - iStartPos] != szProteinSeq[ii])
                   {
-                     if ((pQuery->_pResults[i].szPeptide[ii-iStartPos]!='I' && pQuery->_pResults[i].szPeptide[ii-iStartPos]!='L')
-                           || (szProteinSeq[ii] != 'I' && szProteinSeq[ii] != 'L'))
+                     if ((pQuery->_pResults[i].szPeptide[ii - iStartPos] != 'I' && pQuery->_pResults[i].szPeptide[ii - iStartPos] != 'L')
+                        || (szProteinSeq[ii] != 'I' && szProteinSeq[ii] != 'L'))
                      {
                         bIsDuplicate = 0;
                         break;
@@ -5319,7 +5780,7 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
                }
                else
                {
-                  if (!memcmp(piVarModSites, pQuery->_pResults[i].piVarModSites, sizeof(int)*(pQuery->_pResults[i].usiLenPeptide + 2)))
+                  if (!memcmp(piVarModSites, pQuery->_pResults[i].piVarModSites, sizeof(int) * (pQuery->_pResults[i].usiLenPeptide + 2)))
                      bIsDuplicate = 1;
                   else
                      bIsDuplicate = 0;
@@ -5390,15 +5851,15 @@ int CometSearch::CheckDuplicate(int iWhichQuery,
 }
 
 
-void CometSearch::SubtractVarMods(int *piVarModCounts,
-                                  int cResidue,
-                                  int iResiduePosition)
+void CometSearch::SubtractVarMods(int* piVarModCounts,
+   int cResidue,
+   int iResiduePosition)
 {
    int i;
    for (i = 0; i < VMODS; ++i)
    {
       if (g_staticParams.variableModParameters.varModList[i].bUseMod
-            && strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+         && strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
       {
          if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
             piVarModCounts[i]--;
@@ -5411,7 +5872,7 @@ void CometSearch::SubtractVarMods(int *piVarModCounts,
             }
             else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
             {
-               if (iResiduePosition + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength-1)
+               if (iResiduePosition + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength - 1)
                   piVarModCounts[i]--;
             }
             // Do we just let possible mod residue simply drop off here and
@@ -5427,14 +5888,14 @@ void CometSearch::SubtractVarMods(int *piVarModCounts,
 
 
 // track # of variable mod AA residues in peptide; note that n- and c-term mods are not tracked here
-void CometSearch::CountVarMods(int *piVarModCounts,
-                               int cResidue,
-                               int iResiduePosition)
+void CometSearch::CountVarMods(int* piVarModCounts,
+   int cResidue,
+   int iResiduePosition)
 {
-   for (int i=0; i<VMODS; ++i)
+   for (int i = 0; i < VMODS; ++i)
    {
       if (g_staticParams.variableModParameters.varModList[i].bUseMod
-            && strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+         && strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
       {
          if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
             piVarModCounts[i]++;
@@ -5447,7 +5908,7 @@ void CometSearch::CountVarMods(int *piVarModCounts,
             }
             else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
             {
-              if (iResiduePosition + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength-1)
+               if (iResiduePosition + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength - 1)
                   piVarModCounts[i]++;
             }
             // deal with peptide terminal distance constraint elsewhere
@@ -5462,10 +5923,10 @@ void CometSearch::CountVarMods(int *piVarModCounts,
 
 
 // return true if there are any possible variable mods (including PEFF mods)
-bool CometSearch::HasVariableMod(int *pVarModCounts,
-                                 int iStartPos,
-                                 int iEndPos,
-                                 struct sDBEntry *dbe)
+bool CometSearch::HasVariableMod(int* pVarModCounts,
+   int iStartPos,
+   int iEndPos,
+   struct sDBEntry* dbe)
 {
    int i;
 
@@ -5486,7 +5947,7 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
          if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
          {
             if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                  || g_staticParams.variableModParameters.varModList[i].bCtermMod)
+               || g_staticParams.variableModParameters.varModList[i].bCtermMod)
             {
                // there's a mod on either termini that can appear anywhere in sequence
                return true;
@@ -5500,12 +5961,12 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
             {
                // a distance contraint limiting terminal mod to n-terminus
                if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                     && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                  && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
                {
                   return true;
                }
                if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                     && iEndPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                  && iEndPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
                {
                   return true;
                }
@@ -5516,12 +5977,12 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
             {
                // a distance contraint limiting terminal mod to c-terminus
                if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                     && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength-1)
+                  && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength - 1)
                {
                   return true;
                }
                if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                     && iEndPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength-1)
+                  && iEndPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= _proteinInfo.iTmpProteinSeqLength - 1)
                {
                   return true;
                }
@@ -5533,7 +5994,7 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
                   return true;
                // if distance constraint is from peptide n-term, make sure c-term is within that distance from the n-term
                if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                     && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                  && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
                {
                   return true;
                }
@@ -5545,7 +6006,7 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
                   return true;
                // if distance constraint is from peptide c-term, make sure n-term is within that distance from the c-term
                if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                     && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                  && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
                {
                   return true;
                }
@@ -5564,7 +6025,7 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
       // negative mods are used but will ignore that case until someone complains.
       for (i = 0; i < iSize; ++i)
       {
-         if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <=iEndPos)
+         if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <= iEndPos)
             return true;
          if (dbe->vectorPeffMod.at(i).iPosition > iEndPos)
             break;
@@ -5575,33 +6036,33 @@ bool CometSearch::HasVariableMod(int *pVarModCounts,
 }
 
 
-void CometSearch::VariableModSearch(char *szProteinSeq,
-                                    int piVarModCounts[],
-                                    int iStartPos,
-                                    int iEndPos,
-                                    int iClipNtermMetOffset, // normal =0, n-term met clipped = 1; used to address PEFF mod position
-                                    bool *pbDuplFragment,
-                                    struct sDBEntry *dbe)
+void CometSearch::VariableModSearch(char* szProteinSeq,
+   int piVarModCounts[],
+   int iStartPos,
+   int iEndPos,
+   int iClipNtermMetOffset, // normal =0, n-term met clipped = 1; used to address PEFF mod position
+   bool* pbDuplFragment,
+   struct sDBEntry* dbe)
 {
    int i,
-       ii,
-       i1,
-       i2,
-       i3,
-       i4,
-       i5,
-       i6,
-       i7,
-       i8,
-       i9,
-       i10,
-       i11,
-       i12,
-       i13,
-       i14,
-       i15,
-       piVarModCountsNC[VMODS],   // add n- and c-term mods to the counts here
-       numVarModCounts[VMODS];
+      ii,
+      i1,
+      i2,
+      i3,
+      i4,
+      i5,
+      i6,
+      i7,
+      i8,
+      i9,
+      i10,
+      i11,
+      i12,
+      i13,
+      i14,
+      i15,
+      piVarModCountsNC[VMODS],   // add n- and c-term mods to the counts here
+      numVarModCounts[VMODS];
    double dTmpMass;
 
    int piTmpTotVarModCt[VMODS];
@@ -5612,7 +6073,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
 
    vector<PeffPositionStruct> vPeffArray;
 
-   if (_proteinInfo.iPeffOrigResiduePosition >=0)
+   if (_proteinInfo.iPeffOrigResiduePosition >= 0)
       iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
    else
       iLenProteinMinus1 = _proteinInfo.iTmpProteinSeqLength - 1;
@@ -5631,7 +6092,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
       // negative mods are used but will ignore that case until someone complains.
       for (i = 0; i < iSize; ++i)
       {
-         if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <=iEndPos)
+         if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <= iEndPos)
          {
             bPeffMod = true;
 
@@ -5708,7 +6169,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
          {
             // a distance contraint limiting terminal mod to protein N-terminus
             if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                  && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+               && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
             {
                piVarModCountsNC[i] += 1;
             }
@@ -5716,7 +6177,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
             // have to be conservative here and count possible c-term mods if within iStartPos+3
             // Honestly not sure why I chose iStartPos+3 here.
             if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                  && iStartPos+3 <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+               && iStartPos + 3 <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
             {
                piVarModCountsNC[i] += 1;
             }
@@ -5725,12 +6186,12 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
          {
             // a distance contraint limiting terminal mod to protein C-terminus
             if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                  && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
+               && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
             {
                piVarModCountsNC[i] += 1;
             }
             if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                  && iEndPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
+               && iEndPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
             {
                piVarModCountsNC[i] += 1;
             }
@@ -5740,7 +6201,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
             if (g_staticParams.variableModParameters.varModList[i].bNtermMod)
                piVarModCountsNC[i] += 1;
             if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                  && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+               && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
             {
                piVarModCountsNC[i] += 1;
             }
@@ -5748,7 +6209,7 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
          else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 3)  // peptide C
          {
             if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                  && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+               && iEndPos - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
             {
                piVarModCountsNC[i] += 1;
             }
@@ -5774,598 +6235,604 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
       if (i15 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
          break;
 
-   for (i14 = 0; i14 <= numVarModCounts[VMOD_14_INDEX]; ++i14)
-   {
-      int iSum14 = i15 + i14;
-      if (iSum14 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-   for (i13 = 0; i13 <= numVarModCounts[VMOD_13_INDEX]; ++i13)
-   {
-      int iSum13 = iSum14 + i13;
-      if (iSum13 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-   for (i12 = 0; i12 <= numVarModCounts[VMOD_12_INDEX]; ++i12)
-   {
-      int iSum12 = iSum13 + i12;
-      if (iSum12 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-   for (i11 = 0; i11 <= numVarModCounts[VMOD_11_INDEX]; ++i11)
-   {
-      int iSum11 = iSum12 + i11;
-      if (iSum11 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-   for (i10 = 0; i10 <= numVarModCounts[VMOD_10_INDEX]; ++i10)
-   {
-      int iSum10 = iSum11 + i10;
-      if (iSum10 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-   for (i9 = 0; i9 <= numVarModCounts[VMOD_9_INDEX]; ++i9)
-   {
-      int iSum9 = iSum10 + i9;
-      if (iSum9 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
-         break;
-
-      for (i8 = 0; i8 <= numVarModCounts[VMOD_8_INDEX]; ++i8)
+      for (i14 = 0; i14 <= numVarModCounts[VMOD_14_INDEX]; ++i14)
       {
-         int iSum8 = i9 + i8;
-
-         if (iSum8 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+         int iSum14 = i15 + i14;
+         if (iSum14 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
             break;
 
-         for (i7 = 0; i7 <= numVarModCounts[VMOD_7_INDEX]; ++i7)
+         for (i13 = 0; i13 <= numVarModCounts[VMOD_13_INDEX]; ++i13)
          {
-            int iSum7 = iSum8 + i7;
-
-            if (iSum7 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+            int iSum13 = iSum14 + i13;
+            if (iSum13 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                break;
 
-            for (i6 = 0; i6 <= numVarModCounts[VMOD_6_INDEX]; ++i6)
+            for (i12 = 0; i12 <= numVarModCounts[VMOD_12_INDEX]; ++i12)
             {
-               int iSum6 = iSum7 + i6;
-
-               if (iSum6 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+               int iSum12 = iSum13 + i12;
+               if (iSum12 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                   break;
 
-               for (i5 = 0; i5 <= numVarModCounts[VMOD_5_INDEX]; ++i5)
+               for (i11 = 0; i11 <= numVarModCounts[VMOD_11_INDEX]; ++i11)
                {
-                  int iSum5 = iSum6 + i5;
-
-                  if (iSum5 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                  int iSum11 = iSum12 + i11;
+                  if (iSum11 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                      break;
 
-                  for (i4 = 0; i4 <= numVarModCounts[VMOD_4_INDEX]; ++i4)
+                  for (i10 = 0; i10 <= numVarModCounts[VMOD_10_INDEX]; ++i10)
                   {
-                     int iSum4 = iSum5 + i4;
-
-                     if (iSum4 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                     int iSum10 = iSum11 + i10;
+                     if (iSum10 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                         break;
 
-                     for (i3 = 0; i3 <= numVarModCounts[VMOD_3_INDEX]; ++i3)
+                     for (i9 = 0; i9 <= numVarModCounts[VMOD_9_INDEX]; ++i9)
                      {
-                        int iSum3 = iSum4 + i3;
-
-                        if (iSum3 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                        int iSum9 = iSum10 + i9;
+                        if (iSum9 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                            break;
 
-                        for (i2 = 0; i2 <= numVarModCounts[VMOD_2_INDEX]; ++i2)
+                        for (i8 = 0; i8 <= numVarModCounts[VMOD_8_INDEX]; ++i8)
                         {
-                           int iSum2 = iSum3 + i2;
+                           int iSum8 = i9 + i8;
 
-                           if (iSum2 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                           if (iSum8 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                               break;
 
-                           for (i1 = 0; i1 <= numVarModCounts[VMOD_1_INDEX]; ++i1)
+                           for (i7 = 0; i7 <= numVarModCounts[VMOD_7_INDEX]; ++i7)
                            {
-                              int iSum1 = iSum2 + i1;
+                              int iSum7 = iSum8 + i7;
 
-                              if (iSum1 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                              if (iSum7 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
                                  break;
 
-                              int piTmpVarModCounts[] = {i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15};
-
-                              if (i1>0 || i2>0 || i3>0 || i4>0 || i5>0 || i6>0 || i7>0 || i8>0 || i9>0
-                                 || i10>0 || i11>0 || i12>0 || i13>0 || i14>0 || i15>0 || bPeffMod)
+                              for (i6 = 0; i6 <= numVarModCounts[VMOD_6_INDEX]; ++i6)
                               {
-                                 bool bPass = true;
+                                 int iSum6 = iSum7 + i6;
 
-                                 if (i1 > 0 && i1 < g_staticParams.variableModParameters.varModList[VMOD_1_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i2 > 0 && i2 < g_staticParams.variableModParameters.varModList[VMOD_2_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i3 > 0 && i3 < g_staticParams.variableModParameters.varModList[VMOD_3_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i4 > 0 && i4 < g_staticParams.variableModParameters.varModList[VMOD_4_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i5 > 0 && i5 < g_staticParams.variableModParameters.varModList[VMOD_5_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i6 > 0 && i6 < g_staticParams.variableModParameters.varModList[VMOD_6_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i7 > 0 && i7 < g_staticParams.variableModParameters.varModList[VMOD_7_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i8 > 0 && i8 < g_staticParams.variableModParameters.varModList[VMOD_8_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i9 > 0 && i9 < g_staticParams.variableModParameters.varModList[VMOD_9_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i10 > 0 && i10 < g_staticParams.variableModParameters.varModList[VMOD_10_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i11 > 0 && i11 < g_staticParams.variableModParameters.varModList[VMOD_11_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i12 > 0 && i12 < g_staticParams.variableModParameters.varModList[VMOD_12_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i13 > 0 && i13 < g_staticParams.variableModParameters.varModList[VMOD_13_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i14 > 0 && i14 < g_staticParams.variableModParameters.varModList[VMOD_14_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
-                                 if (i15 > 0 && i15 < g_staticParams.variableModParameters.varModList[VMOD_15_INDEX].iMinNumVarModAAPerMod)
-                                    bPass = false;
+                                 if (iSum6 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                    break;
 
-                                 if (bPass && g_staticParams.variableModParameters.bRareVarModPresent)
+                                 for (i5 = 0; i5 <= numVarModCounts[VMOD_5_INDEX]; ++i5)
                                  {
-                                    // check rare mods ... only allow one of those at a time
-                                    int iCountRareMods = 0;
-                                    for (int xx = 0; xx < VMODS; ++xx)
+                                    int iSum5 = iSum6 + i5;
+
+                                    if (iSum5 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                       break;
+
+                                    for (i4 = 0; i4 <= numVarModCounts[VMOD_4_INDEX]; ++i4)
                                     {
-                                       if (g_staticParams.variableModParameters.varModList[xx].iRequireThisMod == -1 && piTmpVarModCounts[xx] > 0)
-                                          iCountRareMods++;
-                                    }
-                                    if (iCountRareMods > 1)  // only allow 1 rare mod at a time
-                                       bPass = false;
-                                 }
+                                       int iSum4 = iSum5 + i4;
 
-                                 if (bPass)
-                                 {
-                                    double dCalcPepMass;
-                                    int iTmpEnd;
-                                    char cResidue;
+                                       if (iSum4 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                          break;
 
-                                    dCalcPepMass = dTmpMass + TotalVarModMass(piTmpVarModCounts);
-
-                                    for (i = 0; i < VMODS; ++i)
-                                    {
-                                       // this variable tracks how many of each variable mod is in the peptide
-                                       _varModInfo.varModStatList[i].iTotVarModCt = 0;
-                                       _varModInfo.varModStatList[i].iTotBinaryModCt = 0;
-                                    }
-
-                                    // The start of the peptide is established; need to evaluate
-                                    // where the end of the peptide is.
-                                    for (iTmpEnd = iStartPos; iTmpEnd <= iEndPos; ++iTmpEnd)
-                                    {
-                                       if (iTmpEnd - iStartPos + 1 <= g_staticParams.options.peptideLengthRange.iEnd)
+                                       for (i3 = 0; i3 <= numVarModCounts[VMOD_3_INDEX]; ++i3)
                                        {
-                                          cResidue = szProteinSeq[iTmpEnd];
+                                          int iSum3 = iSum4 + i3;
 
-                                          dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[(int)cResidue];
+                                          if (iSum3 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                             break;
 
-                                          for (i = 0; i < VMODS; ++i)
+                                          for (i2 = 0; i2 <= numVarModCounts[VMOD_2_INDEX]; ++i2)
                                           {
-                                             if (g_staticParams.variableModParameters.varModList[i].bUseMod)
+                                             int iSum2 = iSum3 + i2;
+
+                                             if (iSum2 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                                break;
+
+                                             for (i1 = 0; i1 <= numVarModCounts[VMOD_1_INDEX]; ++i1)
                                              {
-                                                // look at residues first
-                                                if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+                                                int iSum1 = iSum2 + i1;
+
+                                                if (iSum1 > g_staticParams.variableModParameters.iMaxVarModPerPeptide)
+                                                   break;
+
+                                                int piTmpVarModCounts[] = { i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15 };
+
+                                                if (i1 > 0 || i2 > 0 || i3 > 0 || i4 > 0 || i5 > 0 || i6 > 0 || i7 > 0 || i8 > 0 || i9 > 0
+                                                   || i10 > 0 || i11 > 0 || i12 > 0 || i13 > 0 || i14 > 0 || i15 > 0 || bPeffMod)
                                                 {
-                                                   if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
-                                                      _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                   bool bPass = true;
 
-                                                   else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
+                                                   if (i1 > 0 && i1 < g_staticParams.variableModParameters.varModList[VMOD_1_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i2 > 0 && i2 < g_staticParams.variableModParameters.varModList[VMOD_2_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i3 > 0 && i3 < g_staticParams.variableModParameters.varModList[VMOD_3_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i4 > 0 && i4 < g_staticParams.variableModParameters.varModList[VMOD_4_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i5 > 0 && i5 < g_staticParams.variableModParameters.varModList[VMOD_5_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i6 > 0 && i6 < g_staticParams.variableModParameters.varModList[VMOD_6_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i7 > 0 && i7 < g_staticParams.variableModParameters.varModList[VMOD_7_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i8 > 0 && i8 < g_staticParams.variableModParameters.varModList[VMOD_8_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i9 > 0 && i9 < g_staticParams.variableModParameters.varModList[VMOD_9_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i10 > 0 && i10 < g_staticParams.variableModParameters.varModList[VMOD_10_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i11 > 0 && i11 < g_staticParams.variableModParameters.varModList[VMOD_11_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i12 > 0 && i12 < g_staticParams.variableModParameters.varModList[VMOD_12_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i13 > 0 && i13 < g_staticParams.variableModParameters.varModList[VMOD_13_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i14 > 0 && i14 < g_staticParams.variableModParameters.varModList[VMOD_14_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+                                                   if (i15 > 0 && i15 < g_staticParams.variableModParameters.varModList[VMOD_15_INDEX].iMinNumVarModAAPerMod)
+                                                      bPass = false;
+
+                                                   if (bPass && g_staticParams.variableModParameters.bRareVarModPresent)
                                                    {
-                                                      if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                         _varModInfo.varModStatList[i].iTotVarModCt++;
-                                                   }
-                                                   else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
-                                                   {
-                                                      if (iTmpEnd + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
-                                                            >= iLenProteinMinus1)
+                                                      // check rare mods ... only allow one of those at a time
+                                                      int iCountRareMods = 0;
+                                                      for (int xx = 0; xx < VMODS; ++xx)
                                                       {
-                                                         _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                         if (g_staticParams.variableModParameters.varModList[xx].iRequireThisMod == -1 && piTmpVarModCounts[xx] > 0)
+                                                            iCountRareMods++;
                                                       }
-                                                   }
-                                                   else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
-                                                   {
-                                                      if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                         _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                      if (iCountRareMods > 1)  // only allow 1 rare mod at a time
+                                                         bPass = false;
                                                    }
 
-                                                   // analyse peptide C term mod later as iTmpEnd is variable
-                                                }
-
-                                                // consider n-term mods only for start residue
-                                                if (iTmpEnd == iStartPos)
-                                                {
-                                                   if (g_staticParams.variableModParameters.varModList[i].bNtermMod
-                                                         && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
-                                                            || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
-                                                               && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                            || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
-                                                                  &&  iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
-                                                                  >= iLenProteinMinus1)
-                                                            || g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2))
+                                                   if (bPass)
                                                    {
-                                                      _varModInfo.varModStatList[i].iTotVarModCt++;
-                                                   }
-                                                }
-                                             }
-                                          }
+                                                      double dCalcPepMass;
+                                                      int iTmpEnd;
+                                                      char cResidue;
 
-                                          if (g_staticParams.variableModParameters.bBinaryModSearch)
-                                          {
-                                             // make iTotBinaryModCt similar to iTotVarModCt but count the
-                                             // number of mod sites in peptide for that particular binary
-                                             // mod group and store in first group entry
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                bool bMatched=false;
+                                                      dCalcPepMass = dTmpMass + TotalVarModMass(piTmpVarModCounts);
 
-                                                if (g_staticParams.variableModParameters.varModList[i].iBinaryMod
-                                                      && g_staticParams.variableModParameters.varModList[i].bUseMod
-                                                      && !bMatched)
-                                                {
-                                                   int ii;
-
-                                                   if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
-                                                   {
-                                                      if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                      for (i = 0; i < VMODS; ++i)
                                                       {
-                                                         _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                         bMatched = true;
+                                                         // this variable tracks how many of each variable mod is in the peptide
+                                                         _varModInfo.varModStatList[i].iTotVarModCt = 0;
+                                                         _varModInfo.varModStatList[i].iTotBinaryModCt = 0;
                                                       }
-                                                      else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
+
+                                                      // The start of the peptide is established; need to evaluate
+                                                      // where the end of the peptide is.
+                                                      for (iTmpEnd = iStartPos; iTmpEnd <= iEndPos; ++iTmpEnd)
                                                       {
-                                                         if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                         if (iTmpEnd - iStartPos + 1 <= g_staticParams.options.peptideLengthRange.iEnd)
                                                          {
-                                                            _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                            bMatched = true;
-                                                         }
-                                                      }
-                                                      else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
-                                                      {
-                                                         if (iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
-                                                               >= iLenProteinMinus1)
-                                                         {
-                                                            _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                            bMatched = true;
-                                                         }
-                                                      }
-                                                      else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
-                                                      {
-                                                         if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                         {
-                                                            _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                            bMatched = true;
-                                                         }
-                                                      }
+                                                            cResidue = szProteinSeq[iTmpEnd];
 
-                                                      // analyse peptide C term mod later as iTmpEnd is variable
-                                                   }
+                                                            dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[(int)cResidue];
 
-                                                   // if we didn't increment iTotBinaryModCt for base mod in group
-                                                   if (!bMatched)
-                                                   {
-                                                      for (ii = i + 1; ii < VMODS; ++ii)
-                                                      {
-                                                         if (g_staticParams.variableModParameters.varModList[ii].bUseMod
-                                                               && (g_staticParams.variableModParameters.varModList[ii].iBinaryMod
-                                                                  == g_staticParams.variableModParameters.varModList[i].iBinaryMod)
-                                                               && strchr(g_staticParams.variableModParameters.varModList[ii].szVarModChar, cResidue))
-                                                         {
-                                                            if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                            for (i = 0; i < VMODS; ++i)
                                                             {
-                                                               _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                               bMatched=true;
-                                                            }
-                                                            else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
-                                                            {
-                                                               if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                               if (g_staticParams.variableModParameters.varModList[i].bUseMod)
                                                                {
-                                                                  _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                                  bMatched=true;
+                                                                  // look at residues first
+                                                                  if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+                                                                  {
+                                                                     if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                                        _varModInfo.varModStatList[i].iTotVarModCt++;
+
+                                                                     else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
+                                                                     {
+                                                                        if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                     }
+                                                                     else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
+                                                                     {
+                                                                        if (iTmpEnd + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
+                                                                           >= iLenProteinMinus1)
+                                                                        {
+                                                                           _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                        }
+                                                                     }
+                                                                     else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
+                                                                     {
+                                                                        if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                     }
+
+                                                                     // analyse peptide C term mod later as iTmpEnd is variable
+                                                                  }
+
+                                                                  // consider n-term mods only for start residue
+                                                                  if (iTmpEnd == iStartPos)
+                                                                  {
+                                                                     if (g_staticParams.variableModParameters.varModList[i].bNtermMod
+                                                                        && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                                           || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
+                                                                              && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
+                                                                              && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
+                                                                              >= iLenProteinMinus1)
+                                                                           || g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2))
+                                                                     {
+                                                                        _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                     }
+                                                                  }
                                                                }
                                                             }
-                                                            else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
+
+                                                            if (g_staticParams.variableModParameters.bBinaryModSearch)
                                                             {
-                                                               if (iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
+                                                               // make iTotBinaryModCt similar to iTotVarModCt but count the
+                                                               // number of mod sites in peptide for that particular binary
+                                                               // mod group and store in first group entry
+                                                               for (i = 0; i < VMODS; ++i)
                                                                {
-                                                                  _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                                  bMatched=true;
+                                                                  bool bMatched = false;
+
+                                                                  if (g_staticParams.variableModParameters.varModList[i].iBinaryMod
+                                                                     && g_staticParams.variableModParameters.varModList[i].bUseMod
+                                                                     && !bMatched)
+                                                                  {
+                                                                     int ii;
+
+                                                                     if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+                                                                     {
+                                                                        if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                                        {
+                                                                           _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                           bMatched = true;
+                                                                        }
+                                                                        else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
+                                                                        {
+                                                                           if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           {
+                                                                              _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                              bMatched = true;
+                                                                           }
+                                                                        }
+                                                                        else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
+                                                                        {
+                                                                           if (iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
+                                                                              >= iLenProteinMinus1)
+                                                                           {
+                                                                              _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                              bMatched = true;
+                                                                           }
+                                                                        }
+                                                                        else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
+                                                                        {
+                                                                           if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           {
+                                                                              _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                              bMatched = true;
+                                                                           }
+                                                                        }
+
+                                                                        // analyse peptide C term mod later as iTmpEnd is variable
+                                                                     }
+
+                                                                     // if we didn't increment iTotBinaryModCt for base mod in group
+                                                                     if (!bMatched)
+                                                                     {
+                                                                        for (ii = i + 1; ii < VMODS; ++ii)
+                                                                        {
+                                                                           if (g_staticParams.variableModParameters.varModList[ii].bUseMod
+                                                                              && (g_staticParams.variableModParameters.varModList[ii].iBinaryMod
+                                                                                 == g_staticParams.variableModParameters.varModList[i].iBinaryMod)
+                                                                              && strchr(g_staticParams.variableModParameters.varModList[ii].szVarModChar, cResidue))
+                                                                           {
+                                                                              if (g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                                              {
+                                                                                 _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                                 bMatched = true;
+                                                                              }
+                                                                              else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0) // protein N
+                                                                              {
+                                                                                 if (iTmpEnd <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                                 {
+                                                                                    _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                                    bMatched = true;
+                                                                                 }
+                                                                              }
+                                                                              else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1) // protein C
+                                                                              {
+                                                                                 if (iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
+                                                                                 {
+                                                                                    _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                                    bMatched = true;
+                                                                                 }
+                                                                              }
+                                                                              else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
+                                                                              {
+                                                                                 if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                                 {
+                                                                                    _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                                    bMatched = true;
+                                                                                 }
+                                                                              }
+                                                                           }
+
+                                                                           if (bMatched)
+                                                                              break;
+                                                                        }
+                                                                     }
+
+                                                                     // consider n-term mods only for start residue
+                                                                     if (iTmpEnd == iStartPos)
+                                                                     {
+                                                                        if (g_staticParams.variableModParameters.varModList[i].bUseMod
+                                                                           && g_staticParams.variableModParameters.varModList[i].bNtermMod
+                                                                           && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
+                                                                              || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
+                                                                                 && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                              || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
+                                                                                 && iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
+                                                                                 >= _proteinInfo.iTmpProteinSeqLength - 1)
+                                                                              || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2)))
+                                                                        {
+                                                                           _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                           bMatched = true;
+                                                                        }
+
+                                                                        if (!bMatched)
+                                                                        {
+                                                                           for (ii = i + 1; ii < VMODS; ++ii)
+                                                                           {
+                                                                              if (g_staticParams.variableModParameters.varModList[ii].bUseMod
+                                                                                 && (g_staticParams.variableModParameters.varModList[ii].iBinaryMod
+                                                                                    == g_staticParams.variableModParameters.varModList[i].iBinaryMod)
+                                                                                 && g_staticParams.variableModParameters.varModList[ii].bNtermMod)
+                                                                              {
+                                                                                 _varModInfo.varModStatList[i].iTotBinaryModCt++;
+                                                                                 bMatched = true;
+                                                                              }
+
+                                                                              if (bMatched)
+                                                                                 break;
+                                                                           }
+                                                                        }
+                                                                     }
+                                                                  }
                                                                }
                                                             }
-                                                            else if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2) // peptide N
+
+
+                                                            bool bValid = true;
+
+                                                            // since we're varying iEndPos, check enzyme consistency first
+                                                            if (!CheckEnzymeTermini(szProteinSeq, iStartPos, iTmpEnd))
+                                                               bValid = false;
+
+                                                            if (bValid)
                                                             {
-                                                               if (iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                               // at this point, consider variable c-term mod at iTmpEnd position
+                                                               for (i = 0; i < VMODS; ++i)
                                                                {
-                                                                  _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                                  bMatched=true;
+                                                                  // Store current number of iTotVarModCt because we're going to possibly
+                                                                  // increment it for variable c-term mod.  But as we continue to extend iEndPos,
+                                                                  // we need to temporarily save this value here and restore it later.
+                                                                  piTmpTotVarModCt[i] = _varModInfo.varModStatList[i].iTotVarModCt;
+                                                                  piTmpTotBinaryModCt[i] = _varModInfo.varModStatList[i].iTotBinaryModCt;
+
+                                                                  // Add in possible c-term variable mods
+                                                                  if (g_staticParams.variableModParameters.varModList[i].bUseMod)
+                                                                  {
+                                                                     if (g_staticParams.variableModParameters.varModList[i].bCtermMod
+                                                                        && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0
+                                                                           || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
+                                                                              && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
+                                                                              && iTmpEnd + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
+                                                                           || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2
+                                                                              && iTmpEnd - iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                           || g_staticParams.variableModParameters.varModList[i].iWhichTerm == 3)))
+                                                                     {
+                                                                        _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                     }
+                                                                  }
+                                                               }
+
+                                                               // also need to consider all residue mods that have a peptide c-term distance
+                                                               // constraint because these depend on iTmpEnd which was not defined until now
+                                                               int x;
+                                                               for (x = iStartPos; x <= iTmpEnd; ++x)
+                                                               {
+                                                                  cResidue = szProteinSeq[x];
+
+                                                                  for (i = 0; i < VMODS; ++i)
+                                                                  {
+                                                                     if (g_staticParams.variableModParameters.varModList[i].bUseMod)
+                                                                     {
+                                                                        if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
+                                                                        {
+                                                                           if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 3)  //c-term pep
+                                                                           {
+                                                                              if (iTmpEnd - x <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
+                                                                                 _varModInfo.varModStatList[i].iTotVarModCt++;
+                                                                           }
+                                                                        }
+                                                                     }
+                                                                  }
+                                                               }
+                                                            }
+
+                                                            if (bValid && !g_staticParams.variableModParameters.bBinaryModSearch)
+                                                            {
+
+                                                               // Check to make sure # required mod are actually present in
+                                                               // current peptide since the end position is variable.
+                                                               for (i = 0; i < VMODS; ++i)
+                                                               {
+                                                                  // varModStatList[i].iTotVarModCt contains # of mod residues in current
+                                                                  // peptide defined by iTmpEnd.  Since piTmpVarModCounts contains # of
+                                                                  // each variable mod to match peptide mass, need to make sure that
+                                                                  // piTmpVarModCounts is not greater than varModStatList[i].iTotVarModCt.
+
+                                                                  // if number of expected modifications is greater than # of modifiable residues
+                                                                  // within start/end then not possible
+                                                                  if (piTmpVarModCounts[i] > _varModInfo.varModStatList[i].iTotVarModCt)
+                                                                  {
+                                                                     bValid = false;
+                                                                     break;
+                                                                  }
+                                                               }
+                                                            }
+
+                                                            if (bValid && g_staticParams.variableModParameters.bBinaryModSearch)
+                                                            {
+                                                               int ii;
+                                                               bool bUsed[VMODS];
+
+                                                               for (ii = 0; ii < VMODS; ++ii)
+                                                                  bUsed[ii] = false;
+
+                                                               // walk through all list of mods, find those with the same iBinaryMod value,
+                                                               // and make sure all mods are accounted for
+                                                               for (i = 0; i < VMODS; ++i)
+                                                               {
+                                                                  // check for binary mods; since multiple sets of binary mods can be
+                                                                  // specified with logical OR, need to compare the sets
+                                                                  int iSumTmpVarModCounts = 0;
+
+                                                                  if (!bUsed[i] && g_staticParams.variableModParameters.varModList[i].iBinaryMod)
+                                                                  {
+                                                                     iSumTmpVarModCounts += piTmpVarModCounts[i];
+
+                                                                     bUsed[i] = true;
+
+                                                                     for (ii = i + 1; ii < VMODS; ++ii)
+                                                                     {
+                                                                        if ((g_staticParams.variableModParameters.varModList[ii].iBinaryMod
+                                                                           == g_staticParams.variableModParameters.varModList[i].iBinaryMod))
+                                                                        {
+                                                                           bUsed[ii] = true;
+                                                                           iSumTmpVarModCounts += piTmpVarModCounts[ii];
+                                                                        }
+                                                                     }
+
+                                                                     // the set sum counts must match total # of mods in peptide
+                                                                     if (iSumTmpVarModCounts != 0
+                                                                        && iSumTmpVarModCounts != _varModInfo.varModStatList[i].iTotBinaryModCt)
+                                                                     {
+                                                                        bValid = false;
+                                                                        break;
+                                                                     }
+                                                                  }
+
+                                                                  if (piTmpVarModCounts[i] > _varModInfo.varModStatList[i].iTotVarModCt)
+                                                                  {
+                                                                     bValid = false;
+                                                                     break;
+                                                                  }
+                                                               }
+                                                            }
+
+                                                            if (bValid && g_staticParams.variableModParameters.iRequireVarMod)
+                                                            {
+                                                               // Check to see if required mods are satisfied; here, we're just making
+                                                               // sure the number of possible modified residues for each mod is non-zero
+                                                               // so don't worry about distance constraint issues yet.
+                                                               for (i = 0; i < VMODS; ++i)
+                                                               {
+                                                                  if (g_staticParams.variableModParameters.varModList[i].iRequireThisMod > 0
+                                                                     && piTmpVarModCounts[i] == 0)
+                                                                  {
+                                                                     bValid = false;
+                                                                     break;
+                                                                  }
+                                                               }
+
+                                                               if (!bValid)
+                                                               {
+                                                                  // Above checked to see if any individual required variable mod is present.
+                                                                  // If we pass above, now check if logical OR of one from a set of mods
+                                                                  // is present.
+                                                                  bValid = false;
+                                                                  for (i = 0; i < VMODS; ++i)
+                                                                  {
+                                                                     if (((g_staticParams.variableModParameters.iRequireVarMod >> (i + 1)) & 1U)
+                                                                        && piTmpVarModCounts[i] > 0)
+                                                                     {
+                                                                        bValid = true;
+                                                                        break;
+                                                                     }
+                                                                  }
+                                                               }
+                                                            }
+
+                                                            if (bValid && HasVariableMod(piTmpVarModCounts, iStartPos, iTmpEnd, dbe))
+                                                            {
+                                                               // mass including terminal mods that need to be tracked separately here
+                                                               // because we are considering multiple terminating positions in peptide
+                                                               double dTmpCalcPepMass;
+
+                                                               dTmpCalcPepMass = dCalcPepMass;
+
+                                                               // static protein terminal mod
+                                                               if (iTmpEnd == iLenProteinMinus1)
+                                                                  dTmpCalcPepMass += g_staticParams.staticModifications.dAddCterminusProtein;
+
+                                                               int iWhichQuery = WithinMassTolerance(dTmpCalcPepMass, szProteinSeq, iStartPos, iTmpEnd);
+
+                                                               bool bDoPeffAnalysis = false;
+
+                                                               // Need to see if peptide + PEFF mod is within mass tolerance of any query.
+                                                               if (bPeffMod)
+                                                               {
+                                                                  bool bPeff = false;
+
+                                                                  // Only need to return true/false here to know whether or not to permute
+                                                                  // through PEFF mods later.  So as long as just 1 combination of PEFF
+                                                                  // mods work, that's great.
+
+                                                                  // First see if PEFF mods are within iStartPos and iTmpEnd
+                                                                  int iPeffModSize = (int)dbe->vectorPeffMod.size();
+                                                                  for (i = 0; i < iPeffModSize; ++i)
+                                                                  {
+                                                                     if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <= iTmpEnd)
+                                                                     {
+                                                                        bPeff = true;
+                                                                        break;
+                                                                     }
+                                                                  }
+
+                                                                  if (bPeff)
+                                                                     bDoPeffAnalysis = WithinMassTolerancePeff(dTmpCalcPepMass, &vPeffArray, iStartPos, iTmpEnd);
+                                                               }
+
+                                                               if (iWhichQuery != -1 || bDoPeffAnalysis)
+                                                               {
+                                                                  // We know that mass is within some query's tolerance range so
+                                                                  // now need to permute variable mods and at each permutation calculate
+                                                                  // fragment ions once and loop through all matching spectra to score.
+                                                                  for (i = 0; i < VMODS; ++i)
+                                                                  {
+                                                                     if (g_staticParams.variableModParameters.varModList[i].dVarModMass > 0.0 && piTmpVarModCounts[i] > 0)
+                                                                     {
+                                                                        memset(_varModInfo.varModStatList[i].iVarModSites, 0, _usiSizepiVarModSites);
+                                                                     }
+
+                                                                     _varModInfo.varModStatList[i].iMatchVarModCt = piTmpVarModCounts[i];
+                                                                  }
+
+                                                                  _varModInfo.iStartPos = iStartPos;
+                                                                  _varModInfo.iEndPos = iTmpEnd;
+                                                                  _varModInfo.dCalcPepMass = dCalcPepMass;
+
+                                                                  // iTmpEnd-iStartPos+3 = length of peptide +2 (for n/c-term)
+                                                                  PermuteMods(szProteinSeq, iWhichQuery, 1, iClipNtermMetOffset, pbDuplFragment, &bDoPeffAnalysis, &vPeffArray, dbe);
+                                                               }
+                                                            }
+
+                                                            if (bValid)
+                                                            {
+                                                               for (i = 0; i < VMODS; ++i)
+                                                               {
+                                                                  _varModInfo.varModStatList[i].iTotVarModCt = piTmpTotVarModCt[i];
+                                                                  _varModInfo.varModStatList[i].iTotBinaryModCt = piTmpTotBinaryModCt[i];
                                                                }
                                                             }
                                                          }
-
-                                                         if (bMatched)
-                                                            break;
-                                                      }
-                                                   }
-
-                                                   // consider n-term mods only for start residue
-                                                   if (iTmpEnd == iStartPos)
-                                                   {
-                                                      if (g_staticParams.variableModParameters.varModList[i].bUseMod
-                                                            && g_staticParams.variableModParameters.varModList[i].bNtermMod
-                                                            && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0)
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
-                                                                  && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
-                                                                     &&  iStartPos + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance
-                                                                     >= _proteinInfo.iTmpProteinSeqLength-1)
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2)))
-                                                      {
-                                                         _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                         bMatched=true;
-                                                      }
-
-                                                      if (!bMatched)
-                                                      {
-                                                         for (ii = i + 1; ii < VMODS; ++ii)
-                                                         {
-                                                            if (g_staticParams.variableModParameters.varModList[ii].bUseMod
-                                                                  && (g_staticParams.variableModParameters.varModList[ii].iBinaryMod
-                                                                     == g_staticParams.variableModParameters.varModList[i].iBinaryMod)
-                                                                  && g_staticParams.variableModParameters.varModList[ii].bNtermMod)
-                                                            {
-                                                               _varModInfo.varModStatList[i].iTotBinaryModCt++;
-                                                               bMatched=true;
-                                                            }
-
-                                                            if (bMatched)
-                                                               break;
-                                                         }
-                                                      }
+                                                      } // loop through iStartPos to iEndPos
                                                    }
                                                 }
-                                             }
-                                          }
-
-
-                                          bool bValid = true;
-
-                                          // since we're varying iEndPos, check enzyme consistency first
-                                          if (!CheckEnzymeTermini(szProteinSeq, iStartPos, iTmpEnd))
-                                             bValid = false;
-
-                                          if (bValid)
-                                          {
-                                             // at this point, consider variable c-term mod at iTmpEnd position
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                // Store current number of iTotVarModCt because we're going to possibly
-                                                // increment it for variable c-term mod.  But as we continue to extend iEndPos,
-                                                // we need to temporarily save this value here and restore it later.
-                                                piTmpTotVarModCt[i] = _varModInfo.varModStatList[i].iTotVarModCt;
-                                                piTmpTotBinaryModCt[i] = _varModInfo.varModStatList[i].iTotBinaryModCt;
-
-                                                // Add in possible c-term variable mods
-                                                if (g_staticParams.variableModParameters.varModList[i].bUseMod)
-                                                {
-                                                   if (g_staticParams.variableModParameters.varModList[i].bCtermMod
-                                                         && ((g_staticParams.variableModParameters.varModList[i].iVarModTermDistance < 0
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 0
-                                                                  && iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 1
-                                                                  &&  iTmpEnd + g_staticParams.variableModParameters.varModList[i].iVarModTermDistance >= iLenProteinMinus1)
-                                                               || (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 2
-                                                                  && iTmpEnd-iStartPos <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                               || g_staticParams.variableModParameters.varModList[i].iWhichTerm == 3)))
-                                                   {
-                                                      _varModInfo.varModStatList[i].iTotVarModCt++;
-                                                   }
-                                                }
-                                             }
-
-                                             // also need to consider all residue mods that have a peptide c-term distance
-                                             // constraint because these depend on iTmpEnd which was not defined until now
-                                             int x;
-                                             for (x = iStartPos; x <= iTmpEnd; ++x)
-                                             {
-                                                cResidue = szProteinSeq[x];
-
-                                                for (i = 0; i < VMODS; ++i)
-                                                {
-                                                   if (g_staticParams.variableModParameters.varModList[i].bUseMod)
-                                                   {
-                                                      if (strchr(g_staticParams.variableModParameters.varModList[i].szVarModChar, cResidue))
-                                                      {
-                                                         if (g_staticParams.variableModParameters.varModList[i].iWhichTerm == 3)  //c-term pep
-                                                         {
-                                                            if (iTmpEnd - x <= g_staticParams.variableModParameters.varModList[i].iVarModTermDistance)
-                                                               _varModInfo.varModStatList[i].iTotVarModCt++;
-                                                         }
-                                                      }
-                                                   }
-                                                }
-                                             }
-                                          }
-
-                                          if (bValid && !g_staticParams.variableModParameters.bBinaryModSearch)
-                                          {
-
-                                             // Check to make sure # required mod are actually present in
-                                             // current peptide since the end position is variable.
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                // varModStatList[i].iTotVarModCt contains # of mod residues in current
-                                                // peptide defined by iTmpEnd.  Since piTmpVarModCounts contains # of
-                                                // each variable mod to match peptide mass, need to make sure that
-                                                // piTmpVarModCounts is not greater than varModStatList[i].iTotVarModCt.
-
-                                                // if number of expected modifications is greater than # of modifiable residues
-                                                // within start/end then not possible
-                                                if (piTmpVarModCounts[i] > _varModInfo.varModStatList[i].iTotVarModCt)
-                                                {
-                                                   bValid = false;
-                                                   break;
-                                                }
-                                             }
-                                          }
-
-                                          if (bValid && g_staticParams.variableModParameters.bBinaryModSearch)
-                                          {
-                                             int ii;
-                                             bool bUsed[VMODS];
-
-                                             for (ii = 0; ii < VMODS; ++ii)
-                                                bUsed[ii] = false;
-
-                                             // walk through all list of mods, find those with the same iBinaryMod value,
-                                             // and make sure all mods are accounted for
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                // check for binary mods; since multiple sets of binary mods can be
-                                                // specified with logical OR, need to compare the sets
-                                                int iSumTmpVarModCounts=0;
-
-                                                if (!bUsed[i] && g_staticParams.variableModParameters.varModList[i].iBinaryMod)
-                                                {
-                                                   iSumTmpVarModCounts += piTmpVarModCounts[i];
-
-                                                   bUsed[i]=true;
-
-                                                   for (ii = i + 1; ii < VMODS; ++ii)
-                                                   {
-                                                      if ((g_staticParams.variableModParameters.varModList[ii].iBinaryMod
-                                                               == g_staticParams.variableModParameters.varModList[i].iBinaryMod))
-                                                      {
-                                                         bUsed[ii]=true;
-                                                         iSumTmpVarModCounts += piTmpVarModCounts[ii];
-                                                      }
-                                                   }
-
-                                                   // the set sum counts must match total # of mods in peptide
-                                                   if (iSumTmpVarModCounts != 0
-                                                         && iSumTmpVarModCounts != _varModInfo.varModStatList[i].iTotBinaryModCt)
-                                                   {
-                                                      bValid = false;
-                                                      break;
-                                                   }
-                                                }
-
-                                                if (piTmpVarModCounts[i] > _varModInfo.varModStatList[i].iTotVarModCt)
-                                                {
-                                                   bValid = false;
-                                                   break;
-                                                }
-                                             }
-                                          }
-
-                                          if (bValid && g_staticParams.variableModParameters.iRequireVarMod)
-                                          {
-                                             // Check to see if required mods are satisfied; here, we're just making
-                                             // sure the number of possible modified residues for each mod is non-zero
-                                             // so don't worry about distance constraint issues yet.
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                if (g_staticParams.variableModParameters.varModList[i].iRequireThisMod > 0
-                                                      && piTmpVarModCounts[i] == 0)
-                                                {
-                                                   bValid = false;
-                                                   break;
-                                                }
-                                             }
-
-                                             if (!bValid)
-                                             {
-                                                // Above checked to see if any individual required variable mod is present.
-                                                // If we pass above, now check if logical OR of one from a set of mods
-                                                // is present.
-                                                bValid = false;
-                                                for (i = 0; i < VMODS; ++i)
-                                                {
-                                                   if (((g_staticParams.variableModParameters.iRequireVarMod >> (i+1)) & 1U)
-                                                         && piTmpVarModCounts[i] > 0)
-                                                   {
-                                                      bValid = true;
-                                                      break;
-                                                   }
-                                                }
-                                             }
-                                          }
-
-                                          if (bValid && HasVariableMod(piTmpVarModCounts, iStartPos, iTmpEnd, dbe))
-                                          {
-                                             // mass including terminal mods that need to be tracked separately here
-                                             // because we are considering multiple terminating positions in peptide
-                                             double dTmpCalcPepMass;
-
-                                             dTmpCalcPepMass = dCalcPepMass;
-
-                                             // static protein terminal mod
-                                             if (iTmpEnd == iLenProteinMinus1)
-                                                dTmpCalcPepMass += g_staticParams.staticModifications.dAddCterminusProtein;
-
-                                             int iWhichQuery = WithinMassTolerance(dTmpCalcPepMass, szProteinSeq, iStartPos, iTmpEnd);
-
-                                             bool bDoPeffAnalysis = false;
-
-                                             // Need to see if peptide + PEFF mod is within mass tolerance of any query.
-                                             if (bPeffMod)
-                                             {
-                                                bool bPeff = false;
-
-                                                // Only need to return true/false here to know whether or not to permute
-                                                // through PEFF mods later.  So as long as just 1 combination of PEFF
-                                                // mods work, that's great.
-
-                                                // First see if PEFF mods are within iStartPos and iTmpEnd
-                                                int iPeffModSize = (int)dbe->vectorPeffMod.size();
-                                                for (i = 0; i < iPeffModSize; ++i)
-                                                {
-                                                   if (dbe->vectorPeffMod.at(i).iPosition >= iStartPos && dbe->vectorPeffMod.at(i).iPosition <=iTmpEnd)
-                                                   {
-                                                      bPeff = true;
-                                                      break;
-                                                   }
-                                                }
-
-                                                if (bPeff)
-                                                   bDoPeffAnalysis = WithinMassTolerancePeff(dTmpCalcPepMass, &vPeffArray, iStartPos, iTmpEnd);
-                                             }
-
-                                             if (iWhichQuery != -1 || bDoPeffAnalysis)
-                                             {
-                                                // We know that mass is within some query's tolerance range so
-                                                // now need to permute variable mods and at each permutation calculate
-                                                // fragment ions once and loop through all matching spectra to score.
-                                                for (i = 0; i < VMODS; ++i)
-                                                {
-                                                   if (g_staticParams.variableModParameters.varModList[i].dVarModMass > 0.0  && piTmpVarModCounts[i] > 0)
-                                                   {
-                                                      memset(_varModInfo.varModStatList[i].iVarModSites, 0, _usiSizepiVarModSites);
-                                                   }
-
-                                                   _varModInfo.varModStatList[i].iMatchVarModCt = piTmpVarModCounts[i];
-                                                }
-
-                                                _varModInfo.iStartPos = iStartPos;
-                                                _varModInfo.iEndPos = iTmpEnd;
-                                                _varModInfo.dCalcPepMass = dCalcPepMass;
-
-                                                // iTmpEnd-iStartPos+3 = length of peptide +2 (for n/c-term)
-                                                PermuteMods(szProteinSeq, iWhichQuery, 1, iClipNtermMetOffset, pbDuplFragment, &bDoPeffAnalysis, &vPeffArray, dbe);
-                                             }
-                                          }
-
-                                          if (bValid)
-                                          {
-                                             for (i = 0; i < VMODS; ++i)
-                                             {
-                                                _varModInfo.varModStatList[i].iTotVarModCt = piTmpTotVarModCt[i];
-                                                _varModInfo.varModStatList[i].iTotBinaryModCt = piTmpTotBinaryModCt[i];
                                              }
                                           }
                                        }
-                                    } // loop through iStartPos to iEndPos
+                                    }
                                  }
                               }
                            }
@@ -6377,19 +6844,13 @@ void CometSearch::VariableModSearch(char *szProteinSeq,
          }
       }
    }
-   }
-   }
-   }
-   }
-   }
-   }
 
    if ((int)dbe->vectorPeffMod.size() > 0)
       vPeffArray.clear();
 }
 
 
-double CometSearch::TotalVarModMass(int *pVarModCounts)
+double CometSearch::TotalVarModMass(int* pVarModCounts)
 {
    double dTotVarModMass = 0;
 
@@ -6402,69 +6863,69 @@ double CometSearch::TotalVarModMass(int *pVarModCounts)
 
 
 // false=exit; true=continue
-bool CometSearch::PermuteMods(char *szProteinSeq,
-                              int iWhichQuery,
-                              int iWhichMod,
-                              int iClipNtermMetOffset,
-                              bool *pbDuplFragment,
-                              bool *bDoPeffAnalysis,
-                              vector <PeffPositionStruct>* vPeffArray,
-                              struct sDBEntry *dbe)
+bool CometSearch::PermuteMods(char* szProteinSeq,
+   int iWhichQuery,
+   int iWhichMod,
+   int iClipNtermMetOffset,
+   bool* pbDuplFragment,
+   bool* bDoPeffAnalysis,
+   vector <PeffPositionStruct>* vPeffArray,
+   struct sDBEntry* dbe)
 {
    int iModIndex;
 
    switch (iWhichMod)
    {
-      case 1:
-         iModIndex = VMOD_1_INDEX;
-         break;
-      case 2:
-         iModIndex = VMOD_2_INDEX;
-         break;
-      case 3:
-         iModIndex = VMOD_3_INDEX;
-         break;
-      case 4:
-         iModIndex = VMOD_4_INDEX;
-         break;
-      case 5:
-         iModIndex = VMOD_5_INDEX;
-         break;
-      case 6:
-         iModIndex = VMOD_6_INDEX;
-         break;
-      case 7:
-         iModIndex = VMOD_7_INDEX;
-         break;
-      case 8:
-         iModIndex = VMOD_8_INDEX;
-         break;
-      case 9:
-         iModIndex = VMOD_9_INDEX;
-         break;
-      case 10:
-         iModIndex = VMOD_10_INDEX;
-         break;
-      case 11:
-         iModIndex = VMOD_11_INDEX;
-         break;
-      case 12:
-         iModIndex = VMOD_12_INDEX;
-         break;
-      case 13:
-         iModIndex = VMOD_13_INDEX;
-         break;
-      case 14:
-         iModIndex = VMOD_14_INDEX;
-         break;
-      case 15:
-         iModIndex = VMOD_15_INDEX;
-         break;
-      default:
-         string strErrorMsg = " Error - in CometSearch::PermuteMods, iWhichIndex=" + std::to_string(iWhichMod) + " (valid range 1 to 9)\n";
-         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-         logerr(strErrorMsg);
-         return false;
+   case 1:
+      iModIndex = VMOD_1_INDEX;
+      break;
+   case 2:
+      iModIndex = VMOD_2_INDEX;
+      break;
+   case 3:
+      iModIndex = VMOD_3_INDEX;
+      break;
+   case 4:
+      iModIndex = VMOD_4_INDEX;
+      break;
+   case 5:
+      iModIndex = VMOD_5_INDEX;
+      break;
+   case 6:
+      iModIndex = VMOD_6_INDEX;
+      break;
+   case 7:
+      iModIndex = VMOD_7_INDEX;
+      break;
+   case 8:
+      iModIndex = VMOD_8_INDEX;
+      break;
+   case 9:
+      iModIndex = VMOD_9_INDEX;
+      break;
+   case 10:
+      iModIndex = VMOD_10_INDEX;
+      break;
+   case 11:
+      iModIndex = VMOD_11_INDEX;
+      break;
+   case 12:
+      iModIndex = VMOD_12_INDEX;
+      break;
+   case 13:
+      iModIndex = VMOD_13_INDEX;
+      break;
+   case 14:
+      iModIndex = VMOD_14_INDEX;
+      break;
+   case 15:
+      iModIndex = VMOD_15_INDEX;
+      break;
+   default:
+      string strErrorMsg = " Error - in CometSearch::PermuteMods, iWhichIndex=" + std::to_string(iWhichMod) + " (valid range 1 to 9)\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
    }
 
    if (_varModInfo.varModStatList[iModIndex].iMatchVarModCt > 0)
@@ -6479,7 +6940,7 @@ bool CometSearch::PermuteMods(char *szProteinSeq,
 
       inittwiddle(M, N, p);
 
-      int iNmM = N-M;
+      int iNmM = N - M;
       for (i = 0; i != iNmM; ++i)
       {
          _varModInfo.varModStatList[iModIndex].iVarModSites[i] = 0;
@@ -6500,7 +6961,7 @@ bool CometSearch::PermuteMods(char *szProteinSeq,
       }
       else
       {
-         if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod+1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
+         if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod + 1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
             return false;
       }
 
@@ -6519,7 +6980,7 @@ bool CometSearch::PermuteMods(char *szProteinSeq,
          }
          else
          {
-            if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod+1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
+            if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod + 1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
                return false;
          }
       }
@@ -6533,7 +6994,7 @@ bool CometSearch::PermuteMods(char *szProteinSeq,
       }
       else
       {
-         if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod+1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
+         if (!PermuteMods(szProteinSeq, iWhichQuery, iWhichMod + 1, iClipNtermMetOffset, pbDuplFragment, bDoPeffAnalysis, vPeffArray, dbe))
             return false;
       }
    }
@@ -6586,7 +7047,7 @@ bool CometSearch::PermuteMods(char *szProteinSeq,
   parameter 'done' has been replaced with a Boolean return value.
 */
 
-int CometSearch::twiddle(int *x, int *y, int *z, int *p)
+int CometSearch::twiddle(int* x, int* y, int* z, int* p)
 {
    int i, j, k;
    j = 1;
@@ -6646,17 +7107,17 @@ int CometSearch::twiddle(int *x, int *y, int *z, int *p)
 }
 
 
-void CometSearch::inittwiddle(int m, int n, int *p)
+void CometSearch::inittwiddle(int m, int n, int* p)
 {
    int i;
 
    p[0] = n + 1;
 
-   int iSize = n-m+1;
+   int iSize = n - m + 1;
    for (i = 1; i != iSize; ++i)
       p[i] = 0;
 
-   while (i != n+1)
+   while (i != n + 1)
    {
       p[i] = i + m - n;
       i++;
@@ -6671,13 +7132,13 @@ void CometSearch::inittwiddle(int m, int n, int *p)
 
 // always need to return true so permutations of variable mods continues
 // except when lMaxIterations is hit
-bool CometSearch::MergeVarMods(char *szProteinSeq,
-                               int iWhichQuery,
-                               int iClipNtermMetOffset,
-                               bool *pbDuplFragment,
-                               bool *bDoPeffAnalysis,
-                               vector <PeffPositionStruct>* vPeffArray,
-                               struct sDBEntry *dbe)
+bool CometSearch::MergeVarMods(char* szProteinSeq,
+   int iWhichQuery,
+   int iClipNtermMetOffset,
+   bool* pbDuplFragment,
+   bool* bDoPeffAnalysis,
+   vector <PeffPositionStruct>* vPeffArray,
+   struct sDBEntry* dbe)
 {
    int piVarModSites[MAX_PEPTIDE_LEN_P2];
    int piVarModCharIdx[VMODS];
@@ -6692,10 +7153,10 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
    double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
 
    int iLenMinus1 = _varModInfo.iEndPos - _varModInfo.iStartPos;     // equals iLenPeptide-1
-   int iLenPeptide = iLenMinus1+1;
+   int iLenPeptide = iLenMinus1 + 1;
    int iLenProteinMinus1;
 
-   if (_proteinInfo.iPeffOrigResiduePosition>=0)
+   if (_proteinInfo.iPeffOrigResiduePosition >= 0)
       iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
    else
       iLenProteinMinus1 = _proteinInfo.iTmpProteinSeqLength - 1;
@@ -6710,9 +7171,9 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
    // deal with n-term mod
    for (j = 0; j < VMODS; ++j)
    {
-      if ( g_staticParams.variableModParameters.varModList[j].bNtermMod
-            && g_staticParams.variableModParameters.varModList[j].bUseMod
-            && (_varModInfo.varModStatList[j].iMatchVarModCt > 0) )
+      if (g_staticParams.variableModParameters.varModList[j].bNtermMod
+         && g_staticParams.variableModParameters.varModList[j].bUseMod
+         && (_varModInfo.varModStatList[j].iMatchVarModCt > 0))
       {
          if (_varModInfo.varModStatList[j].iVarModSites[piVarModCharIdx[j]])
          {
@@ -6730,17 +7191,17 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
    // deal with c-term mod
    for (j = 0; j < VMODS; ++j)
    {
-      if ( g_staticParams.variableModParameters.varModList[j].bCtermMod
-            && g_staticParams.variableModParameters.varModList[j].bUseMod
-            && (_varModInfo.varModStatList[j].iMatchVarModCt > 0) )
+      if (g_staticParams.variableModParameters.varModList[j].bCtermMod
+         && g_staticParams.variableModParameters.varModList[j].bUseMod
+         && (_varModInfo.varModStatList[j].iMatchVarModCt > 0))
       {
          if (_varModInfo.varModStatList[j].iVarModSites[piVarModCharIdx[j]])
          {
-            if (piVarModSites[iLenPeptide+1] != 0)  // conflict in two variable mods on c-term
+            if (piVarModSites[iLenPeptide + 1] != 0)  // conflict in two variable mods on c-term
                return true;
 
             // store the modification number at modification position
-            piVarModSites[iLenPeptide+1] = _varModInfo.varModStatList[j].iVarModSites[piVarModCharIdx[j]];
+            piVarModSites[iLenPeptide + 1] = _varModInfo.varModStatList[j].iVarModSites[piVarModCharIdx[j]];
             dCalcPepMass += g_staticParams.variableModParameters.varModList[j].dVarModMass;
          }
          piVarModCharIdx[j] += 1;
@@ -6758,8 +7219,8 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
       for (j = 0; j < VMODS; ++j)
       {
          if (g_staticParams.variableModParameters.varModList[j].bUseMod
-               && (_varModInfo.varModStatList[j].iMatchVarModCt > 0)
-               && strchr(g_staticParams.variableModParameters.varModList[j].szVarModChar, szProteinSeq[i]))
+            && (_varModInfo.varModStatList[j].iMatchVarModCt > 0)
+            && strchr(g_staticParams.variableModParameters.varModList[j].szVarModChar, szProteinSeq[i]))
          {
             if (g_staticParams.variableModParameters.varModList[j].iVarModTermDistance < 0)
             {
@@ -6851,7 +7312,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
       for (j = 0; j < VMODS; ++j)
       {
          if (g_staticParams.variableModParameters.varModList[j].iRequireThisMod > 0
-               && g_staticParams.variableModParameters.varModList[j].bUseMod)
+            && g_staticParams.variableModParameters.varModList[j].bUseMod)
          {
             bool bPresent = false;
 
@@ -6862,7 +7323,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
                int iPos = i - _varModInfo.iStartPos;
 
                // variable mode code is j+1. Check if that required j mod is present in peptide
-               if (piVarModSites[iPos] == j+1)
+               if (piVarModSites[iPos] == j + 1)
                {
                   bPresent = true;
                   break;
@@ -6880,7 +7341,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
 
       // above checked for required individual mods; now check if any of multiple mods is present
       bool bValid = false;
-      int iSize = _varModInfo.iEndPos+2;
+      int iSize = _varModInfo.iEndPos + 2;
       for (i = _varModInfo.iStartPos; i <= iSize; ++i)
       {
          int iWhichMod = piVarModSites[i - _varModInfo.iStartPos];
@@ -6899,10 +7360,10 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
    for (j = 0; j < VMODS; ++j)
    {
       if (g_staticParams.variableModParameters.varModList[j].iVarModTermDistance == -2
-            && g_staticParams.variableModParameters.varModList[j].bUseMod)
+         && g_staticParams.variableModParameters.varModList[j].bUseMod)
       {
          // not allowed for terminal residue to have this mod
-         if (piVarModSites[_varModInfo.iEndPos - _varModInfo.iStartPos] == j+1)
+         if (piVarModSites[_varModInfo.iEndPos - _varModInfo.iStartPos] == j + 1)
             return true;
       }
    }
@@ -6953,14 +7414,14 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
                if (iWhichQuery != -1)
                {
                   bool bValidPeffPosition = true;
-                  int iTmpModPosition  = iPeffPosition - _varModInfo.iStartPos;
+                  int iTmpModPosition = iPeffPosition - _varModInfo.iStartPos;
 
                   // make sure PEFF mod location doesn't conflict with existing variable mod
                   if (piVarModSites[iTmpModPosition] == 0)
                   {
                      // PEFF mods are encoded as negative values to reference appropriate PeffModStruct entry
                      // Sadly needs to be offset by -1 because first PEFF index is 0
-                     piVarModSites[iTmpModPosition] = -1 -(*vPeffArray).at(i).vectorWhichPeff.at(ii); // use negative values for PEFF mods
+                     piVarModSites[iTmpModPosition] = -1 - (*vPeffArray).at(i).vectorWhichPeff.at(ii); // use negative values for PEFF mods
                   }
                   else
                   {
@@ -6968,7 +7429,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
                      break;
                   }
 
-                  if  (bValidPeffPosition)
+                  if (bValidPeffPosition)
                   {
                      // Need to check if mass is ok
 
@@ -6977,7 +7438,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
 
                      // Seek back to first peptide entry that matches mass tolerance in case binary
                      // search doesn't hit the first entry.
-                     while (iWhichQuery>0 && g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
+                     while (iWhichQuery > 0 && g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus >= dCalcPepMass)
                         iWhichQuery--;
 
                      // Only if this PEFF mod (plus possible variable mods) is within mass tolerance, continue
@@ -6995,7 +7456,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
    else
    {
       bool bHasVarMod = false;
-      int iLen2 = iLenPeptide+2;
+      int iLen2 = iLenPeptide + 2;
 
       for (int x = 0; x < iLen2; ++x)
       {
@@ -7011,7 +7472,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
          }
 
          // check to make sure there is a variable mod
-         else if  (piVarModSites[x] > 0)
+         else if (piVarModSites[x] > 0)
          {
             bHasVarMod = true;
          }
@@ -7027,7 +7488,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
             DBIndex sDBTmp;
             sDBTmp.dPepMass = dCalcPepMass;  //MH+ mass
             strncpy(sDBTmp.szPeptide, szProteinSeq + _varModInfo.iStartPos, iLenPeptide);
-            sDBTmp.szPeptide[iLenPeptide]='\0';
+            sDBTmp.szPeptide[iLenPeptide] = '\0';
 
             if (_varModInfo.iStartPos == 0)
                sDBTmp.cPrevAA = '-';
@@ -7043,7 +7504,7 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
 
             memset(sDBTmp.pcVarModSites, 0, sizeof(sDBTmp.pcVarModSites));
 
-            for (int x=0; x<iLen2; x++)  // +2 for n/c term mods
+            for (int x = 0; x < iLen2; x++)  // +2 for n/c term mods
                sDBTmp.pcVarModSites[x] = piVarModSites[x];
 
             try
@@ -7069,13 +7530,13 @@ bool CometSearch::MergeVarMods(char *szProteinSeq,
 }
 
 
-bool CometSearch::CalcVarModIons(char *szProteinSeq,
-                                 int iWhichQuery,
-                                 bool *pbDuplFragment,
-                                 int *piVarModSites,
-                                 double dCalcPepMass,
-                                 int iLenPeptide,
-                                 struct sDBEntry *dbe)
+bool CometSearch::CalcVarModIons(char* szProteinSeq,
+   int iWhichQuery,
+   bool* pbDuplFragment,
+   int* piVarModSites,
+   double dCalcPepMass,
+   int iLenPeptide,
+   struct sDBEntry* dbe)
 {
    int piVarModSitesDecoy[MAX_PEPTIDE_LEN_P2];
    char szDecoyPeptide[MAX_PEPTIDE_LEN_P2];  // allow for prev/next AA in string
@@ -7158,7 +7619,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                {
                   if (i > _varModInfo.iStartPos)
                   {
-                     for (int x = 0 ; x < VMODS; ++x)
+                     for (int x = 0; x < VMODS; ++x)
                      {
                         iCountNLB[x][iPosForward] = iCountNLB[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i
                         iCountNLY[x][iPosForward] = iCountNLY[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i (R to L in sequence)
@@ -7175,7 +7636,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   dBion += g_staticParams.variableModParameters.varModList[iMod].dVarModMass;
 
                   if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                        && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                     && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                   {
                      iFoundVariableMod = 2;
 
@@ -7204,7 +7665,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   dYion += g_staticParams.variableModParameters.varModList[iMod].dVarModMass;
 
                   if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                        && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                     && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                   {
                      iFoundVariableMod = 2;
 
@@ -7257,7 +7718,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                     continue;
 
                                  if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
                                     int iScaleFactor;
 
@@ -7269,9 +7730,9 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                     double dNewMass;
 
                                     if (iWhichNL == 0)
-                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
+                                       dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
                                     else
-                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
+                                       dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
 
                                     iVal = BIN(dNewMass);
 
@@ -7338,7 +7799,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                     continue;
 
                                  if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                    || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                  {
                                     int iScaleFactor;
 
@@ -7350,9 +7811,9 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                     double dNewMass;
 
                                     if (iWhichNL == 0)
-                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
+                                       dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
                                     else
-                                       dNewMass  = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
+                                       dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
 
                                     if (dNewMass >= 0.0)
                                     {
@@ -7376,7 +7837,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
             // Precursor NL peaks added here
             for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
             {
-               for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+               for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                {
                   double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
 
@@ -7393,7 +7854,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
          }
 
          XcorrScore(szProteinSeq, _varModInfo.iStartPos, _varModInfo.iEndPos, _varModInfo.iStartPos, _varModInfo.iEndPos,
-               iFoundVariableMod, dCalcPepMass, false, iWhichQuery, iLenPeptide, piVarModSites, dbe);
+            iFoundVariableMod, dCalcPepMass, false, iWhichQuery, iLenPeptide, piVarModSites, dbe);
 
          if (bFirstTimeThroughLoopForPeptide)
          {
@@ -7432,21 +7893,21 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                      szDecoyPeptide[0] = '-';
                }
                else
-                  szDecoyPeptide[0]=szProteinSeq[_varModInfo.iStartPos-1];
+                  szDecoyPeptide[0] = szProteinSeq[_varModInfo.iStartPos - 1];
 
                if (_varModInfo.iEndPos == iLenProteinMinus1)
                   szDecoyPeptide[iLenPeptide + 1] = '-';
                else
                   szDecoyPeptide[iLenPeptide + 1] = szProteinSeq[_varModInfo.iEndPos + 1];
 
-               szDecoyPeptide[iLenPeptide+2]='\0';
+               szDecoyPeptide[iLenPeptide + 2] = '\0';
 
                // Now reverse the peptide and reverse the variable mod locations too
                if (g_staticParams.enzymeInformation.iSearchEnzymeOffSet == 1)
                {
                   // last residue stays the same:  change ABCDEK to EDCBAK
 
-                  for (int i = _varModInfo.iEndPos-1; i >= _varModInfo.iStartPos; --i)
+                  for (int i = _varModInfo.iEndPos - 1; i >= _varModInfo.iStartPos; --i)
                   {
                      szDecoyPeptide[_varModInfo.iEndPos - i] = szProteinSeq[i];
                      piTmpVarModSearchSites[_varModInfo.iEndPos - i - 1] = piVarModSites[i - _varModInfo.iStartPos];
@@ -7465,11 +7926,11 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                      piTmpVarModSearchSites[_varModInfo.iEndPos - i + 1] = piVarModSites[i - _varModInfo.iStartPos];
                   }
 
-                  szDecoyPeptide[1]=szProteinSeq[_varModInfo.iStartPos];  // first residue stays same
+                  szDecoyPeptide[1] = szProteinSeq[_varModInfo.iStartPos];  // first residue stays same
                   piTmpVarModSearchSites[0] = piVarModSites[0];
                }
 
-               piTmpVarModSearchSites[iLenPeptide]   = piVarModSites[iLenPeptide];    // N-term
+               piTmpVarModSearchSites[iLenPeptide] = piVarModSites[iLenPeptide];    // N-term
                piTmpVarModSearchSites[iLenPeptide + 1] = piVarModSites[iLenPeptide + 1];  // C-term
                memcpy(piVarModSitesDecoy, piTmpVarModSearchSites, (iLenPeptide + 2) * sizeof(int));
 
@@ -7490,7 +7951,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   dYion += g_staticParams.variableModParameters.varModList[piVarModSitesDecoy[iLenPeptide + 1] - 1].dVarModMass;
 
                iDecoyStartPos = 1;  // This is start/end for newly created decoy peptide
-               iDecoyEndPos = (int)strlen(szDecoyPeptide)-2;
+               iDecoyEndPos = (int)strlen(szDecoyPeptide) - 2;
 
                int iPosForward;  // count forward in peptide from 0
                int iPosReverse;  // point to residue in reverse order
@@ -7515,12 +7976,12 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                   dBion += g_staticParams.massUtility.pdAAMassFragment[(int)szDecoyPeptide[i]];
                   if (piVarModSitesDecoy[iPosForward] > 0)
                   {
-                     int iMod = piVarModSitesDecoy[iPosForward]-1;
+                     int iMod = piVarModSitesDecoy[iPosForward] - 1;
 
                      dBion += g_staticParams.variableModParameters.varModList[iMod].dVarModMass;
 
                      if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                           && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                        && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                      {
                         iFoundVariableModDecoy = 2;
 
@@ -7541,12 +8002,12 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
 
                   if (piVarModSitesDecoy[iPosReverseModSite] > 0)
                   {
-                     int iMod = piVarModSitesDecoy[iPosReverseModSite]-1;
+                     int iMod = piVarModSitesDecoy[iPosReverseModSite] - 1;
 
                      dYion += g_staticParams.variableModParameters.varModList[iMod].dVarModMass;
 
                      if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                           && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
+                        && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
                      {
                         iFoundVariableModDecoy = 2;
 
@@ -7593,7 +8054,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                        continue;
 
                                     if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
                                        double dNewMass;
 
@@ -7621,9 +8082,9 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                // initialize precursorNL for decoy
                for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
                {
-                  for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+                  for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                   {
-                     double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                     double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                      int iVal = BIN(dNLMass);
 
                      if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal)
@@ -7665,13 +8126,13 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                                        continue;
 
                                     if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                          || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1-ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
+                                       || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
                                     {
                                        double dNewMass;
 
                                        if (iWhichNL == 0)
                                           dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge;
-                                       else 
+                                       else
                                           dNewMass = dFragMass - g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge;
 
                                        iVal = BIN(dNewMass);
@@ -7693,9 +8154,9 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
                // Precursor NL peaks added here
                for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
                {
-                  for (ctCharge=g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge>=1; ctCharge--)
+                  for (ctCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctCharge >= 1; ctCharge--)
                   {
-                     double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge*PROTON_MASS)/ctCharge;
+                     double dNLMass = (dCalcPepMass - PROTON_MASS - g_staticParams.precursorNLIons[ctNL] + ctCharge * PROTON_MASS) / ctCharge;
                      int iVal = BIN(dNLMass);
 
                      if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
@@ -7712,7 +8173,7 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
          if (g_staticParams.options.iDecoySearch)
          {
             XcorrScore(szDecoyPeptide, iDecoyStartPos, iDecoyEndPos, 1, iLenPeptide,
-                  iFoundVariableModDecoy, dCalcPepMass, true, iWhichQuery, iLenPeptide, piVarModSitesDecoy, dbe);
+               iFoundVariableModDecoy, dCalcPepMass, true, iWhichQuery, iLenPeptide, piVarModSitesDecoy, dbe);
          }
       }
 
@@ -7720,4 +8181,400 @@ bool CometSearch::CalcVarModIons(char *szProteinSeq,
    }
 
    return true;
+}
+
+// Task 1.2: Thread-local overload accepting Query* directly.
+bool CometSearch::CheckMassMatch(Query* pQuery,
+   double dCalcPepMass)
+{
+   int iMassOffsetsSize = (int)g_staticParams.vectorMassOffsets.size();
+
+   if ((dCalcPepMass >= pQuery->_pepMassInfo.dPeptideMassToleranceMinus)
+      && (dCalcPepMass <= pQuery->_pepMassInfo.dPeptideMassTolerancePlus))
+   {
+      if (g_staticParams.tolerances.iIsotopeError == 0 && iMassOffsetsSize == 0)
+         return true;
+      else if (iMassOffsetsSize > 0)
+      {
+         if (g_staticParams.tolerances.iIsotopeError <= 6)
+         {
+            int iMaxIsotope = 3;
+            if (g_staticParams.tolerances.iIsotopeError < 3)
+               iMaxIsotope = g_staticParams.tolerances.iIsotopeError;
+
+            if (g_staticParams.tolerances.iIsotopeError == 5)
+               iMaxIsotope = 1;
+
+            for (int i = 0; i < iMassOffsetsSize; ++i)
+            {
+               for (int x = 0; x <= iMaxIsotope; ++x)
+               {
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * C13_DIFF
+                     && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  {
+                     return true;
+                  }
+               }
+            }
+
+            if (g_staticParams.tolerances.iIsotopeError >= 4 && g_staticParams.tolerances.iIsotopeError <= 6)
+            {
+               if (g_staticParams.tolerances.iIsotopeError == 4 || g_staticParams.tolerances.iIsotopeError == 5)
+                  iMaxIsotope = 1;
+               else
+                  iMaxIsotope = 3;
+
+               for (int i = 0; i < iMassOffsetsSize; ++i)
+               {
+                  for (int x = 0; x <= iMaxIsotope; ++x)
+                  {
+                     if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x * C13_DIFF
+                        && dCalcPepMass + g_staticParams.vectorMassOffsets[i] - x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                     {
+                        return true;
+                     }
+                  }
+               }
+            }
+
+            return false;
+         }
+         else if (g_staticParams.tolerances.iIsotopeError == 7)
+         {
+            for (int i = 0; i < iMassOffsetsSize; ++i)
+            {
+               for (int x = -2; x <= 2; ++x)
+               {
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * 4.0070995
+                     && dCalcPepMass + g_staticParams.vectorMassOffsets[i] + x * 4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  {
+                     return true;
+                  }
+               }
+            }
+            return false;
+         }
+         else
+         {
+            string strErrorMsg = " Error - iIsotopeError=" + std::to_string(g_staticParams.tolerances.iIsotopeError) + ", should not be here!\n";
+            g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+            logerr(strErrorMsg);
+            return false;
+         }
+      }
+      else
+      {
+         if (g_staticParams.tolerances.iIsotopeError <= 6)
+         {
+            int iMaxIsotope = 3;
+            if (g_staticParams.tolerances.iIsotopeError < 3)
+               iMaxIsotope = g_staticParams.tolerances.iIsotopeError;
+
+            if (g_staticParams.tolerances.iIsotopeError == 5)
+               iMaxIsotope = 1;
+
+            for (int x = 0; x <= iMaxIsotope; ++x)
+            {
+               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x * C13_DIFF
+                  && dCalcPepMass + x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+               {
+                  return true;
+               }
+            }
+
+            if (g_staticParams.tolerances.iIsotopeError >= 4 && g_staticParams.tolerances.iIsotopeError <= 6)
+            {
+               if (g_staticParams.tolerances.iIsotopeError == 4 || g_staticParams.tolerances.iIsotopeError == 5)
+                  iMaxIsotope = 1;
+               else
+                  iMaxIsotope = 3;
+
+               for (int x = 0; x <= iMaxIsotope; ++x)
+               {
+                  if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass - x * C13_DIFF
+                     && dCalcPepMass - x * C13_DIFF <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+                  {
+                     return true;
+                  }
+               }
+            }
+
+            return false;
+         }
+         else if (g_staticParams.tolerances.iIsotopeError == 7)
+         {
+            for (int x = -2; x <= 2; ++x)
+            {
+               if ((pQuery->_pepMassInfo.dPeptideMassToleranceLow <= dCalcPepMass + x * 4.0070995
+                  && dCalcPepMass + x * 4.0070995 <= pQuery->_pepMassInfo.dPeptideMassToleranceHigh))
+               {
+                  return true;
+               }
+            }
+
+            return false;
+         }
+         else
+         {
+            string strErrorMsg = " Error - iIsotopeError=" + std::to_string(g_staticParams.tolerances.iIsotopeError) + ", should not be here!\n";
+            g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+            logerr(strErrorMsg);
+            return false;
+         }
+      }
+   }
+
+   return false;
+}
+
+
+// Task 1.2: Thread-local XcorrScoreI overload accepting Query* directly.
+void CometSearch::XcorrScoreI(char* szProteinSeq,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,
+   double dCalcPepMass,
+   bool bDecoyPep,
+   Query* pQuery,
+   int iLenPeptide,
+   int* piVarModSites,
+   struct sDBEntry* dbe,
+   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS + 2],
+   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
+   int iNumMatchedFragmentIons)
+{
+   int  ctLen,
+      ctIonSeries,
+      ctCharge;
+   double dXcorr = 0.0;
+   int iLenPeptideMinus1 = iLenPeptide - 1;
+
+   // iMax is largest x-value allowed as iMax+1 is allocated and we're 0-index
+   int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
+
+   int bin, x, y;
+
+   float** ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
+
+   for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+   {
+      for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
+      {
+         for (ctLen = 0; ctLen < iLenPeptideMinus1; ++ctLen)
+         {
+            //MH: newer sparse matrix converts bin to sparse matrix bin
+            bin = uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0];
+
+            x = bin / SPARSE_MATRIX_SIZE;
+
+            if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
+            {
+               y = bin - (x * SPARSE_MATRIX_SIZE);
+               dXcorr += ppSparseFastXcorrData[x][y];
+            }
+
+            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
+            {
+               for (int ii = 0; ii < FRAGINDEX_VMODS; ++ii)
+               {
+                  for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                  {
+                     if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss == 0.0)
+                        continue;
+                     else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss2 == 0.0)
+                        continue;
+
+                     bin = uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][ii + 1 + iWhichNL];
+
+                     x = bin / SPARSE_MATRIX_SIZE;
+
+                     if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL))
+                     {
+                        y = bin - (x * SPARSE_MATRIX_SIZE);
+                        dXcorr += ppSparseFastXcorrData[x][y];
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   // precursor NL
+   for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
+   {
+      for (int ctZ = pQuery->_spectrumInfoInternal.usiChargeState; ctZ >= 1; --ctZ)
+      {
+         bin = uiBinnedPrecursorNL[ctNL][ctZ];
+
+         x = bin / SPARSE_MATRIX_SIZE;
+
+         if (bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)
+            continue;
+
+         y = bin - (x * SPARSE_MATRIX_SIZE);
+
+         dXcorr += ppSparseFastXcorrData[x][y];
+      }
+   }
+
+   dXcorr *= 0.005;  // Scale intensities to 50 and divide score by 1E4.
+
+   dXcorr = std::round(dXcorr * 1000.0) / 1000.0;  // round to 3 decimal points
+
+   Threading::LockMutex(pQuery->accessMutex);
+
+   // Increment matched peptide counts.
+   if (bDecoyPep && g_staticParams.options.iDecoySearch == 2)
+      pQuery->_uliNumMatchedDecoyPeptides++;
+   else
+      pQuery->_uliNumMatchedPeptides++;
+
+   if (g_staticParams.options.bPrintExpectScore
+      || g_staticParams.options.bOutputPepXMLFile
+      || g_staticParams.options.bOutputPercolatorFile
+      || g_staticParams.options.bOutputTxtFile)
+   {
+      int iTmp;
+
+      iTmp = (int)(dXcorr * 10.0 + 0.5);
+
+      if (iTmp < 0)
+         iTmp = 0;
+
+      // lump some zero decoy entries into iMinXcorrHisto bin
+      if (szProteinSeq[iStartPos] >= 'A' && szProteinSeq[iStartPos] <= 'H' && iTmp < pQuery->iMinXcorrHisto)
+         iTmp = pQuery->iMinXcorrHisto;
+
+      if (iTmp >= HISTO_SIZE)
+         iTmp = HISTO_SIZE - 1;
+
+      pQuery->iXcorrHistogram[iTmp] += 1;
+      pQuery->uiHistogramCount += 1;
+   }
+
+   if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
+   {
+      StorePeptideI(pQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
+         dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
+   }
+
+   Threading::UnlockMutex(pQuery->accessMutex);
+}
+
+
+// Task 1.2: Thread-local StorePeptideI overload accepting Query* directly.
+void CometSearch::StorePeptideI(Query* pQuery,
+   int iStartPos,
+   int iEndPos,
+   int iFoundVariableMod,
+   char* szProteinSeq,
+   double dCalcPepMass,
+   double dXcorr,
+   bool bDecoyPep,
+   int* piVarModSites,
+   struct sDBEntry* dbe)
+{
+   int iLenPeptide = iEndPos - iStartPos + 1;
+   int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
+
+   short siLowestXcorrScoreIndex = pQuery->siLowestXcorrScoreIndex;
+
+   pQuery->iMatchPeptideCount++;
+   pQuery->_pResults[siLowestXcorrScoreIndex].usiLenPeptide = iLenPeptide;
+
+   memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide, szProteinSeq + iStartPos, iLenPeptide * sizeof(char));
+   pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide[iLenPeptide] = '\0';
+   pQuery->_pResults[siLowestXcorrScoreIndex].dPepMass = dCalcPepMass;
+
+   if (pQuery->_spectrumInfoInternal.usiChargeState > 2)
+   {
+      pQuery->_pResults[siLowestXcorrScoreIndex].usiTotalIons = (iLenPeptide - 1)
+         * pQuery->_spectrumInfoInternal.usiMaxFragCharge
+         * g_staticParams.ionInformation.iNumIonSeriesUsed;
+   }
+   else
+   {
+      pQuery->_pResults[siLowestXcorrScoreIndex].usiTotalIons = (iLenPeptide - 1)
+         * g_staticParams.ionInformation.iNumIonSeriesUsed;
+   }
+
+   pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr = (float)dXcorr;
+
+   if (iStartPos == 0)
+      pQuery->_pResults[siLowestXcorrScoreIndex].cPrevAA = '-';
+   else
+      pQuery->_pResults[siLowestXcorrScoreIndex].cPrevAA = szProteinSeq[iStartPos - 1];
+
+   if (iEndPos == iLenProteinMinus1)
+      pQuery->_pResults[siLowestXcorrScoreIndex].cNextAA = '-';
+   else
+      pQuery->_pResults[siLowestXcorrScoreIndex].cNextAA = szProteinSeq[iEndPos + 1];
+
+   pQuery->_pResults[siLowestXcorrScoreIndex].iPeffOrigResiduePosition = NO_PEFF_VARIANT;
+   pQuery->_pResults[siLowestXcorrScoreIndex].sPeffOrigResidues.clear();
+   pQuery->_pResults[siLowestXcorrScoreIndex].iPeffNewResidueCount = 0;
+
+   pQuery->_pResults[siLowestXcorrScoreIndex].pWhichProtein.clear();
+   pQuery->_pResults[siLowestXcorrScoreIndex].pWhichDecoyProtein.clear();
+   pQuery->_pResults[siLowestXcorrScoreIndex].lProteinFilePosition = dbe->lProteinFilePosition;
+
+   pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_None;
+
+   int iSizepiVarModSites = sizeof(int) * MAX_PEPTIDE_LEN_P2;
+   int iSizepdVarModSites = sizeof(double) * MAX_PEPTIDE_LEN_P2;
+
+   if (g_staticParams.variableModParameters.bVarModSearch)
+   {
+      if (!iFoundVariableMod)
+      {
+         memset(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, 0, iSizepiVarModSites);
+         memset(pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites, 0, iSizepdVarModSites);
+      }
+      else
+      {
+         memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, piVarModSites, iSizepiVarModSites);
+
+         int iVal;
+         for (int i = 0; i < iLenPeptide + 2; ++i)
+         {
+            iVal = pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites[i];
+
+            if (iVal > 0)
+            {
+               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal - 1].dVarModMass;
+
+               if (g_staticParams.options.iPrintAScoreProScore == -1
+                  || (g_staticParams.options.iPrintAScoreProScore > 0 && iVal == g_AScoreOptions.getSymbol() - '0'))
+               {
+                  pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_AScorePro;
+               }
+               else if (pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod == HasVariableModType_None)
+                  pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_True;
+            }
+            else
+               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = 0.0;
+         }
+      }
+   }
+   else
+   {
+      memset(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, 0, iSizepiVarModSites);
+      memset(pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites, 0, iSizepdVarModSites);
+   }
+
+   // Get new lowest score.
+   pQuery->dLowestXcorrScore = pQuery->_pResults[0].fXcorr;
+   siLowestXcorrScoreIndex = 0;
+
+   for (int i = g_staticParams.options.iNumStored - 1; i > 0; --i)
+   {
+      if (pQuery->_pResults[i].fXcorr < pQuery->dLowestXcorrScore || pQuery->_pResults[i].usiLenPeptide == 0)
+      {
+         pQuery->dLowestXcorrScore = pQuery->_pResults[i].fXcorr;
+         siLowestXcorrScoreIndex = i;
+      }
+   }
+
+   pQuery->siLowestXcorrScoreIndex = siLowestXcorrScoreIndex;
 }

--- a/CometSearch/CometSearch.h
+++ b/CometSearch/CometSearch.h
@@ -71,6 +71,11 @@ public:
                          int iPercentEnd,
                          ThreadPool* tp);
    static bool RunSearch(ThreadPool* tp);
+
+   // Task 1.3: Thread-local overload — searches a caller-owned Query* without
+   // touching g_pvQuery.  Allocates its own pbDuplFragment scratch buffer.
+   static bool RunSearch(Query* pQuery);
+
    static bool RunSpecLibSearch(int iPercentStart,
                                 int iPercentEnd,
                                 ThreadPool* tp);
@@ -80,6 +85,15 @@ public:
                             double dMaxMS1RTDiff,
                             const double dMaxSpecLibRT,
                             const double dMaxQueryRT);
+   // Thread-local overload: searches a caller-owned QueryMS1* against read-only g_vSpecLib.
+   // Returns top-N results in the output vector. No global mutable state accessed.
+   static bool RunMS1Search(QueryMS1* pQueryMS1,
+                            const int topN,
+                            double dRT,
+                            double dMaxMS1RTDiff,
+                            const double dMaxSpecLibRT,
+                            const double dMaxQueryRT,
+                            vector<CometScoresMS1>& scores);
 
    static void SearchThreadProc(SearchThreadData* pSearchThreadData,
                                 ThreadPool* tp);
@@ -99,6 +113,9 @@ public:
                         int end,
                         double dCalcPepMass) const;
    static bool CheckMassMatch(size_t iWhichQuery,
+                              double dCalcPepMass);
+   // Task 1.2: Thread-local overload accepting Query* directly.
+   static bool CheckMassMatch(Query* pQuery,
                               double dCalcPepMass);
 
    struct ProteinInfo
@@ -165,6 +182,7 @@ private:
                    int iLenPeptide,
                    int *piVarModSites,
                    struct sDBEntry *dbe);
+   // Existing batch-path overload (indexes g_pvQuery)
    static void XcorrScoreI(char *szProteinSeq,
                            int iStartPos,
                            int iEndPos,
@@ -172,6 +190,20 @@ private:
                            double dCalcPepMass,
                            bool bDecoyPep,
                            size_t iWhichQuery,
+                           int iLenPeptide,
+                           int *piVarModSites,
+                           struct sDBEntry *dbe,
+                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS+2],
+                           unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
+                           int iNumMatchedFragmentIons);
+   // Task 1.2: Thread-local overload accepting Query* directly.
+   static void XcorrScoreI(char *szProteinSeq,
+                           int iStartPos,
+                           int iEndPos,
+                           int iFoundVariableMod,
+                           double dCalcPepMass,
+                           bool bDecoyPep,
+                           Query* pQuery,
                            int iLenPeptide,
                            int *piVarModSites,
                            struct sDBEntry *dbe,
@@ -207,7 +239,19 @@ private:
                      bool bStoreSeparateDecoy,
                      int *piVarModSites,
                      struct sDBEntry *dbe);
+   // Existing batch-path overload (indexes g_pvQuery)
    static void StorePeptideI(size_t iWhichQuery,
+                             int iStartPos,
+                             int iEndPos,
+                             int iFoundVariableMod,
+                             char *szProteinSeq,
+                             double dCalcPepMass,
+                             double dXcorr,
+                             bool bStoreSeparateDecoy,
+                             int *piVarModSites,
+                             struct sDBEntry *dbe);
+   // Task 1.2: Thread-local overload accepting Query* directly.
+   static void StorePeptideI(Query* pQuery,
                              int iStartPos,
                              int iEndPos,
                              int iFoundVariableMod,
@@ -249,8 +293,15 @@ private:
                        double dCalcPepMass,
                        int iLenPeptide,
                        struct sDBEntry* dbe);
+   // Existing batch-path overload (indexes g_pvQuery)
    static void SearchFragmentIndex(size_t iWhichQuery,
                                    ThreadPool* tp);
+
+   // Task 1.1: Thread-local overload — searches a caller-owned Query* with
+   // a per-call pbDuplFragment buffer. Does not access g_pvQuery.
+   static void SearchFragmentIndex(Query* pQuery,
+                                   bool* pbDuplFragment);
+
    bool SearchPeptideIndex(ThreadPool* tp);
    void AnalyzePeptideIndex(int iWhichQuery,
                             DBIndex sDBI,

--- a/CometSearch/CometSearch.h
+++ b/CometSearch/CometSearch.h
@@ -67,12 +67,14 @@ public:
    static bool AllocateMemory(int maxNumThreads);
    static bool DeallocateMemory(int maxNumThreads);
 
+   static bool InitializeMassesFromPeptideIndex();
+
    static bool RunSearch(int iPercentStart,
                          int iPercentEnd,
                          ThreadPool* tp);
    static bool RunSearch(ThreadPool* tp);
 
-   // Task 1.3: Thread-local overload — searches a caller-owned Query* without
+   // Task 1.3: Thread-local overload: searches a caller-owned Query* without
    // touching g_pvQuery.  Allocates its own pbDuplFragment scratch buffer.
    static bool RunSearch(Query* pQuery);
 
@@ -86,7 +88,7 @@ public:
                             const double dMaxSpecLibRT,
                             const double dMaxQueryRT);
    // Thread-local overload: searches a caller-owned QueryMS1* against read-only g_vSpecLib.
-   // Returns top-N results in the output vector. No global mutable state accessed.
+   // No global mutable state accessed.
    static bool RunMS1Search(QueryMS1* pQueryMS1,
                             const int topN,
                             double dRT,
@@ -117,6 +119,8 @@ public:
    // Task 1.2: Thread-local overload accepting Query* directly.
    static bool CheckMassMatch(Query* pQuery,
                               double dCalcPepMass);
+
+   bool SearchPeptideIndex(ThreadPool* tp);
 
    struct ProteinInfo
    {
@@ -193,7 +197,7 @@ private:
                            int iLenPeptide,
                            int *piVarModSites,
                            struct sDBEntry *dbe,
-                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS+2],
+                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS+2],
                            unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
                            int iNumMatchedFragmentIons);
    // Task 1.2: Thread-local overload accepting Query* directly.
@@ -207,7 +211,7 @@ private:
                            int iLenPeptide,
                            int *piVarModSites,
                            struct sDBEntry *dbe,
-                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][FRAGINDEX_VMODS+2],
+                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS+2],
                            unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
                            int iNumMatchedFragmentIons);
 /*
@@ -293,20 +297,31 @@ private:
                        double dCalcPepMass,
                        int iLenPeptide,
                        struct sDBEntry* dbe);
+   
    // Existing batch-path overload (indexes g_pvQuery)
    static void SearchFragmentIndex(size_t iWhichQuery,
                                    ThreadPool* tp);
 
-   // Task 1.1: Thread-local overload — searches a caller-owned Query* with
+   // Thread-local overload: searches a caller-owned Query* with
    // a per-call pbDuplFragment buffer. Does not access g_pvQuery.
    static void SearchFragmentIndex(Query* pQuery,
                                    bool* pbDuplFragment);
 
-   bool SearchPeptideIndex(ThreadPool* tp);
+   // Thread-local overload: searches a caller-owned Query* against the
+   // read-only g_pvDBIndex. Does not access g_pvQuery.
+   static void SearchPeptideIndex(Query* pQuery, bool* pbDuplFragment);
+
    void AnalyzePeptideIndex(int iWhichQuery,
                             DBIndex sDBI,
                             bool *pbDuplFragment,
                             struct sDBEntry *dbe);
+
+   // Thread-local overload accepting Query* directly.
+   static void AnalyzePeptideIndex(Query* pQuery,
+                                   DBIndex sDBI,
+                                   bool* pbDuplFragment,
+                                   struct sDBEntry* dbe);
+
    bool SearchForPeptides(struct sDBEntry dbe,
                           char* szProteinSeq,
                           int iNtermPeptideOnly,  // used in clipped methionine sequence

--- a/CometSearch/CometSearch.vcxproj
+++ b/CometSearch/CometSearch.vcxproj
@@ -94,6 +94,7 @@
     <ClInclude Include="CometDataInternal.h" />
     <ClInclude Include="CometDecoys.h" />
     <ClInclude Include="CometFragmentIndex.h" />
+    <ClInclude Include="CometFragmentIndexReader.h" />
     <ClInclude Include="CometInterfaces.h" />
     <ClInclude Include="CometMassSpecUtils.h" />
     <ClInclude Include="CometModificationsPermuter.h" />

--- a/CometSearch/CometSearch.vcxproj.filters
+++ b/CometSearch/CometSearch.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="BS_thread_pool.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CometFragmentIndexReader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CometMassSpecUtils.cpp">

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -39,7 +39,13 @@
 #undef PERF_DEBUG
 
 std::vector<Query*>           g_pvQuery;
+
+// g_pvQueryMS1: BATCH PATH ONLY — used by RunMS1Search(ThreadPool*,...) and
+// PreprocessMS1SingleSpectrum(). The single-spectrum MS1 search path
+// (DoMS1SearchMultiResults) uses thread-local QueryMS1* objects and never
+// reads or writes this vector. Do not access from concurrent search threads.
 std::vector<QueryMS1*>        g_pvQueryMS1;
+
 std::vector<InputFileInfo *>  g_pvInputFiles;
 StaticParams                  g_staticParams;
 vector<DBIndex>               g_pvDBIndex;
@@ -57,6 +63,8 @@ AScoreProCpp::AScoreOptions   g_AScoreOptions;  // AScore options
 AScoreProCpp::AScoreDllInterface* g_AScoreInterface;
 
 vector<vector<comet_fileoffset_t>> g_pvProteinsList;
+
+// Fragment index globals - INITIALIZED ONCE, READ-ONLY DURING SEARCH
 unsigned int** g_iFragmentIndex;                            // stores fragment index; [BIN(fragmass)][which g_vFragmentPeptides entries]
 unsigned int* g_iCountFragmentIndex;                        // stores counts of fragment index; [BIN(fragmass)]
 bool* g_bIndexPrecursors;                                   // array for BIN(precursors), set to true if precursor present in file
@@ -74,6 +82,11 @@ bool g_bCometPreprocessMemoryAllocated = false;
 bool g_bCometSearchMemoryAllocated = false;
 
 bool g_bIdxNoFasta = false;  // if true, .idx file has no associated .fasta file
+
+// FI Thread-safety notes:
+// - Index is created once in InitializeSingleSpectrumSearch() under mutex protection
+// - All search threads access index READ-ONLY
+// - No modifications after g_bPlainPeptideIndexRead = true
 
 double dMaxSpecLibRT = 0.0;
 
@@ -1771,6 +1784,12 @@ bool CometSearchManager::InitializeStaticParams()
 
    g_staticParams.iArraySizeGlobal = (int)((dUseMaxMass + dCushion) / dUseBinSize);
 
+   // Ensure pool buffers are large enough for MS1 binning (BINPREC) as well.
+   // BINPREC uses dMS1BinSize which can produce larger indices than BIN.
+   int iArraySizeMS1 = BINPREC(g_staticParams.options.dMS1MaxMass) + 1;
+   if (iArraySizeMS1 > g_staticParams.iArraySizeGlobal)
+      g_staticParams.iArraySizeGlobal = iArraySizeMS1;
+
    staticParamsInitializationComplete = true;
 
 /*
@@ -2263,11 +2282,6 @@ bool CometSearchManager::DoSearch()
          if (!g_staticParams.options.bOutputSqtStream)
             cout << CometMassSpecUtils::ElapsedTime(tTime1) << endl;
       }
-      else
-      {
-         cout << " - read precursors ... skipping" << endl;
-         fflush(stdout);
-      }
    }
 
    if (g_bPerformSpecLibSearch)
@@ -2563,7 +2577,7 @@ bool CometSearchManager::DoSearch()
             fpoutd_mzidentml = fopen(sOutputDecoyMzIdentML.c_str(), "w");
             if (!fpoutd_mzidentml)
             {
-               string strErrorMsg = " Error - cannot write to decoy file \"" + sOutputDecoyMzIdentML + "\".\n";
+               string strErrorMsg = " Error - cannot write to decoy file \"" + sOutputDecoyMzIdentML + "\n";
                g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
                logerr(strErrorMsg);
                bSucceeded = false;
@@ -2977,7 +2991,7 @@ bool CometSearchManager::DoSearch()
 cleanup_results:
 
             // Deleting each Query object in the vector calls its destructor, which
-            // frees the spectral memory (see definition for Query in CometData.h).
+            // frees the spectral memory (see definition for Query in CometDataInternal.h).
             for (auto it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
                delete (*it);
 
@@ -3205,32 +3219,47 @@ cleanup_results:
 
 bool CometSearchManager::InitializeSingleSpectrumSearch()
 {
+   static Mutex g_initSingleSearchMutex;
 
-   // Skip doing if already completed successfully.
+   // Fast path
    if (singleSearchInitializationComplete)
       return true;
 
+   // RAII lock guard (automatically unlocks on scope exit)
+   struct ScopedLock
+   {
+      Mutex* m;
+      ScopedLock(Mutex* mutex) : m(mutex) { Threading::LockMutex(*m); }
+      ~ScopedLock() { Threading::UnlockMutex(*m); }
+   } lock(&g_initSingleSearchMutex);
+
+   // Double-check
+   if (singleSearchInitializationComplete)
+      return true;
+
+   // Initialization code (no manual unlock needed!)
    if (!InitializeStaticParams())
       return false;
 
    if (!ValidateSequenceDatabaseFile())
       return false;
 
+   g_sCometVersion = comet_version;
+
    g_staticParams.precalcMasses.iMinus17 = BIN(g_staticParams.massUtility.dH2O);
    g_staticParams.precalcMasses.iMinus18 = BIN(g_staticParams.massUtility.dNH3);
    g_massRange.dMinMass = g_staticParams.options.dPeptideMassLow;
    g_massRange.dMaxMass = g_staticParams.options.dPeptideMassHigh;
 
-   bool bSucceeded;
    //MH: Allocate memory shared by threads during spectral processing.
-   bSucceeded = CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads);
+   bool bSucceeded = CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads);
    if (!bSucceeded)
-      return bSucceeded;
+      return false;
 
    // Allocate memory shared by threads during search
    bSucceeded = CometSearch::AllocateMemory(g_staticParams.options.iNumThreads);
    if (!bSucceeded)
-      return bSucceeded;
+      return false;
 
    ThreadPool* tp = _tp;
    tp->fillPool(g_staticParams.options.iNumThreads < 0 ? 0 : g_staticParams.options.iNumThreads - 1);
@@ -3243,14 +3272,14 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
       // WritePeptideIndex calls RunSearch just to query fasta and generate uniq peptide list
       bSucceeded = CometPeptideIndex::WritePeptideIndex(tp);
       if (!bSucceeded)
-         return bSucceeded;
+         return false;
    }
+
    if (g_staticParams.options.bCreateFragmentIndex)
    {
       bSucceeded = CreateFragmentIndex();
-
       if (!bSucceeded)
-         return bSucceeded;
+         return false;
    }
 
    if (g_staticParams.iIndexDb == 1 && !g_bPlainPeptideIndexRead)
@@ -3260,7 +3289,9 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
 
       if (g_staticParams.options.iPrintAScoreProScore)
       {
-         SetAScoreOptions(g_AScoreOptions);  // normally set at end of InitializeStaticParams; must do here again after ReadPlainPeptideIndex for single spectrum search
+         // normally set at end of InitializeStaticParams; must do here again after
+         // ReadPlainPeptideIndex for single spectrum search
+         SetAScoreOptions(g_AScoreOptions);
 //       PrintAScoreOptions(g_AScoreOptions);
 
          // Create the AScoreDllInterface using the factory function
@@ -3268,12 +3299,17 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
          if (!g_AScoreInterface)
          {
             std::cerr << "Failed to create AScore interface." << std::endl;
-            exit(1);
+            return false;
          }
       }
    }
 
+   // Mark as complete BEFORE unlocking (mutex unlock provides memory fence)
    singleSearchInitializationComplete = true;
+
+   // Freeze index (make immutable); already set in ReadPlainPeptideIndex but doing
+   // here again to be safe for no good reason.
+   g_bPlainPeptideIndexRead = true;
 
    return true;
 }
@@ -3294,40 +3330,35 @@ void CometSearchManager::FinalizeSingleSpectrumSearch()
 }
 
 
-bool CometSearchManager::InitializeSingleSpectrumMS1Search()
+// Task 1.1 + 1.2: Load reference library once during init; fix thread pool deadlock
+bool CometSearchManager::InitializeSingleSpectrumMS1Search(const double dMaxQueryRT)
 {
-   // Skip doing if already completed successfully.
    if (singleSearchMS1InitializationComplete)
       return true;
 
    if (!InitializeStaticParams())
       return false;
 
-   if (!ValidateSpecLibFile())
+   int iNumThreads = g_staticParams.options.iNumThreads;
+   if (iNumThreads < 1)
+      iNumThreads = 1;
+
+   // Task 1.2: Ensure at least 1 worker thread so LoadSpecLibMS1Raw doesn't deadlock.
+   // _tp may already be created by InitializeSingleSpectrumSearch(); if so, reuse it.
+   // If not, create it here.
+   if (_tp == nullptr)
+      _tp = new ThreadPool();
+
+   // fillPool with at least 1 worker — fillPool(0) causes deadlock in LoadSpecLibMS1Raw
+   int iPoolSize = (iNumThreads > 1) ? (iNumThreads - 1) : 1;
+   _tp->fillPool(iPoolSize);
+
+   // Task 1.1: Load reference library ONCE, here in init (single-threaded context).
+   // After this call, g_vSpecLib is populated and g_bSpecLibRead == true.
+   if (!CometSpecLib::LoadSpecLibMS1Raw(_tp, dMaxQueryRT, &dMaxSpecLibRT))
       return false;
 
-   // these two mean nothing for MS1
-   g_massRange.dMinMass = g_staticParams.options.dPeptideMassLow;
-   g_massRange.dMaxMass = g_staticParams.options.dPeptideMassHigh;
-
-   bool bSucceeded;
-   //MH: Allocate memory shared by threads during spectral processing.
-   bSucceeded = CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads);
-   if (!bSucceeded)
-      return bSucceeded;
-
-   // Allocate memory shared by threads during search
-   bSucceeded = CometSearch::AllocateMemory(g_staticParams.options.iNumThreads);
-   if (!bSucceeded)
-      return bSucceeded;
-
-   pMS1Aligner.reset();
-
-   ThreadPool* tp = _tp;
-   tp->fillPool(g_staticParams.options.iNumThreads < 0 ? 0 : g_staticParams.options.iNumThreads - 1);
-
    singleSearchMS1InitializationComplete = true;
-
    return true;
 }
 
@@ -3366,9 +3397,6 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
    // tRealTimeStart used to track elapsed search time and to exit if g_staticParams.options.iMaxIndexRunTime is surpased
    g_staticParams.tRealTimeStart = std::chrono::high_resolution_clock::now();
 
-   // We need to reset some of the static variables in-between input files
-   CometPreprocess::Reset();
-
 #ifdef PERF_DEBUG
    // print set search parameters
    std::map<std::string, CometParam*> mapParams = GetParamsMap();
@@ -3381,177 +3409,244 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
    }
 #endif
 
-   // IMPORTANT: From this point onwards, because we've loaded some
-   // spectra, we MUST "goto cleanup_results" before exiting the loop,
-   // or we will create a memory leak!
+   bool bSucceeded = true;
 
-   string sTmpDB;
-   double* pdTmpSpectrum = new double[g_staticParams.iArraySizeGlobal];  // use this to determine most intense b/y-ions masses to report back
+   // Allocate thread-local scratch spectrum buffer for fragment ion matching
+   double* pdTmpSpectrum = new double[g_staticParams.iArraySizeGlobal]();
 
-   bool bSucceeded = CometPreprocess::PreprocessSingleSpectrum(iPrecursorCharge, dMZ, pdMass, pdInten, iNumPeaks, pdTmpSpectrum);
+   // Step 1: Preprocess into a thread-local Query* (does NOT touch g_pvQuery)
+   Query* pQuery = CometPreprocess::PreprocessSingleSpectrumThreadLocal(
+      iPrecursorCharge, dMZ, pdMass, pdInten, iNumPeaks, pdTmpSpectrum);
 
-   int iSize;
-   int takeSearchResultsN;
-   ThreadPool* tp = _tp;  // filled in InitializeSingleSpectrumSearch
-
-   if (!bSucceeded)
-      goto cleanup_results;
-
-   if (g_pvQuery.empty())
+   if (pQuery == nullptr)
    {
       delete[] pdTmpSpectrum;
-      return false; // no search to run
-   }
-   bSucceeded = AllocateResultsMem();
-
-   int iWhichQuery;
-
-   if (!bSucceeded)
-      goto cleanup_results;
-
-   iWhichQuery = 0; // dealing with one query
-
-   Query* pQuery;
-   pQuery = g_pvQuery.at(iWhichQuery);  // there's only a single query spectrum
-
-   g_massRange.dMinMass = pQuery->_pepMassInfo.dPeptideMassToleranceMinus;
-   g_massRange.dMaxMass = g_pvQuery.at(g_pvQuery.size() - 1)->_pepMassInfo.dPeptideMassTolerancePlus;
-
-   if (g_massRange.dMaxMass - g_massRange.dMinMass > g_massRange.dMinMass)
-      g_massRange.bNarrowMassRange = true;  // unused in this context but setting here anyways
-   else
-      g_massRange.bNarrowMassRange = false;
-
-   g_sCometVersion = comet_version;
-
-   // Now that spectra are loaded to memory and sorted, do search.
-   bSucceeded = CometSearch::RunSearch(tp);
-
-   iSize = g_pvQuery.at(0)->iMatchPeptideCount;
-   if (iSize > g_staticParams.options.iNumStored)
-      iSize = g_staticParams.options.iNumStored;
-
-   if (iSize > 1)
-   {
-      std::sort(pQuery->_pResults, pQuery->_pResults + iSize, CometPostAnalysis::SortFnXcorr);
-   }
-
-   takeSearchResultsN = topN; // return up to the top N results, or iSize
-
-   if (takeSearchResultsN > iSize)
-      takeSearchResultsN = iSize;
-
-   if (bSucceeded && pQuery->iMatchPeptideCount > 0)
-   {
-      CometPostAnalysis::CalculateSP(pQuery->_pResults, 0, takeSearchResultsN);
-      CometPostAnalysis::CalculateEValue(iWhichQuery, 0);
-      CometPostAnalysis::CalculateDeltaCn(iWhichQuery);
-
-      if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
-         && g_pvQuery.at(0)->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
-      {
-         CometPostAnalysis::CalculateAScorePro(0, g_AScoreInterface);
-      }
-   }
-   else
-      goto cleanup_results;
-
-   bSucceeded = !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
-
-   if (!bSucceeded)
-      goto cleanup_results;
-
-   // Open .idx file for retrieving protein names
-   FILE* fp;
-   if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
-   {
-      string strErrorMsg = " Error - cannot read indexed database file \"" + std::string(g_staticParams.databaseInfo.szDatabase)
-         + "\" " + std::strerror(errno) + "\n.";
-      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-      logerr(strErrorMsg);
       return false;
    }
 
-   for (int iWhichResult = 0; iWhichResult < takeSearchResultsN; ++iWhichResult)
+   // Step 3: Run the fragment index search on the thread-local Query*
+   // This uses the new RunSearch(Query*) overload that allocates its own
+   // pbDuplFragment and never touches g_pvQuery or _ppbDuplFragmentArr.
+   bSucceeded = CometSearch::RunSearch(pQuery); 
+
+   if (!bSucceeded)
+      goto cleanup_results;
+
    {
-      CometScores score;
-      score.dCn = 0;
-      score.xCorr = g_staticParams.options.dMinimumXcorr;
-      score.matchedIons = 0;
-      score.totalIons = 0;
-      score.dAScorePro = 0;
-      score.sAScoreProSiteScores.clear();
-      std::string eachStrReturnPeptide;
-      std::string eachStrReturnProtein;
-      vector<Fragment> eachMatchedFragments;
+      int iSize = pQuery->iMatchPeptideCount;
+      if (iSize > g_staticParams.options.iNumStored)
+         iSize = g_staticParams.options.iNumStored;
 
-      if (iSize > 0 && pQuery->_pResults[iWhichResult].fXcorr > g_staticParams.options.dMinimumXcorr
-            && pQuery->_pResults[iWhichResult].usiLenPeptide > 0)
+      if (iSize > 1)
       {
-         Results* pOutput = pQuery->_pResults;
+         std::sort(pQuery->_pResults, pQuery->_pResults + iSize, CometPostAnalysis::SortFnXcorr);
+      }
 
-         // Set return values for peptide sequence, protein, xcorr and E-value
-         eachStrReturnPeptide = std::string(1, pOutput[iWhichResult].cPrevAA) + ".";
+      int takeSearchResultsN = topN;
+      if (takeSearchResultsN > iSize)
+         takeSearchResultsN = iSize;
 
-         // n-term variable mod
-         if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide] != 0)
+      // Step 4: Post-analysis using Query* overloads (no g_pvQuery access)
+      if (pQuery->iMatchPeptideCount > 0)
+      {
+         CometPostAnalysis::CalculateSP(pQuery->_pResults, pQuery, takeSearchResultsN);
+         CometPostAnalysis::CalculateEValue(pQuery, false);
+         CometPostAnalysis::CalculateDeltaCn(pQuery);
+
+         if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
+            && pQuery->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
          {
-            std::stringstream ss;
-            ss << "n[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide] << "]";
-            eachStrReturnPeptide += ss.str();
+            bool bHasTerminalVariableMod = false;
+            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0
+               || pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
+            {
+               bHasTerminalVariableMod = true;
+            }
+            if (!bHasTerminalVariableMod)
+               CometPostAnalysis::CalculateAScorePro(pQuery, g_AScoreInterface);
          }
+      }
+      else
+      {
+         goto cleanup_results;
+      }
 
-         for (int i = 0; i < pOutput[iWhichResult].usiLenPeptide; ++i)
+      bSucceeded = !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
+      if (!bSucceeded)
+         goto cleanup_results;
+
+      // Step 5: Open .idx file for retrieving protein names
+      // Each concurrent call opens its own FILE* so there is no shared file pointer state.
+      FILE* fp;
+      if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
+      {
+         string strErrorMsg = " Error - cannot read indexed database file \"" + std::string(g_staticParams.databaseInfo.szDatabase)
+            + "\" " + std::strerror(errno) + "\n.";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         bSucceeded = false;
+         goto cleanup_results;
+      }
+
+      // Step 6: Extract results from thread-local Query*
+      for (int iWhichResult = 0; iWhichResult < takeSearchResultsN; ++iWhichResult)
+      {
+         CometScores score;
+         score.dCn = 0;
+         score.xCorr = g_staticParams.options.dMinimumXcorr;
+         score.matchedIons = 0;
+         score.totalIons = 0;
+         score.dAScorePro = 0;
+         score.sAScoreProSiteScores.clear();
+         std::string eachStrReturnPeptide;
+         std::string eachStrReturnProtein;
+         vector<Fragment> eachMatchedFragments;
+
+         if (iSize > 0 && pQuery->_pResults[iWhichResult].fXcorr > g_staticParams.options.dMinimumXcorr
+            && pQuery->_pResults[iWhichResult].usiLenPeptide > 0)
          {
-            eachStrReturnPeptide += pOutput[iWhichResult].szPeptide[i];
+            Results* pOutput = pQuery->_pResults;
 
-            if (pOutput[iWhichResult].piVarModSites[i] != 0)
+            // Set return values for peptide sequence, protein, xcorr and E-value
+            eachStrReturnPeptide = std::string(1, pOutput[iWhichResult].cPrevAA) + ".";
+
+            // n-term variable mod
+            if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide] != 0)
             {
                std::stringstream ss;
-               ss << "[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[i] << "]";
+               ss << "n[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide] << "]";
                eachStrReturnPeptide += ss.str();
             }
-         }
 
-         // c-term variable mod
-         if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] != 0)
-         {
-            std::stringstream ss;
-            ss << "c[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] << "]";
-            eachStrReturnPeptide += ss.str();
-         }
-         eachStrReturnPeptide += "." + std::string(1, pOutput[iWhichResult].cNextAA);
+            for (int i = 0; i < pOutput[iWhichResult].usiLenPeptide; ++i)
+            {
+               eachStrReturnPeptide += pOutput[iWhichResult].szPeptide[i];
 
-         std::vector<string> vProteinTargets;  // store vector of target protein names
-         std::vector<string> vProteinDecoys;   // store vector of decoy protein names
-         std::vector<string>::iterator it;
+               if (pOutput[iWhichResult].piVarModSites[i] != 0)
+               {
+                  std::stringstream ss;
+                  ss << "[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[i] << "]";
+                  eachStrReturnPeptide += ss.str();
+               }
+            }
 
-         int iPrintTargetDecoy = 0;
-         unsigned int uiNumTotProteins = 0;
-         bool bReturnFullProteinString = true;
+            // c-term variable mod
+            if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] != 0)
+            {
+               std::stringstream ss;
+               ss << "c[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] << "]";
+               eachStrReturnPeptide += ss.str();
+            }
+            eachStrReturnPeptide += "." + std::string(1, pOutput[iWhichResult].cNextAA);
 
-         CometMassSpecUtils::GetProteinNameString(fp, iWhichQuery, iWhichResult, iPrintTargetDecoy,
-               bReturnFullProteinString, &uiNumTotProteins, vProteinTargets, vProteinDecoys);
+            // Protein name retrieval — done inline using pOutput directly instead of
+            // calling GetProteinNameString which indexes into g_pvQuery.
+            // This replicates the indexed-db path from GetProteinNameString.
+               char szProteinName[512];
+            int iLenDecoyPrefix = (int)strlen(g_staticParams.szDecoyPrefix);
 
-         bool bPrintDelim = false;
-         if (iPrintTargetDecoy != 2)  // if not decoy only, print target proteins
-         {
-            for (it = vProteinTargets.begin(); it != vProteinTargets.end(); ++it)
+            std::vector<string> vProteinTargets;
+            std::vector<string> vProteinDecoys;
+
+            if (g_staticParams.iIndexDb)
+            {
+               comet_fileoffset_t lEntry = pOutput[iWhichResult].lProteinFilePosition;
+               int iPrintDuplicateProteinCt = 0;
+
+               for (auto itProt = g_pvProteinsList.at(lEntry).begin(); itProt != g_pvProteinsList.at(lEntry).end(); ++itProt)
+               {
+                  comet_fseek(fp, *itProt, SEEK_SET);
+                  if (fgets(szProteinName, 511, fp) == NULL)
+                  {
+                     // error reading protein name; skip
+                  }
+                  szProteinName[500] = '\0';
+
+                  // remove trailing newline/carriage return
+                  while (strlen(szProteinName) > 0
+                     && (szProteinName[strlen(szProteinName) - 1] == '\n'
+                        || szProteinName[strlen(szProteinName) - 1] == '\r'))
+                  {
+                     szProteinName[strlen(szProteinName) - 1] = '\0';
+                  }
+
+                  if (!strncmp(szProteinName, g_staticParams.szDecoyPrefix, iLenDecoyPrefix))
+                     vProteinDecoys.push_back(szProteinName);
+                  else
+                     vProteinTargets.push_back(szProteinName);
+
+                  iPrintDuplicateProteinCt++;
+                  if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
+                     break;
+               }
+            }
+            else
+            {
+               // Non-indexed (FASTA) path
+               int iPrintDuplicateProteinCt = 0;
+
+               if (pOutput[iWhichResult].pWhichProtein.size() > 0)
+               {
+                  for (auto itProt = pOutput[iWhichResult].pWhichProtein.begin(); itProt != pOutput[iWhichResult].pWhichProtein.end(); ++itProt)
+                  {
+                     comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
+                     if (fgets(szProteinName, 511, fp) == NULL)
+                     {
+                        // error
+                     }
+                     szProteinName[500] = '\0';
+                     while (strlen(szProteinName) > 0
+                        && (szProteinName[strlen(szProteinName) - 1] == '\n'
+                           || szProteinName[strlen(szProteinName) - 1] == '\r'))
+                     {
+                        szProteinName[strlen(szProteinName) - 1] = '\0';
+                     }
+                     vProteinTargets.push_back(szProteinName);
+                     iPrintDuplicateProteinCt++;
+                     if (iPrintDuplicateProteinCt > g_staticParams.options.iMaxDuplicateProteins)
+                        break;
+                  }
+               }
+
+               if (pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
+               {
+                  for (auto itProt = pOutput[iWhichResult].pWhichDecoyProtein.begin(); itProt != pOutput[iWhichResult].pWhichDecoyProtein.end(); ++itProt)
+                  {
+                     if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
+                        break;
+                     comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
+                     if (fgets(szProteinName, 511, fp) == NULL)
+                     {
+                        // error
+                     }
+                     szProteinName[500] = '\0';
+                     while (strlen(szProteinName) > 0
+                        && (szProteinName[strlen(szProteinName) - 1] == '\n'
+                           || szProteinName[strlen(szProteinName) - 1] == '\r'))
+                     {
+                        szProteinName[strlen(szProteinName) - 1] = '\0';
+                     }
+                     vProteinDecoys.push_back(szProteinName);
+                     iPrintDuplicateProteinCt++;
+                  }
+               }
+            }
+
+            // Build the protein string from targets and decoys
+            bool bPrintDelim = false;
+            for (auto itProt = vProteinTargets.begin(); itProt != vProteinTargets.end(); ++itProt)
             {
                if (bPrintDelim)
                   eachStrReturnProtein += " ; ";
                else
                   bPrintDelim = true;
 
-               string sTmp = *it;
-               std::replace(sTmp.begin(), sTmp.end(), ';', ',');  // since ';' is the delimiter between proteins, change all occurrences to ','
+               string sTmp = *itProt;
+               std::replace(sTmp.begin(), sTmp.end(), ';', ',');
                eachStrReturnProtein += sTmp;
             }
-         }
 
-         if (iPrintTargetDecoy != 1)  // if not target only, print decoy proteins
-         {
-            for (it = vProteinDecoys.begin(); it != vProteinDecoys.end(); ++it)
+            for (auto itProt = vProteinDecoys.begin(); itProt != vProteinDecoys.end(); ++itProt)
             {
                if (bPrintDelim)
                   eachStrReturnProtein += " ; ";
@@ -3559,196 +3654,194 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
                   bPrintDelim = true;
 
                string sTmp;
-               if ((*it).starts_with(g_staticParams.szDecoyPrefix))
-                  sTmp = *it;
+               if ((*itProt).starts_with(g_staticParams.szDecoyPrefix))
+                  sTmp = *itProt;
                else
                {
                   sTmp = g_staticParams.szDecoyPrefix;
-                  sTmp += *it;
+                  sTmp += *itProt;
                }
 
-               std::replace(sTmp.begin(), sTmp.end(), ';', ',');  // since ';' is the delimiter between proteins, change all occurrences to ','
+               std::replace(sTmp.begin(), sTmp.end(), ';', ',');
                eachStrReturnProtein += sTmp;
             }
-         }
 
-         score.xCorr = pOutput[iWhichResult].fXcorr;                      // xcorr
-         score.dCn = pOutput[iWhichResult].fDeltaCn;                      // deltaCn
-         score.dSp = pOutput[iWhichResult].fScoreSp;                      // prelim score
-         score.dExpect = pOutput[iWhichResult].dExpect;                   // E-value
-         score.mass = pOutput[iWhichResult].dPepMass - PROTON_MASS;       // calc neutral pep mass
-         score.matchedIons = pOutput[iWhichResult].usiMatchedIons;        // ions matched
-         score.totalIons = pOutput[iWhichResult].usiTotalIons;            // ions tot
-         score.dAScorePro = pOutput[iWhichResult].fAScorePro;             // AScore
-         score.sAScoreProSiteScores = pOutput[iWhichResult].sAScoreProSiteScores; // AScore site-specific
+            score.xCorr = pOutput[iWhichResult].fXcorr;
+            score.dCn = pOutput[iWhichResult].fDeltaCn;
+            score.dSp = pOutput[iWhichResult].fScoreSp;
+            score.dExpect = pOutput[iWhichResult].dExpect;
+            score.mass = pOutput[iWhichResult].dPepMass - PROTON_MASS;
+            score.matchedIons = pOutput[iWhichResult].usiMatchedIons;
+            score.totalIons = pOutput[iWhichResult].usiTotalIons;
+            score.dAScorePro = pOutput[iWhichResult].fAScorePro;
+            score.sAScoreProSiteScores = pOutput[iWhichResult].sAScoreProSiteScores;
 
-         int iMinLength = g_staticParams.options.peptideLengthRange.iEnd;
-         for (int x = 0; x < iSize; ++x)
-         {
-            int iLen = (int)strlen(pOutput[x].szPeptide);
-            if (iLen == 0)
-               break;
-            if (iLen < iMinLength)
-               iMinLength = iLen;
-         }
-
-         // Conversion table from b/y ions to the other types (a,c,x,z)
-         const double ionMassesRelative[NUM_ION_SERIES] =
-         {
-            // N term relative
-            -(Carbon_Mono + Oxygen_Mono),                       // a (CO difference from b)
-            0,                                                  // b
-            (Nitrogen_Mono + (3 * Hydrogen_Mono)),              // c (NH3 difference from b)
-
-            // C Term relative
-            (Carbon_Mono + Oxygen_Mono - (2 * Hydrogen_Mono)),  // x (CO-2H difference from y)
-            0,                                                  // y
-            -(Nitrogen_Mono + (2 * Hydrogen_Mono)),             // z (NH2 difference from y)
-            -(Nitrogen_Mono + (3 * Hydrogen_Mono))              // z+1
-         };
-
-         // now deal with calculating b- and y-ions and returning most intense matches
-         double dBion = g_staticParams.precalcMasses.dNtermProton;
-         double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
-
-         if (pQuery->_pResults[iWhichResult].cPrevAA == '-')
-         {
-            dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-         }
-         if (pQuery->_pResults[iWhichResult].cNextAA == '-')
-         {
-            dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-         }
-
-         // mods at peptide length +1 and +2 are for n- and c-terminus
-         if (g_staticParams.variableModParameters.bVarModSearch
-               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] != 0))
-         {
-            dBion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] - 1].dVarModMass;
-         }
-
-         if (g_staticParams.variableModParameters.bVarModSearch
-               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] != 0))
-         {
-            dYion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] - 1].dVarModMass;
-         }
-
-         int iTmp;
-         bool bAddNtermFragmentNeutralLoss[VMODS];
-         bool bAddCtermFragmentNeutralLoss[VMODS];
-
-         for (int iMod = 0; iMod < VMODS; ++iMod)
-         {
-            bAddNtermFragmentNeutralLoss[iMod] = false;
-            bAddCtermFragmentNeutralLoss[iMod] = false;
-         }
-
-         // Generate pdAAforward for pQuery->_pResults[iWhichResult].szPeptide.
-         for (int i = 0; i < pQuery->_pResults[iWhichResult].usiLenPeptide - 1; ++i)
-         {
-            int iPos = pQuery->_pResults[iWhichResult].usiLenPeptide - i - 1;
-
-            dBion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[i]];
-            dYion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[iPos]];
-
-            if (g_staticParams.variableModParameters.bVarModSearch)
+            int iMinLength = g_staticParams.options.peptideLengthRange.iEnd;
+            for (int x = 0; x < iSize; ++x)
             {
-               if (pQuery->_pResults[iWhichResult].piVarModSites[i] != 0)
-                  dBion += pQuery->_pResults[iWhichResult].pdVarModSites[i];
-
-               if (pQuery->_pResults[iWhichResult].piVarModSites[iPos] != 0)
-                  dYion += pQuery->_pResults[iWhichResult].pdVarModSites[iPos];
+               int iLen = (int)strlen(pOutput[x].szPeptide);
+               if (iLen == 0)
+                  break;
+               if (iLen < iMinLength)
+                  iMinLength = iLen;
             }
 
-            map<int, double>::iterator it;
-            for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+            // Conversion table from b/y ions to the other types (a,c,x,z)
+            const double ionMassesRelative[NUM_ION_SERIES] =
             {
-               // calculate every ion series the user specified
-               for (int ionSeries = 0; ionSeries < NUM_ION_SERIES; ++ionSeries)
+               // N term relative
+               -(Carbon_Mono + Oxygen_Mono),                       // a (CO difference from b)
+               0,                                                  // b
+               (Nitrogen_Mono + (3 * Hydrogen_Mono)),              // c (NH3 difference from b)
+
+               // C Term relative
+               (Carbon_Mono + Oxygen_Mono - (2 * Hydrogen_Mono)),  // x (CO-2H difference from y)
+               0,                                                  // y
+               -(Nitrogen_Mono + (2 * Hydrogen_Mono)),             // z (NH2 difference from y)
+               -(Nitrogen_Mono + (3 * Hydrogen_Mono))              // z+1
+            };
+
+            // now deal with calculating b- and y-ions and returning most intense matches
+            double dBion = g_staticParams.precalcMasses.dNtermProton;
+            double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
+
+            if (pQuery->_pResults[iWhichResult].cPrevAA == '-')
+            {
+               dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+            }
+            if (pQuery->_pResults[iWhichResult].cNextAA == '-')
+            {
+               dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+            }
+
+            // mods at peptide length +1 and +2 are for n- and c-terminus
+            if (g_staticParams.variableModParameters.bVarModSearch
+               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] != 0))
+            {
+               dBion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] - 1].dVarModMass;
+            }
+
+            if (g_staticParams.variableModParameters.bVarModSearch
+               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] != 0))
+            {
+               dYion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] - 1].dVarModMass;
+            }
+
+            int iTmp;
+            bool bAddNtermFragmentNeutralLoss[VMODS];
+            bool bAddCtermFragmentNeutralLoss[VMODS];
+
+            for (int iMod = 0; iMod < VMODS; ++iMod)
+            {
+               bAddNtermFragmentNeutralLoss[iMod] = false;
+               bAddCtermFragmentNeutralLoss[iMod] = false;
+            }
+
+            // Generate pdAAforward for pQuery->_pResults[iWhichResult].szPeptide.
+            for (int i = 0; i < pQuery->_pResults[iWhichResult].usiLenPeptide - 1; ++i)
+            {
+               int iPos = pQuery->_pResults[iWhichResult].usiLenPeptide - i - 1;
+
+               dBion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[i]];
+               dYion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[iPos]];
+
+               if (g_staticParams.variableModParameters.bVarModSearch)
                {
-                  // skip ion series that are not enabled.
-                  if (!g_staticParams.ionInformation.iIonVal[ionSeries])
+                  if (pQuery->_pResults[iWhichResult].piVarModSites[i] != 0)
+                     dBion += pQuery->_pResults[iWhichResult].pdVarModSites[i];
+
+                  if (pQuery->_pResults[iWhichResult].piVarModSites[iPos] != 0)
+                     dYion += pQuery->_pResults[iWhichResult].pdVarModSites[iPos];
+               }
+
+               for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+               {
+                  // calculate every ion series the user specified
+                  for (int ionSeries = 0; ionSeries < NUM_ION_SERIES; ++ionSeries)
                   {
-                     continue;
-                  }
-
-                  bool isNTerm = (ionSeries <= ION_SERIES_C);
-
-                  // get the fragment mass if it is n- or c-terimnus
-                  double mass = (isNTerm) ? dBion : dYion;
-                  int fragNumber = i + 1;
-
-                  // Add any conversion factor from different ion series (e.g. b -> a, or y -> z)
-                  mass += ionMassesRelative[ionSeries];
-
-                  double mz = (mass + (ctCharge - 1) * PROTON_MASS) / ctCharge;
-                  iTmp = BIN(mz);
-                  if (iTmp < g_staticParams.iArraySizeGlobal && pdTmpSpectrum[iTmp] > 0.0)
-                  {
-                     Fragment frag;
-                     frag.intensity = pdTmpSpectrum[iTmp];
-                     frag.mass = mass;
-                     frag.type = ionSeries;
-                     frag.number = fragNumber;
-                     frag.charge = ctCharge;
-                     frag.neutralLoss = false;
-                     frag.neutralLossMass = 0.0;
-                     eachMatchedFragments.push_back(frag);
-                  }
-
-                  if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
-                  {
-                     for (int iMod = 0; iMod < VMODS; ++iMod)
+                     // skip ion series that are not enabled.
+                     if (!g_staticParams.ionInformation.iIonVal[ionSeries])
                      {
-                        for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                        continue;
+                     }
+
+                     bool isNTerm = (ionSeries <= ION_SERIES_C);
+
+                     // get the fragment mass if it is n- or c-terminus
+                     double mass = (isNTerm) ? dBion : dYion;
+                     int fragNumber = i + 1;
+
+                     // Add any conversion factor from different ion series (e.g. b -> a, or y -> z)
+                     mass += ionMassesRelative[ionSeries];
+
+                     double mz = (mass + (ctCharge - 1) * PROTON_MASS) / ctCharge;
+                     iTmp = BIN(mz);
+                     if (iTmp < g_staticParams.iArraySizeGlobal && pdTmpSpectrum[iTmp] > 0.0)
+                     {
+                        Fragment frag;
+                        frag.intensity = pdTmpSpectrum[iTmp];
+                        frag.mass = mass;
+                        frag.type = ionSeries;
+                        frag.number = fragNumber;
+                        frag.charge = ctCharge;
+                        frag.neutralLoss = false;
+                        frag.neutralLossMass = 0.0;
+                        eachMatchedFragments.push_back(frag);
+                     }
+
+                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
+                     {
+                        for (int iMod = 0; iMod < VMODS; ++iMod)
                         {
-                           double dNLmass;
-
-                           if (iWhichNL == 0)
-                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
-                           else
-                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
-
-                           if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
+                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                            {
-                              continue;  // continue if this iMod entry has no mod mass or no NL mass specified
-                           }
+                              double dNLmass;
 
-                           if (isNTerm)
-                           {
-                              // if have not already come across n-term mod residue for variable mod iMod, see if position i contains the variable mod
-                              if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[i] == iMod + 1)
+                              if (iWhichNL == 0)
+                                 dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
+                              else
+                                 dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
+
+                              if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
                               {
-                                 bAddNtermFragmentNeutralLoss[iMod] = true;
+                                 continue;
                               }
-                           }
-                           else
-                           {
-                              if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[iPos] == iMod + 1)
+
+                              if (isNTerm)
                               {
-                                 bAddCtermFragmentNeutralLoss[iMod] = true;
+                                 if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[i] == iMod + 1)
+                                 {
+                                    bAddNtermFragmentNeutralLoss[iMod] = true;
+                                 }
                               }
-                           }
+                              else
+                              {
+                                 if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[iPos] == iMod + 1)
+                                 {
+                                    bAddCtermFragmentNeutralLoss[iMod] = true;
+                                 }
+                              }
 
-                           if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
-                              || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
-                           {
-                              continue;  // no fragment NL yet in peptide so continue
-                           }
+                              if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
+                                 || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
+                              {
+                                 continue;
+                              }
 
-                           double dNLfragMz = mz - (dNLmass / ctCharge);
-                           iTmp = BIN(dNLfragMz);
-                           if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
-                           {
-                              Fragment frag;
-                              frag.intensity = pdTmpSpectrum[iTmp];
-                              frag.mass = mass - dNLmass;
-                              frag.type = ionSeries;
-                              frag.number = fragNumber;
-                              frag.charge = ctCharge;
-                              frag.neutralLoss = true;
-                              frag.neutralLossMass = dNLmass;
-                              eachMatchedFragments.push_back(frag);
+                              double dNLfragMz = mz - (dNLmass / ctCharge);
+                              iTmp = BIN(dNLfragMz);
+                              if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
+                              {
+                                 Fragment frag;
+                                 frag.intensity = pdTmpSpectrum[iTmp];
+                                 frag.mass = mass - dNLmass;
+                                 frag.type = ionSeries;
+                                 frag.number = fragNumber;
+                                 frag.charge = ctCharge;
+                                 frag.neutralLoss = true;
+                                 frag.neutralLossMass = dNLmass;
+                                 eachMatchedFragments.push_back(frag);
+                              }
                            }
                         }
                      }
@@ -3756,65 +3849,60 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
                }
             }
          }
-      }
-      else
-      {
-         eachStrReturnPeptide = "";  // peptide
-         eachStrReturnProtein = "";  // protein
-         score.xCorr = -999  ;       // xcorr
-         score.dSp = 0;        // prelim score
-         score.dExpect = 999;      // E-value
-         score.mass = 0;        // calc neutral pep mass
-         score.matchedIons = 0;        // ions matched
-         score.totalIons = 0;        // ions tot
-         score.dAScorePro = 0;        // AScore
-         score.dCn = 0;        // dCn
-         score.sAScoreProSiteScores.clear();
-      }
-
-      if (false)  // set to true to enable debug mass check
-      {
-         // Compare peptide against input mz/charge mass
-         double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
-         for (int i = 0; i < pQuery->_pResults[0].usiLenPeptide; ++i)
+         else
          {
-            dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[pQuery->_pResults[0].szPeptide[i]];
+            eachStrReturnPeptide = "";
+            eachStrReturnProtein = "";
+            score.xCorr = -999;
+            score.dSp = 0;
+            score.dExpect = 999;
+            score.mass = 0;
+            score.matchedIons = 0;
+            score.totalIons = 0;
+            score.dAScorePro = 0;
+            score.dCn = 0;
+            score.sAScoreProSiteScores.clear();
+         }
+
+         if (false)  // set to true to enable debug mass check
+         {
+            // Compare peptide against input mz/charge mass
+            double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
+            for (int i = 0; i < pQuery->_pResults[0].usiLenPeptide; ++i)
+            {
+               dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[pQuery->_pResults[0].szPeptide[i]];
+               if (g_staticParams.variableModParameters.bVarModSearch)
+                  if (pQuery->_pResults[0].piVarModSites[i] != 0)
+                     dCalcPepMass += pQuery->_pResults[0].pdVarModSites[i];
+            }
             if (g_staticParams.variableModParameters.bVarModSearch)
-               if (pQuery->_pResults[0].piVarModSites[i] != 0)
-                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[i];
+            {
+               // n-term mod
+               if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0)
+                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide];
+               // c-term mod
+               if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
+                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide + 1];
+            }
          }
-         if (g_staticParams.variableModParameters.bVarModSearch)
-         {
-            // n-term mod
-            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0)
-               dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide];
-            // c-term mod
-            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
-               dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide + 1];
-         }
+
+         strReturnPeptide.push_back(eachStrReturnPeptide);
+         strReturnProtein.push_back(eachStrReturnProtein);
+         matchedFragments.push_back(eachMatchedFragments);
+         scores.push_back(score);
       }
 
-      strReturnPeptide.push_back(eachStrReturnPeptide);
-      strReturnProtein.push_back(eachStrReturnProtein);
-      matchedFragments.push_back(eachMatchedFragments);
-      scores.push_back(score);
+      if (fp != NULL)
+         fclose(fp);
    }
-
-   if (fp != NULL)
-      fclose(fp);
 
 cleanup_results:
 
-   // Deleting each Query object in the vector calls its destructor, which
-   // frees the spectral memory (see definition for Query in CometDataInternal.h).
-   for (auto it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
-      delete (*it);
-
-   g_pvQuery.clear();
-
-   // Clean up the input files vector
-   g_staticParams.vectorMassOffsets.clear();
-   g_staticParams.precursorNLIons.clear();
+   // Clean up the thread-local Query* — its destructor frees spectral memory
+   // (pfFastXcorrData, pfFastXcorrDataNL, etc.)
+   // The _pResults and _pDecoys arrays were allocated by PreprocessSingleSpectrumCore.
+   delete pQuery;
+   pQuery = nullptr;
 
    delete[] pdTmpSpectrum;
 
@@ -3825,78 +3913,63 @@ cleanup_results:
 // Load all MS1 from raw file. Then search each MS1 query.
 bool CometSearchManager::DoMS1SearchMultiResults(const double dMaxMS1RTDiff,
                                                  const double dMaxQueryRT,
-                                                 const int /*topN*/,
+                                                 const int topN,
                                                  const double dQueryRT,
                                                  double* pdMass,
                                                  double* pdInten,
                                                  int iNumPeaks,
                                                  vector<CometScoresMS1>& scoresMS1)
 {
-   bool bSucceeded = false;
-   double dMatchedSpecLibRT = 0.0;
-   double dLinearRegressionRT = 0.0;
+   // Phase 3 / Task 3.2: Verify init completed before any search call.
+   // InitializeSingleSpectrumMS1Search() must be called (and return) before
+   // any thread calls DoMS1SearchMultiResults(). The C# Task.Run() scheduling
+   // provides a happens-before guarantee for all writes made during init.
+   if (!singleSearchMS1InitializationComplete)
+   {
+      string strErrorMsg = " Error - DoMS1SearchMultiResults() called before InitializeSingleSpectrumMS1Search() completed.\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   // At this point g_vSpecLib and g_bSpecLibRead are guaranteed visible and immutable.
 
    if (iNumPeaks == 0)
       return false;
 
-   bSucceeded = InitializeSingleSpectrumMS1Search();
-   if (bSucceeded == false)
-      return bSucceeded;
+   // Task 2.1: Create thread-local QueryMS1* — no global state touched.
+   QueryMS1* pQueryMS1 = CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(pdMass, pdInten, iNumPeaks);
 
-   g_pvQueryMS1.clear();
+   if (pQueryMS1 == nullptr)
+      return false;
 
-   ThreadPool* tp = _tp;  // filled in InitializeSingleSpectrumSearch
+   // Task 2.2: Run search using thread-local overload — reads only g_vSpecLib (immutable).
+   vector<CometScoresMS1> localScores;
+   bool bSucceeded = CometSearch::RunMS1Search(pQueryMS1, topN, dQueryRT, dMaxMS1RTDiff, dMaxSpecLibRT, dMaxQueryRT, localScores);
 
-   //Load all MS1 spectrum from file
-   if (g_bSpecLibRead == false)
-      CometSpecLib::LoadSpecLibMS1Raw(tp, dMaxQueryRT, &dMaxSpecLibRT);
-
-   // Process current MS1
-   bSucceeded = CometPreprocess::PreprocessMS1SingleSpectrum(pdMass, pdInten, iNumPeaks);
-
-   if (!bSucceeded)
-      goto cleanup_results;
-
-   if (g_pvQueryMS1.empty())
-      return false; // no search to run
-
-   bSucceeded = AllocateResultsMemMS1();
-
-   if (!bSucceeded)
-      goto cleanup_results;
-
-   QueryMS1* pQueryMS1;
-   pQueryMS1 = g_pvQueryMS1.at(0);
-   pQueryMS1->_pSpecLibResultsMS1.fDotProduct = 0.0;
-   pQueryMS1->_pSpecLibResultsMS1.fRTime = 0.0;
-   pQueryMS1->_pSpecLibResultsMS1.iWhichSpecLib = 0;
-
-   bSucceeded = CometSearch::RunMS1Search(tp, dQueryRT, dMaxMS1RTDiff, dMaxSpecLibRT, dMaxQueryRT);
-
-   // pass best RT match to regression
-   dMatchedSpecLibRT = pQueryMS1->_pSpecLibResultsMS1.fRTime;
-   dLinearRegressionRT = pMS1Aligner.processRetentionMatch(dQueryRT, dMatchedSpecLibRT);
-
-   if (bSucceeded)
+   if (bSucceeded && !localScores.empty())
    {
-      CometScoresMS1 scoreMS1;
-      scoreMS1.fDotProduct = pQueryMS1->_pSpecLibResultsMS1.fDotProduct;
-//      scoreMS1.fRTime = pQueryMS1->_pSpecLibResultsMS1.fRTime;
-      scoreMS1.fRTime = (float)dLinearRegressionRT;
-      scoreMS1.iScanNumber = pQueryMS1->_pSpecLibResultsMS1.iWhichSpecLib;
-      scoresMS1.push_back(scoreMS1);
+      // Pass best RT match to regression aligner.
+      // pMS1Aligner is per-CometSearchManager instance state, but the C# code
+      // currently calls DoMS1SearchMultiResults from multiple threads.
+      // For now, protect with the existing g_pvQueryMutex since the aligner
+      // is lightweight and this serialization only affects the RT regression,
+      // not the scoring.
+      double dMatchedSpecLibRT = localScores[0].fRTime;
+
+      Threading::LockMutex(g_pvQueryMutex);
+      double dLinearRegressionRT = pMS1Aligner.processRetentionMatch(dQueryRT, dMatchedSpecLibRT);
+      Threading::UnlockMutex(g_pvQueryMutex);
+
+      // Overwrite the RT with the regression-adjusted value
+      localScores[0].fRTime = (float)dLinearRegressionRT;
+
+      scoresMS1 = std::move(localScores);
    }
-   else
-      goto cleanup_results;
 
-cleanup_results:
-
-   // Deleting each Query object in the vector calls its destructor, which
-   // frees the spectral memory (see definition for Query in CometDataInternal.h).
-   for (auto it = g_pvQuery.begin(); it != g_pvQuery.end(); ++it)
-      delete (*it);
-
-   g_pvQuery.clear();
+   // Task 2.3: Clean up thread-local QueryMS1*
+   delete pQueryMS1;
+   pQueryMS1 = nullptr;
 
    return bSucceeded;
 }

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -63,7 +63,7 @@ map<long long, IndexProteinStruct>    g_pvProteinNames;  // for either db index
 
 
 AScoreProCpp::AScoreOptions   g_AScoreOptions;  // AScore options
-// Thread-safety note — g_AScoreInterface is shared across PostAnalysis threads.
+// Thread-safety note - g_AScoreInterface is shared across PostAnalysis threads.
 // AScoreDllInterface::CalculateScoreWithOptions() is assumed to be thread-safe because
 // it does not modify any mutable member state; all intermediate computation uses local
 // variables. If AScorePro is ever changed to use internal mutable state, this must be
@@ -403,8 +403,10 @@ static bool ValidateSequenceDatabaseFile()
    // open FASTA for retrieving protein names
    string sTmpDB = g_staticParams.databaseInfo.szDatabase;
 
-   if (!strcmp(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   size_t databaseLen = strlen(g_staticParams.databaseInfo.szDatabase);
+   if (databaseLen >= 4 && strcmp(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
       sTmpDB = sTmpDB.erase(sTmpDB.size() - 4); // need plain fasta if indexdb input
+
    if ((fpcheck = fopen(sTmpDB.c_str(), "r")) == NULL)
    {
       g_bIdxNoFasta = true;  // .idx database but corresponding fasta not found
@@ -417,7 +419,7 @@ static bool ValidateSequenceDatabaseFile()
 
    // if .idx database specified but does not exist, first see if corresponding
    // fasta exists and if it does, create the .idx file
-   if (strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   if (databaseLen >= 4 &&  strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
    {
       if ((fpcheck=fopen(g_staticParams.databaseInfo.szDatabase, "r")) == NULL)
       {
@@ -1717,7 +1719,8 @@ bool CometSearchManager::InitializeStaticParams()
    g_massRange.uiMaxFragmentArrayIndex = BIN(g_staticParams.options.dFragIndexMaxMass) + 1;
 
    // At this point, check extension to set whether index database or not
-   if (!strcmp(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   size_t databaseLen = strlen(g_staticParams.databaseInfo.szDatabase);
+   if (databaseLen >= 4 && !strcmp(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
    {
       // Has .idx extension.  Now parse first line ot see if peptide index or fragment index.
       // either "Comet peptide index" or "Comet fragment ion index"
@@ -3282,7 +3285,8 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
       return false;
 
    // Determine index type from .idx file header
-   if (strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   size_t databaseLen = strlen(g_staticParams.databaseInfo.szDatabase);
+   if (databaseLen >= 4 && strstr(g_staticParams.databaseInfo.szDatabase + databaseLen - 4, ".idx"))
    {
       FILE* fpCheck = fopen(g_staticParams.databaseInfo.szDatabase, "rb");
       if (fpCheck)
@@ -3633,7 +3637,7 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
    {
       string strErrorMsg = " Error - cannot read indexed database file \"" + std::string(g_staticParams.databaseInfo.szDatabase)
          + "\" " + std::strerror(errno) + "\n.";
-      // Don't poison global state — just log and fail this query
+      // Don't poison global state - just log and fail this query
       logerr(strErrorMsg);
       bSucceeded = false;
       goto cleanup_results;

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -38,9 +38,11 @@
 
 #undef PERF_DEBUG
 
+extern comet_fileoffset_t clSizeCometFileOffset;
+
 std::vector<Query*>           g_pvQuery;
 
-// g_pvQueryMS1: BATCH PATH ONLY — used by RunMS1Search(ThreadPool*,...) and
+// g_pvQueryMS1: BATCH PATH ONLY - used by RunMS1Search(ThreadPool*,...) and
 // PreprocessMS1SingleSpectrum(). The single-spectrum MS1 search path
 // (DoMS1SearchMultiResults) uses thread-local QueryMS1* objects and never
 // reads or writes this vector. Do not access from concurrent search threads.
@@ -54,12 +56,18 @@ Mutex                         g_pvQueryMutex;
 Mutex                         g_pvDBIndexMutex;
 Mutex                         g_preprocessMemoryPoolMutex;
 Mutex                         g_searchMemoryPoolMutex;
+Mutex                         g_ms1AlignerMutex;
 CometStatus                   g_cometStatus;
 string                        g_sCometVersion;
 map<long long, IndexProteinStruct>    g_pvProteinNames;  // for either db index
 
 
 AScoreProCpp::AScoreOptions   g_AScoreOptions;  // AScore options
+// Thread-safety note — g_AScoreInterface is shared across PostAnalysis threads.
+// AScoreDllInterface::CalculateScoreWithOptions() is assumed to be thread-safe because
+// it does not modify any mutable member state; all intermediate computation uses local
+// variables. If AScorePro is ever changed to use internal mutable state, this must be
+// protected with a mutex or made thread-local.
 AScoreProCpp::AScoreDllInterface* g_AScoreInterface;
 
 vector<vector<comet_fileoffset_t>> g_pvProteinsList;
@@ -74,7 +82,7 @@ vector<vector<unsigned int>> g_vulSpecLibPrecursorIndex;    // mass index for Sp
 vector<SpecLibStruct> g_vSpecLib;                           // stores the SpecLib
 
 bool g_bPlainPeptideIndexRead = false;
-bool g_bPeptideIndexRead = false;
+std::atomic<bool> g_bPeptideIndexRead = false;
 bool g_bSpecLibRead = false;
 bool g_bPerformSpecLibSearch = false;
 bool g_bPerformDatabaseSearch = false;
@@ -289,7 +297,6 @@ static bool AllocateResultsMem()
          pQuery->_pResults[j].usiMatchedIons = 0;
          pQuery->_pResults[j].usiTotalIons = 0;
          pQuery->_pResults[j].szPeptide[0] = '\0';
-         pQuery->_pResults[j].strSingleSearchProtein.clear();
          pQuery->_pResults[j].sAScoreProSiteScores.clear();
          pQuery->_pResults[j].pWhichProtein.clear();
          pQuery->_pResults[j].sPeffOrigResidues.clear();
@@ -311,7 +318,6 @@ static bool AllocateResultsMem()
             pQuery->_pDecoys[j].usiMatchedIons = 0;
             pQuery->_pDecoys[j].usiTotalIons = 0;
             pQuery->_pDecoys[j].szPeptide[0] = '\0';
-            pQuery->_pDecoys[j].strSingleSearchProtein.clear();
             pQuery->_pDecoys[j].sAScoreProSiteScores.clear();
             pQuery->_pDecoys[j].pWhichProtein.clear();
             pQuery->_pDecoys[j].sPeffOrigResidues.clear();
@@ -433,9 +439,23 @@ static bool ValidateSequenceDatabaseFile()
             return true;
          }
       }
+      else
+      {
+         // Detect index type from .idx file header
+         char szHeader[256];
+         if (fgets(szHeader, sizeof(szHeader), fpcheck))
+         {
+            if (strstr(szHeader, "Comet peptide index database"))
+               g_staticParams.iDbType = DbType::PI_DB;  // peptide index
+            else
+               g_staticParams.iDbType = DbType::FI_DB;  // fragment ion index
+         }
+      }
 
       fclose(fpcheck);
       g_staticParams.options.bCreateFragmentIndex = false;
+      g_staticParams.options.bCreatePeptideIndex = false;
+
       return true;
    }
 
@@ -520,8 +540,8 @@ static bool ValidatePeptideLengthRange()
          && g_staticParams.options.peptideLengthRange.iEnd != 0)
    {
       string strErrorMsg = " Error - peptide length range set as "
-         + std::to_string(g_staticParams.options.scanRange.iStart) + " to "
-         + std::to_string(g_staticParams.options.scanRange.iEnd)
+         + std::to_string(g_staticParams.options.peptideLengthRange.iStart) + " to "
+         + std::to_string(g_staticParams.options.peptideLengthRange.iEnd)
          + ".\n The maximum length must be >= to the minimum length.\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
       logerr(strErrorMsg);
@@ -540,8 +560,7 @@ static bool ValidatePeptideLengthRange()
 CometSearchManager::CometSearchManager() :
    singleSearchInitializationComplete(false),
    singleSearchMS1InitializationComplete(false),
-   staticParamsInitializationComplete(false),
-   singleSearchThreadCount(1)
+   staticParamsInitializationComplete(false)
 {
    // Initialize the mutexes we'll use to protect global data.
    Threading::InitMutex(&g_pvQueryMutex);
@@ -555,9 +574,18 @@ CometSearchManager::CometSearchManager() :
    // Initialize the mutex we'll use to protect the search memory pool
    Threading::InitMutex(&g_searchMemoryPoolMutex);
 
+   // Initialize the mutex we'll use to protect the MS1 RT aligner
+   Threading::InitMutex(&g_ms1AlignerMutex);
+
    // Initialize the Comet version
    SetParam("# comet_version", comet_version, comet_version);
    _tp = new ThreadPool();
+
+   // Wire up the error handler so that uncaught exceptions in thread pool
+   // tasks are propagated to g_cometStatus for the main thread to detect.
+   _tp->setErrorHandler([](const std::string& strErrorMsg) {
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      });
 }
 
 CometSearchManager::~CometSearchManager()
@@ -573,6 +601,9 @@ CometSearchManager::~CometSearchManager()
 
    // Destroy the mutex we used to protect the search memory pool
    Threading::DestroyMutex(g_searchMemoryPoolMutex);
+
+   // Destroy the mutex we used to protect the MS1 RT aligner
+   Threading::DestroyMutex(g_ms1AlignerMutex);
 
    //std::vector calls destructor of every element it contains when clear() is called
    g_pvInputFiles.clear();
@@ -1150,7 +1181,7 @@ bool CometSearchManager::InitializeStaticParams()
    if (GetParamValue("set_Z_user_amino_acid", dDoubleData))
    {
       if (dDoubleData != 0.0)
-         g_staticParams.massUtility.pdAAMassUser[(int)'X'] = dDoubleData;
+         g_staticParams.massUtility.pdAAMassUser[(int)'Z'] = dDoubleData;
    }
 
    if (GetParamValue("fragindex_min_fragmentmass", dDoubleData))
@@ -1697,7 +1728,7 @@ bool CometSearchManager::InitializeStaticParams()
       // for the search.
       if ( (fp=fopen(g_staticParams.databaseInfo.szDatabase, "r")) == NULL)
       {
-         g_staticParams.iIndexDb = 1;  // fragment ion index
+         g_staticParams.iDbType = DbType::FI_DB;
          if (g_staticParams.options.iSpectrumBatchSize > FRAGINDEX_MAX_BATCHSIZE || g_staticParams.options.iSpectrumBatchSize == 0)
             g_staticParams.options.iSpectrumBatchSize = FRAGINDEX_MAX_BATCHSIZE;
       }
@@ -1714,11 +1745,11 @@ bool CometSearchManager::InitializeStaticParams()
 
          if (!strncmp(szTmp, "Comet peptide index", 19))
          {
-            g_staticParams.iIndexDb = 2;  // peptide index
+            g_staticParams.iDbType = DbType::PI_DB;
          }
          else if (!strncmp(szTmp, "Comet fragment ion index", 24))
          {
-             g_staticParams.iIndexDb = 1;  // fragment ion index
+             g_staticParams.iDbType = DbType::FI_DB;
 
             // if searching fragment index database, limit load of query spectra as no
             // need to load all spectra into memory since querying spectra sequentially
@@ -1736,7 +1767,7 @@ bool CometSearchManager::InitializeStaticParams()
       }
    }
 
-   if (g_staticParams.options.bCreateFragmentIndex && g_staticParams.iIndexDb)
+   if (g_staticParams.options.bCreateFragmentIndex && g_staticParams.iDbType != DbType::FASTA_DB)
    {
       string strErrorMsg = " Error - input database already indexed: \"" + std::string(g_staticParams.databaseInfo.szDatabase) + "\".\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
@@ -1744,7 +1775,7 @@ bool CometSearchManager::InitializeStaticParams()
       return false;
    }
 
-   if (g_staticParams.iIndexDb == 1)
+   if (g_staticParams.iDbType == DbType::FI_DB)
    {
       g_bIndexPrecursors = (bool*)malloc(BIN(g_staticParams.options.dPeptideMassHigh) * sizeof(bool));
       if (g_bIndexPrecursors == NULL)
@@ -2185,23 +2216,33 @@ bool CometSearchManager::DoSearch()
    else
       g_sCometVersion = std::string(comet_version);
 
-   if (!g_staticParams.options.bOutputSqtStream) // && !g_staticParams.iIndexDb)
+   if (!g_staticParams.options.bOutputSqtStream)
    {
       strOut = "\n Comet version \"" + g_sCometVersion + "\"\n\n";
       logout(strOut);
       fflush(stdout);
    }
 
-   tp->fillPool(g_staticParams.options.iNumThreads < 0 ? 0 : g_staticParams.options.iNumThreads - 1);
-
-   if (g_staticParams.options.bCreatePeptideIndex)
+   try
    {
-      // WritePeptideIndex calls RunSearch just to query fasta and generate uniq peptide list
+      tp->fillPool(g_staticParams.options.iNumThreads);
+   }
+   catch (const std::exception& e)
+   {
+      string strErrorMsg = " Error - thread pool initialization failed: " + std::string(e.what()) + "\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
+
+   if (g_staticParams.options.bCreatePeptideIndex && g_staticParams.iDbType == DbType::FASTA_DB)
+   {
+      // WritePeptideIndex calls RunSearch just to query fasta and generate unique peptide list
       bSucceeded = CometPeptideIndex::WritePeptideIndex(tp);
       return bSucceeded;
    }
 
-   if (g_staticParams.options.bCreateFragmentIndex || !g_staticParams.iIndexDb)
+   if (g_staticParams.options.bCreateFragmentIndex || g_staticParams.iDbType == DbType::FASTA_DB)
    {
       // If specified, read in the protein variable mod filter file content.
       // Do this here only for classic search or if creating the plain peptide index.
@@ -2250,7 +2291,7 @@ bool CometSearchManager::DoSearch()
 
    bool bBlankSearchFile = false;
 
-   if (g_bPerformDatabaseSearch && g_staticParams.iIndexDb == 1)
+   if (g_bPerformDatabaseSearch && g_staticParams.iDbType == DbType::FI_DB)
    {
       if (!g_staticParams.options.iFragIndexSkipReadPrecursors)
       {
@@ -2301,7 +2342,7 @@ bool CometSearchManager::DoSearch()
       time(&tStartTime);
       strftime(g_staticParams.szDate, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tStartTime));
 
-      if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+      if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
       {
          strOut = " Search start:  " + string(g_staticParams.szDate) + "\n";
          strOut += " - Input file: " + string(g_staticParams.inputFile.szFileName) + "\n";
@@ -2577,7 +2618,7 @@ bool CometSearchManager::DoSearch()
             fpoutd_mzidentml = fopen(sOutputDecoyMzIdentML.c_str(), "w");
             if (!fpoutd_mzidentml)
             {
-               string strErrorMsg = " Error - cannot write to decoy file \"" + sOutputDecoyMzIdentML + "\n";
+               string strErrorMsg = " Error - cannot write to decoy file \"" + sOutputDecoyMzIdentML + "\".\n";
                g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
                logerr(strErrorMsg);
                bSucceeded = false;
@@ -2664,7 +2705,7 @@ bool CometSearchManager::DoSearch()
          {
             string sTmpDB = g_staticParams.databaseInfo.szDatabase;
 
-            if (g_staticParams.iIndexDb > 0)
+            if (g_staticParams.iDbType != DbType::FASTA_DB)
             {
                // .idx db so first open .idx file
                if ((fpidx = fopen(sTmpDB.c_str(), "r")) == NULL)
@@ -2698,7 +2739,7 @@ bool CometSearchManager::DoSearch()
             }
          }
 
-         if (g_staticParams.options.iSpectrumBatchSize == 0 && !g_staticParams.iIndexDb)
+         if (g_staticParams.options.iSpectrumBatchSize == 0 && g_staticParams.iDbType == DbType::FASTA_DB)
          {
             logout("   - Reading all spectra into memory; set \"spectrum_batch_size\" if search terminates here.\n");
             fflush(stdout);
@@ -2706,7 +2747,7 @@ bool CometSearchManager::DoSearch()
 
          CometFragmentIndex sqSearch;
 
-         if (g_bPerformDatabaseSearch && g_staticParams.iIndexDb == 1)
+         if (g_bPerformDatabaseSearch && g_staticParams.iDbType == DbType::FI_DB)
          {
             if (!g_bPlainPeptideIndexRead)
             {
@@ -2745,7 +2786,7 @@ bool CometSearchManager::DoSearch()
          }
 
          auto tBeginTime = chrono::steady_clock::now();
-         if (g_staticParams.iIndexDb)
+         if (g_staticParams.iDbType != DbType::FASTA_DB)
          {
             printf(" - searching \"%s\" ... ", g_staticParams.inputFile.szBaseName);
             fflush(stdout);
@@ -2754,7 +2795,7 @@ bool CometSearchManager::DoSearch()
          FILE* fpdb = NULL;
          if (g_bPerformDatabaseSearch)
          {
-            if (g_staticParams.iIndexDb > 0)
+            if (g_staticParams.iDbType != DbType::FASTA_DB)
                fpdb = fpidx;
             else
                fpdb = fpfasta;
@@ -2778,7 +2819,7 @@ bool CometSearchManager::DoSearch()
             szTimeBuffer[0] = '\0';
 #endif
             // Load and preprocess all the spectra.
-            if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+            if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
             {
                logout("   - Load spectra:");
 
@@ -2832,7 +2873,7 @@ bool CometSearchManager::DoSearch()
 
             { // need strStatusMsg in it's own scope due to goto statement above
                string strStatusMsg = " " + std::to_string(g_pvQuery.size()) + string("\n");
-               if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+               if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
                {
                   logout(strStatusMsg);
                }
@@ -2924,7 +2965,7 @@ bool CometSearchManager::DoSearch()
             if (!bSucceeded)
                goto cleanup_results;
 
-            if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+            if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
             {
                logout("     - Post analysis:");
                fflush(stdout);
@@ -2958,7 +2999,7 @@ bool CometSearchManager::DoSearch()
             // Sort g_pvQuery vector by scan.
             std::sort(g_pvQuery.begin(), g_pvQuery.end(), compareByScanNumber);
 
-            if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+            if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
             {
                logout("  done\n");
                fflush(stdout);
@@ -3001,7 +3042,7 @@ cleanup_results:
                break;
          }
 
-         if (g_bPerformDatabaseSearch && g_staticParams.iIndexDb)
+         if (g_bPerformDatabaseSearch && g_staticParams.iDbType != DbType::FASTA_DB)
          {
             const auto duration = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - tBeginTime);
             double dTimePerSpectra = (double)duration.count() / (double)iTotalSpectraSearched;
@@ -3057,7 +3098,7 @@ cleanup_results:
                remove(sOutputDecoyMzIdentMLtmp.c_str());
             }
 
-            if (!g_staticParams.options.bOutputSqtStream && !g_staticParams.iIndexDb)
+            if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
             {
                time_t tEndTime;
 
@@ -3189,7 +3230,7 @@ cleanup_results:
          break;
    }
 
-   if (g_staticParams.iIndexDb == 1) // clean fragment ion index
+   if (g_staticParams.iDbType == DbType::FI_DB) // clean fragment ion index
    {
       free(g_bIndexPrecursors);       // allocated in InitializeStaticParams
 
@@ -3204,7 +3245,7 @@ cleanup_results:
       delete[] g_iCountFragmentIndex;
    }
 
-   if (g_staticParams.iIndexDb) // for either index search
+   if (g_staticParams.iDbType != DbType::FASTA_DB) // for either index search
       std::cout << " - done. (" << CometMassSpecUtils::ElapsedTime(tGlobalStartTime) << ")" << endl << endl;
 
    if (g_staticParams.options.iPrintAScoreProScore)
@@ -3219,22 +3260,18 @@ cleanup_results:
 
 bool CometSearchManager::InitializeSingleSpectrumSearch()
 {
-   static Mutex g_initSingleSearchMutex;
+   static std::mutex g_initSingleSearchMutex;
 
-   // Fast path
-   if (singleSearchInitializationComplete)
+   // Fast path: atomic acquire-load avoids data race while bypassing the mutex
+   // when initialization is already complete.
+   if (singleSearchInitializationComplete.load(std::memory_order_acquire))
       return true;
 
-   // RAII lock guard (automatically unlocks on scope exit)
-   struct ScopedLock
-   {
-      Mutex* m;
-      ScopedLock(Mutex* mutex) : m(mutex) { Threading::LockMutex(*m); }
-      ~ScopedLock() { Threading::UnlockMutex(*m); }
-   } lock(&g_initSingleSearchMutex);
+   std::lock_guard<std::mutex> lock(g_initSingleSearchMutex);
 
-   // Double-check
-   if (singleSearchInitializationComplete)
+   // Double-check under the lock (relaxed is sufficient: the mutex provides
+   // the required happens-before relationship).
+   if (singleSearchInitializationComplete.load(std::memory_order_relaxed))
       return true;
 
    // Initialization code (no manual unlock needed!)
@@ -3243,6 +3280,39 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
 
    if (!ValidateSequenceDatabaseFile())
       return false;
+
+   // Determine index type from .idx file header
+   if (strstr(g_staticParams.databaseInfo.szDatabase + strlen(g_staticParams.databaseInfo.szDatabase) - 4, ".idx"))
+   {
+      FILE* fpCheck = fopen(g_staticParams.databaseInfo.szDatabase, "rb");
+      if (fpCheck)
+      {
+         char szHeader[256];
+         if (fgets(szHeader, sizeof(szHeader), fpCheck))
+         {
+            if (strstr(szHeader, "Comet peptide index database"))
+            {
+               g_staticParams.iDbType = DbType::PI_DB;  // peptide index
+               g_staticParams.options.bCreatePeptideIndex = false;
+               g_bPeptideIndexRead = false;
+            }
+            else if (strstr(szHeader, "Comet fragment ion index plain peptides"))
+            {
+               g_staticParams.iDbType = DbType::FI_DB;  // fragment ion index
+               g_staticParams.options.bCreateFragmentIndex = false;
+            }
+            else
+            {
+               string strErrorMsg = " Error - unrecognized .idx file header in file \"" + string(g_staticParams.databaseInfo.szDatabase) + "\".\n";
+               strErrorMsg += " Found header: \"" + string(szHeader) + "\"\n";
+               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+               logerr(strErrorMsg);
+               return false;
+            }
+         }
+         fclose(fpCheck);
+      }
+   }
 
    g_sCometVersion = comet_version;
 
@@ -3262,54 +3332,100 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
       return false;
 
    ThreadPool* tp = _tp;
-   tp->fillPool(g_staticParams.options.iNumThreads < 0 ? 0 : g_staticParams.options.iNumThreads - 1);
 
-   // Load databases
-   CometFragmentIndex sqSearch;
-
-   if (g_staticParams.options.bCreatePeptideIndex)
+   try
    {
-      // WritePeptideIndex calls RunSearch just to query fasta and generate uniq peptide list
-      bSucceeded = CometPeptideIndex::WritePeptideIndex(tp);
-      if (!bSucceeded)
-         return false;
+      tp->fillPool(g_staticParams.options.iNumThreads);
+   }
+   catch (const std::exception& e)
+   {
+      string strErrorMsg = " Error - thread pool initialization failed: " + std::string(e.what()) + "\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
    }
 
-   if (g_staticParams.options.bCreateFragmentIndex)
+   if (g_staticParams.iDbType == DbType::FI_DB)
    {
-      bSucceeded = CreateFragmentIndex();
-      if (!bSucceeded)
-         return false;
-   }
+      // Load databases
+      CometFragmentIndex sqSearch;
 
-   if (g_staticParams.iIndexDb == 1 && !g_bPlainPeptideIndexRead)
-   {
-      sqSearch.ReadPlainPeptideIndex();
-      sqSearch.CreateFragmentIndex(tp);
-
-      if (g_staticParams.options.iPrintAScoreProScore)
+      if (g_staticParams.options.bCreateFragmentIndex)
       {
-         // normally set at end of InitializeStaticParams; must do here again after
-         // ReadPlainPeptideIndex for single spectrum search
-         SetAScoreOptions(g_AScoreOptions);
-//       PrintAScoreOptions(g_AScoreOptions);
-
-         // Create the AScoreDllInterface using the factory function
-         g_AScoreInterface = CreateAScoreDllInterface();
-         if (!g_AScoreInterface)
-         {
-            std::cerr << "Failed to create AScore interface." << std::endl;
+         bSucceeded = CreateFragmentIndex();
+         if (!bSucceeded)
             return false;
+      }
+
+      if (g_staticParams.iDbType == DbType::FI_DB && !g_bPlainPeptideIndexRead)
+      {
+         sqSearch.ReadPlainPeptideIndex();
+         sqSearch.CreateFragmentIndex(tp);
+
+         if (g_staticParams.options.iPrintAScoreProScore)
+         {
+            // normally set at end of InitializeStaticParams; must do here again after
+            // ReadPlainPeptideIndex for single spectrum search
+            SetAScoreOptions(g_AScoreOptions);
+            //       PrintAScoreOptions(g_AScoreOptions);
+
+                     // Create the AScoreDllInterface using the factory function
+            g_AScoreInterface = CreateAScoreDllInterface();
+            if (!g_AScoreInterface)
+            {
+               std::cerr << "Failed to create AScore interface." << std::endl;
+               return false;
+            }
          }
       }
+
+      // Freeze index (make immutable); already set in ReadPlainPeptideIndex but doing
+      // here again to be safe for no good reason.
+      g_bPlainPeptideIndexRead = true;
    }
 
-   // Mark as complete BEFORE unlocking (mutex unlock provides memory fence)
-   singleSearchInitializationComplete = true;
+   // Detect peptide index from .idx file header and load into memory.
+   // This runs once under the singleSearchInitializationComplete atomic guard.
+   if (g_staticParams.iDbType == DbType::PI_DB && !g_bPeptideIndexRead)
+   {
+      if (!CometPeptideIndex::ReadPeptideIndex())
+      {
+         string strErrorMsg = " Error - failed to read peptide index in InitializeSingleSpectrumSearch().\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
 
-   // Freeze index (make immutable); already set in ReadPlainPeptideIndex but doing
-   // here again to be safe for no good reason.
-   g_bPlainPeptideIndexRead = true;
+      // Re-initialize fragment masses from .idx header so they match
+      // the static/variable mods used when building the index.
+      // Without this, pdAAMassFragment retains values from
+      // InitializeStaticParams() which may have double-applied static mods.
+      if (!CometSearch::InitializeMassesFromPeptideIndex())
+      {
+         string strErrorMsg = " Error - failed to parse .idx header for mass initialization.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
+
+      // Allocate search memory (pbDuplFragment arrays) needed by RunSearch(Query*)
+      if (!CometSearch::AllocateMemory(g_staticParams.options.iNumThreads))
+      {
+         string strErrorMsg = " Error - AllocateMemory failed for peptide index search.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
+
+      g_bPeptideIndexRead = true;
+   }
+
+   // --- End: peptide index initialization for iDbType == 2 ---
+
+   // Release-store ensures all initialization writes above are visible to any
+   // thread that subsequently observes this flag as true.
+   singleSearchInitializationComplete.store(true, std::memory_order_release);
+
 
    return true;
 }
@@ -3317,15 +3433,15 @@ bool CometSearchManager::InitializeSingleSpectrumSearch()
 
 void CometSearchManager::FinalizeSingleSpectrumSearch()
 {
-   if (singleSearchInitializationComplete)
+   if (singleSearchInitializationComplete.load(std::memory_order_acquire))
    {
       // Deallocate search memory
-      CometSearch::DeallocateMemory(singleSearchThreadCount);
+      CometSearch::DeallocateMemory(g_staticParams.options.iNumThreads);
 
       if (g_staticParams.options.iPrintAScoreProScore)
          DeleteAScoreDllInterface(g_AScoreInterface);
 
-      singleSearchInitializationComplete = false;
+      singleSearchInitializationComplete.store(false, std::memory_order_release);
    }
 }
 
@@ -3333,43 +3449,53 @@ void CometSearchManager::FinalizeSingleSpectrumSearch()
 // Task 1.1 + 1.2: Load reference library once during init; fix thread pool deadlock
 bool CometSearchManager::InitializeSingleSpectrumMS1Search(const double dMaxQueryRT)
 {
-   if (singleSearchMS1InitializationComplete)
+   static std::mutex g_initSingleMS1SearchMutex;
+
+   if (singleSearchMS1InitializationComplete.load(std::memory_order_acquire))
+      return true;
+
+   std::lock_guard<std::mutex> lock(g_initSingleMS1SearchMutex);
+
+   if (singleSearchMS1InitializationComplete.load(std::memory_order_relaxed))
       return true;
 
    if (!InitializeStaticParams())
       return false;
 
-   int iNumThreads = g_staticParams.options.iNumThreads;
-   if (iNumThreads < 1)
-      iNumThreads = 1;
-
-   // Task 1.2: Ensure at least 1 worker thread so LoadSpecLibMS1Raw doesn't deadlock.
    // _tp may already be created by InitializeSingleSpectrumSearch(); if so, reuse it.
    // If not, create it here.
    if (_tp == nullptr)
       _tp = new ThreadPool();
 
-   // fillPool with at least 1 worker — fillPool(0) causes deadlock in LoadSpecLibMS1Raw
-   int iPoolSize = (iNumThreads > 1) ? (iNumThreads - 1) : 1;
-   _tp->fillPool(iPoolSize);
+   try
+   {
+      _tp->fillPool(g_staticParams.options.iNumThreads);
+   }
+   catch (const std::exception& e)
+   {
+      string strErrorMsg = " Error - thread pool initialization failed: " + std::string(e.what()) + "\n";
+      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+      logerr(strErrorMsg);
+      return false;
+   }
 
    // Task 1.1: Load reference library ONCE, here in init (single-threaded context).
    // After this call, g_vSpecLib is populated and g_bSpecLibRead == true.
    if (!CometSpecLib::LoadSpecLibMS1Raw(_tp, dMaxQueryRT, &dMaxSpecLibRT))
       return false;
 
-   singleSearchMS1InitializationComplete = true;
+   singleSearchMS1InitializationComplete.store(true, std::memory_order_release);
    return true;
 }
 
 
 void CometSearchManager::FinalizeSingleSpectrumMS1Search()
 {
-   if (singleSearchMS1InitializationComplete)
+   if (singleSearchMS1InitializationComplete.load(std::memory_order_acquire))
    {
       // Deallocate search memory
-      CometSearch::DeallocateMemory(singleSearchThreadCount);
-      singleSearchMS1InitializationComplete = false;
+      CometSearch::DeallocateMemory(g_staticParams.options.iNumThreads);
+      singleSearchMS1InitializationComplete.store(false, std::memory_order_release);
    }
 }
 
@@ -3393,9 +3519,6 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
 
    if (!InitializeSingleSpectrumSearch())
       return false;
-
-   // tRealTimeStart used to track elapsed search time and to exit if g_staticParams.options.iMaxIndexRunTime is surpased
-   g_staticParams.tRealTimeStart = std::chrono::high_resolution_clock::now();
 
 #ifdef PERF_DEBUG
    // print set search parameters
@@ -3424,424 +3547,451 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
       return false;
    }
 
+/*
+   // Validate the sparse matrix spectrum for pQuery is valid and not empty after preprocessing (e.g. all peaks filtered out).
+   // first check if first dimension of ppSparseFastXcorrData is non-null
+   bool bEmpty = true;
+   int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
+   for (int i = 0; i < iMax; ++i)
+   {
+      if (pQuery->ppfSparseFastXcorrData[i] != nullptr)
+      {
+         bEmpty = false;
+         break;
+      }
+   }
+   if (!bEmpty)
+   {
+      printf("OK this spectrum is not empty\n");
+   }
+   else
+      return false;
+*/
+
+   // Record per-query start time for iMaxIndexRunTime timeout (thread-safe; avoids writing to global)
+   pQuery->tSearchStart = std::chrono::high_resolution_clock::now();
+
    // Step 3: Run the fragment index search on the thread-local Query*
    // This uses the new RunSearch(Query*) overload that allocates its own
    // pbDuplFragment and never touches g_pvQuery or _ppbDuplFragmentArr.
    bSucceeded = CometSearch::RunSearch(pQuery); 
 
+   FILE* fp = NULL;
+   int iSize;
+   int takeSearchResultsN;
+
    if (!bSucceeded)
       goto cleanup_results;
 
+   iSize = pQuery->iMatchPeptideCount;
+   if (iSize > g_staticParams.options.iNumStored)
+      iSize = g_staticParams.options.iNumStored;
+
+   if (iSize > 1)
    {
-      int iSize = pQuery->iMatchPeptideCount;
-      if (iSize > g_staticParams.options.iNumStored)
-         iSize = g_staticParams.options.iNumStored;
+      std::sort(pQuery->_pResults, pQuery->_pResults + iSize, CometPostAnalysis::SortFnXcorr);
+   }
 
-      if (iSize > 1)
+   takeSearchResultsN = topN;
+   if (takeSearchResultsN > iSize)
+      takeSearchResultsN = iSize;
+
+   // Step 4: Post-analysis using Query* overloads (no g_pvQuery access)
+   if (pQuery->iMatchPeptideCount > 0)
+   {
+      CometPostAnalysis::CalculateSP(pQuery->_pResults, pQuery, takeSearchResultsN);
+      CometPostAnalysis::CalculateEValue(pQuery, false);
+      CometPostAnalysis::CalculateDeltaCn(pQuery);
+
+      if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
+         && pQuery->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
       {
-         std::sort(pQuery->_pResults, pQuery->_pResults + iSize, CometPostAnalysis::SortFnXcorr);
-      }
-
-      int takeSearchResultsN = topN;
-      if (takeSearchResultsN > iSize)
-         takeSearchResultsN = iSize;
-
-      // Step 4: Post-analysis using Query* overloads (no g_pvQuery access)
-      if (pQuery->iMatchPeptideCount > 0)
-      {
-         CometPostAnalysis::CalculateSP(pQuery->_pResults, pQuery, takeSearchResultsN);
-         CometPostAnalysis::CalculateEValue(pQuery, false);
-         CometPostAnalysis::CalculateDeltaCn(pQuery);
-
-         if ((g_staticParams.options.iPrintAScoreProScore == -1 || g_staticParams.options.iPrintAScoreProScore > 0)
-            && pQuery->_pResults[0].cHasVariableMod == HasVariableModType_AScorePro)
+         bool bHasTerminalVariableMod = false;
+         if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0
+            || pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
          {
-            bool bHasTerminalVariableMod = false;
-            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0
-               || pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
-            {
-               bHasTerminalVariableMod = true;
-            }
-            if (!bHasTerminalVariableMod)
-               CometPostAnalysis::CalculateAScorePro(pQuery, g_AScoreInterface);
+            bHasTerminalVariableMod = true;
          }
+         if (!bHasTerminalVariableMod)
+            CometPostAnalysis::CalculateAScorePro(pQuery, g_AScoreInterface);
       }
-      else
+   }
+   else
+   {
+      goto cleanup_results;
+   }
+
+   if (g_cometStatus.IsCancel())
+   {
+      bSucceeded = false;
+      goto cleanup_results;
+   }
+
+   // Step 5: Open .idx file for retrieving protein names
+   // Each concurrent call opens its own FILE* so there is no shared file pointer state.
+   if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
+   {
+      string strErrorMsg = " Error - cannot read indexed database file \"" + std::string(g_staticParams.databaseInfo.szDatabase)
+         + "\" " + std::strerror(errno) + "\n.";
+      // Don't poison global state — just log and fail this query
+      logerr(strErrorMsg);
+      bSucceeded = false;
+      goto cleanup_results;
+   }
+
+   // Step 6: Extract results from thread-local Query*
+   for (int iWhichResult = 0; iWhichResult < takeSearchResultsN; ++iWhichResult)
+   {
+      CometScores score;
+      score.dCn = 0;
+      score.xCorr = g_staticParams.options.dMinimumXcorr;
+      score.matchedIons = 0;
+      score.totalIons = 0;
+      score.dAScorePro = 0;
+      score.sAScoreProSiteScores.clear();
+      std::string eachStrReturnPeptide;
+      std::string eachStrReturnProtein;
+      vector<Fragment> eachMatchedFragments;
+
+      if (iSize > 0 && pQuery->_pResults[iWhichResult].fXcorr > g_staticParams.options.dMinimumXcorr
+         && pQuery->_pResults[iWhichResult].usiLenPeptide > 0)
       {
-         goto cleanup_results;
-      }
+         Results* pOutput = pQuery->_pResults;
 
-      bSucceeded = !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
-      if (!bSucceeded)
-         goto cleanup_results;
+         // Set return values for peptide sequence, protein, xcorr and E-value
+         eachStrReturnPeptide = std::string(1, pOutput[iWhichResult].cPrevAA) + ".";
 
-      // Step 5: Open .idx file for retrieving protein names
-      // Each concurrent call opens its own FILE* so there is no shared file pointer state.
-      FILE* fp;
-      if ((fp = fopen(g_staticParams.databaseInfo.szDatabase, "rb")) == NULL)
-      {
-         string strErrorMsg = " Error - cannot read indexed database file \"" + std::string(g_staticParams.databaseInfo.szDatabase)
-            + "\" " + std::strerror(errno) + "\n.";
-         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-         logerr(strErrorMsg);
-         bSucceeded = false;
-         goto cleanup_results;
-      }
-
-      // Step 6: Extract results from thread-local Query*
-      for (int iWhichResult = 0; iWhichResult < takeSearchResultsN; ++iWhichResult)
-      {
-         CometScores score;
-         score.dCn = 0;
-         score.xCorr = g_staticParams.options.dMinimumXcorr;
-         score.matchedIons = 0;
-         score.totalIons = 0;
-         score.dAScorePro = 0;
-         score.sAScoreProSiteScores.clear();
-         std::string eachStrReturnPeptide;
-         std::string eachStrReturnProtein;
-         vector<Fragment> eachMatchedFragments;
-
-         if (iSize > 0 && pQuery->_pResults[iWhichResult].fXcorr > g_staticParams.options.dMinimumXcorr
-            && pQuery->_pResults[iWhichResult].usiLenPeptide > 0)
+         // n-term variable mod
+         if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide] != 0)
          {
-            Results* pOutput = pQuery->_pResults;
+            std::stringstream ss;
+            ss << "n[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide] << "]";
+            eachStrReturnPeptide += ss.str();
+         }
 
-            // Set return values for peptide sequence, protein, xcorr and E-value
-            eachStrReturnPeptide = std::string(1, pOutput[iWhichResult].cPrevAA) + ".";
+         for (int i = 0; i < pOutput[iWhichResult].usiLenPeptide; ++i)
+         {
+            eachStrReturnPeptide += pOutput[iWhichResult].szPeptide[i];
 
-            // n-term variable mod
-            if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide] != 0)
+            if (pOutput[iWhichResult].piVarModSites[i] != 0)
             {
                std::stringstream ss;
-               ss << "n[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide] << "]";
+               ss << "[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[i] << "]";
                eachStrReturnPeptide += ss.str();
             }
+         }
 
-            for (int i = 0; i < pOutput[iWhichResult].usiLenPeptide; ++i)
+         // c-term variable mod
+         if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] != 0)
+         {
+            std::stringstream ss;
+            ss << "c[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] << "]";
+            eachStrReturnPeptide += ss.str();
+         }
+         eachStrReturnPeptide += "." + std::string(1, pOutput[iWhichResult].cNextAA);
+
+         // Protein name retrieval - done inline using pOutput directly instead of
+         // calling GetProteinNameString which indexes into g_pvQuery.
+         // This replicates the indexed-db path from GetProteinNameString.
+         char szProteinName[512];
+         int iLenDecoyPrefix = (int)strlen(g_staticParams.szDecoyPrefix);
+
+         std::vector<string> vProteinTargets;
+         std::vector<string> vProteinDecoys;
+
+         if (g_staticParams.iDbType != DbType::FASTA_DB)
+         {
+            comet_fileoffset_t lEntry = pOutput[iWhichResult].lProteinFilePosition;
+            int iPrintDuplicateProteinCt = 0;
+
+            for (auto itProt = g_pvProteinsList.at(lEntry).begin(); itProt != g_pvProteinsList.at(lEntry).end(); ++itProt)
             {
-               eachStrReturnPeptide += pOutput[iWhichResult].szPeptide[i];
-
-               if (pOutput[iWhichResult].piVarModSites[i] != 0)
+               comet_fseek(fp, *itProt, SEEK_SET);
+               if (fgets(szProteinName, 511, fp) == NULL)
                {
-                  std::stringstream ss;
-                  ss << "[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[i] << "]";
-                  eachStrReturnPeptide += ss.str();
+                  // error reading protein name; skip
                }
-            }
+               szProteinName[500] = '\0';
 
-            // c-term variable mod
-            if (pOutput[iWhichResult].piVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] != 0)
-            {
-               std::stringstream ss;
-               ss << "c[" << std::fixed << std::setprecision(4) << pOutput[iWhichResult].pdVarModSites[pOutput[iWhichResult].usiLenPeptide + 1] << "]";
-               eachStrReturnPeptide += ss.str();
-            }
-            eachStrReturnPeptide += "." + std::string(1, pOutput[iWhichResult].cNextAA);
-
-            // Protein name retrieval — done inline using pOutput directly instead of
-            // calling GetProteinNameString which indexes into g_pvQuery.
-            // This replicates the indexed-db path from GetProteinNameString.
-               char szProteinName[512];
-            int iLenDecoyPrefix = (int)strlen(g_staticParams.szDecoyPrefix);
-
-            std::vector<string> vProteinTargets;
-            std::vector<string> vProteinDecoys;
-
-            if (g_staticParams.iIndexDb)
-            {
-               comet_fileoffset_t lEntry = pOutput[iWhichResult].lProteinFilePosition;
-               int iPrintDuplicateProteinCt = 0;
-
-               for (auto itProt = g_pvProteinsList.at(lEntry).begin(); itProt != g_pvProteinsList.at(lEntry).end(); ++itProt)
+               // remove trailing newline/carriage return
+               while (strlen(szProteinName) > 0
+                  && (szProteinName[strlen(szProteinName) - 1] == '\n'
+                     || szProteinName[strlen(szProteinName) - 1] == '\r'))
                {
-                  comet_fseek(fp, *itProt, SEEK_SET);
+                  szProteinName[strlen(szProteinName) - 1] = '\0';
+               }
+
+               if (!strncmp(szProteinName, g_staticParams.szDecoyPrefix, iLenDecoyPrefix))
+                  vProteinDecoys.push_back(szProteinName);
+               else
+                  vProteinTargets.push_back(szProteinName);
+
+               iPrintDuplicateProteinCt++;
+               if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
+                  break;
+            }
+         }
+         else
+         {
+            // Non-indexed (FASTA) path
+            int iPrintDuplicateProteinCt = 0;
+
+            if (pOutput[iWhichResult].pWhichProtein.size() > 0)
+            {
+               for (auto itProt = pOutput[iWhichResult].pWhichProtein.begin(); itProt != pOutput[iWhichResult].pWhichProtein.end(); ++itProt)
+               {
+                  comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
                   if (fgets(szProteinName, 511, fp) == NULL)
                   {
-                     // error reading protein name; skip
+                     // error
                   }
                   szProteinName[500] = '\0';
-
-                  // remove trailing newline/carriage return
                   while (strlen(szProteinName) > 0
                      && (szProteinName[strlen(szProteinName) - 1] == '\n'
                         || szProteinName[strlen(szProteinName) - 1] == '\r'))
                   {
                      szProteinName[strlen(szProteinName) - 1] = '\0';
                   }
-
-                  if (!strncmp(szProteinName, g_staticParams.szDecoyPrefix, iLenDecoyPrefix))
-                     vProteinDecoys.push_back(szProteinName);
-                  else
-                     vProteinTargets.push_back(szProteinName);
-
+                  vProteinTargets.push_back(szProteinName);
                   iPrintDuplicateProteinCt++;
-                  if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
+                  if (iPrintDuplicateProteinCt > g_staticParams.options.iMaxDuplicateProteins)
                      break;
                }
             }
+
+            if (pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
+            {
+               for (auto itProt = pOutput[iWhichResult].pWhichDecoyProtein.begin(); itProt != pOutput[iWhichResult].pWhichDecoyProtein.end(); ++itProt)
+               {
+                  if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
+                     break;
+                  comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
+                  if (fgets(szProteinName, 511, fp) == NULL)
+                  {
+                     // error
+                  }
+                  szProteinName[500] = '\0';
+                  while (strlen(szProteinName) > 0
+                     && (szProteinName[strlen(szProteinName) - 1] == '\n'
+                        || szProteinName[strlen(szProteinName) - 1] == '\r'))
+                  {
+                     szProteinName[strlen(szProteinName) - 1] = '\0';
+                  }
+                  vProteinDecoys.push_back(szProteinName);
+                  iPrintDuplicateProteinCt++;
+               }
+            }
+         }
+
+         // Build the protein string from targets and decoys
+         bool bPrintDelim = false;
+         for (auto itProt = vProteinTargets.begin(); itProt != vProteinTargets.end(); ++itProt)
+         {
+            if (bPrintDelim)
+               eachStrReturnProtein += " ; ";
+            else
+               bPrintDelim = true;
+
+            string sTmp = *itProt;
+            std::replace(sTmp.begin(), sTmp.end(), ';', ',');
+            eachStrReturnProtein += sTmp;
+         }
+
+         for (auto itProt = vProteinDecoys.begin(); itProt != vProteinDecoys.end(); ++itProt)
+         {
+            if (bPrintDelim)
+               eachStrReturnProtein += " ; ";
+            else
+               bPrintDelim = true;
+
+            string sTmp;
+            if ((*itProt).starts_with(g_staticParams.szDecoyPrefix))
+               sTmp = *itProt;
             else
             {
-               // Non-indexed (FASTA) path
-               int iPrintDuplicateProteinCt = 0;
+               sTmp = g_staticParams.szDecoyPrefix;
+               sTmp += *itProt;
+            }
 
-               if (pOutput[iWhichResult].pWhichProtein.size() > 0)
+            std::replace(sTmp.begin(), sTmp.end(), ';', ',');
+            eachStrReturnProtein += sTmp;
+         }
+
+         score.xCorr = pOutput[iWhichResult].fXcorr;
+         score.dCn = pOutput[iWhichResult].fDeltaCn;
+         score.dSp = pOutput[iWhichResult].fScoreSp;
+         score.dExpect = pOutput[iWhichResult].dExpect;
+         score.mass = pOutput[iWhichResult].dPepMass - PROTON_MASS;
+         score.matchedIons = pOutput[iWhichResult].usiMatchedIons;
+         score.totalIons = pOutput[iWhichResult].usiTotalIons;
+         score.dAScorePro = pOutput[iWhichResult].fAScorePro;
+         score.sAScoreProSiteScores = pOutput[iWhichResult].sAScoreProSiteScores;
+
+         int iMinLength = g_staticParams.options.peptideLengthRange.iEnd;
+         for (int x = 0; x < iSize; ++x)
+         {
+            int iLen = (int)strlen(pOutput[x].szPeptide);
+            if (iLen == 0)
+               break;
+            if (iLen < iMinLength)
+               iMinLength = iLen;
+         }
+
+         // Conversion table from b/y ions to the other types (a,c,x,z)
+         const double ionMassesRelative[NUM_ION_SERIES] =
+         {
+            // N term relative
+            -(Carbon_Mono + Oxygen_Mono),                       // a (CO difference from b)
+            0,                                                  // b
+            (Nitrogen_Mono + (3 * Hydrogen_Mono)),              // c (NH3 difference from b)
+
+            // C Term relative
+            (Carbon_Mono + Oxygen_Mono - (2 * Hydrogen_Mono)),  // x (CO-2H difference from y)
+            0,                                                  // y
+            -(Nitrogen_Mono + (2 * Hydrogen_Mono)),             // z (NH2 difference from y)
+            -(Nitrogen_Mono + (3 * Hydrogen_Mono))              // z+1
+         };
+
+         // now deal with calculating b- and y-ions and returning most intense matches
+         double dBion = g_staticParams.precalcMasses.dNtermProton;
+         double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
+
+         if (pQuery->_pResults[iWhichResult].cPrevAA == '-')
+         {
+            dBion += g_staticParams.staticModifications.dAddNterminusProtein;
+         }
+         if (pQuery->_pResults[iWhichResult].cNextAA == '-')
+         {
+            dYion += g_staticParams.staticModifications.dAddCterminusProtein;
+         }
+
+         // mods at peptide length +1 and +2 are for n- and c-terminus
+         if (g_staticParams.variableModParameters.bVarModSearch
+            && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] != 0))
+         {
+            dBion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] - 1].dVarModMass;
+         }
+
+         if (g_staticParams.variableModParameters.bVarModSearch
+            && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] != 0))
+         {
+            dYion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] - 1].dVarModMass;
+         }
+
+         int iTmp;
+         bool bAddNtermFragmentNeutralLoss[VMODS];
+         bool bAddCtermFragmentNeutralLoss[VMODS];
+
+         for (int iMod = 0; iMod < VMODS; ++iMod)
+         {
+            bAddNtermFragmentNeutralLoss[iMod] = false;
+            bAddCtermFragmentNeutralLoss[iMod] = false;
+         }
+
+         // Generate pdAAforward for pQuery->_pResults[iWhichResult].szPeptide.
+         for (int i = 0; i < pQuery->_pResults[iWhichResult].usiLenPeptide - 1; ++i)
+         {
+            int iPos = pQuery->_pResults[iWhichResult].usiLenPeptide - i - 1;
+
+            dBion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[i]];
+            dYion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[iPos]];
+
+            if (g_staticParams.variableModParameters.bVarModSearch)
+            {
+               if (pQuery->_pResults[iWhichResult].piVarModSites[i] != 0)
+                  dBion += pQuery->_pResults[iWhichResult].pdVarModSites[i];
+
+               if (pQuery->_pResults[iWhichResult].piVarModSites[iPos] != 0)
+                  dYion += pQuery->_pResults[iWhichResult].pdVarModSites[iPos];
+            }
+
+            for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
+            {
+               // calculate every ion series the user specified
+               for (int ionSeries = 0; ionSeries < NUM_ION_SERIES; ++ionSeries)
                {
-                  for (auto itProt = pOutput[iWhichResult].pWhichProtein.begin(); itProt != pOutput[iWhichResult].pWhichProtein.end(); ++itProt)
+                  // skip ion series that are not enabled.
+                  if (!g_staticParams.ionInformation.iIonVal[ionSeries])
                   {
-                     comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
-                     if (fgets(szProteinName, 511, fp) == NULL)
-                     {
-                        // error
-                     }
-                     szProteinName[500] = '\0';
-                     while (strlen(szProteinName) > 0
-                        && (szProteinName[strlen(szProteinName) - 1] == '\n'
-                           || szProteinName[strlen(szProteinName) - 1] == '\r'))
-                     {
-                        szProteinName[strlen(szProteinName) - 1] = '\0';
-                     }
-                     vProteinTargets.push_back(szProteinName);
-                     iPrintDuplicateProteinCt++;
-                     if (iPrintDuplicateProteinCt > g_staticParams.options.iMaxDuplicateProteins)
-                        break;
+                     continue;
                   }
-               }
 
-               if (pOutput[iWhichResult].pWhichDecoyProtein.size() > 0)
-               {
-                  for (auto itProt = pOutput[iWhichResult].pWhichDecoyProtein.begin(); itProt != pOutput[iWhichResult].pWhichDecoyProtein.end(); ++itProt)
+                  bool isNTerm = (ionSeries <= ION_SERIES_C);
+
+                  // get the fragment mass if it is n- or c-terminus
+                  double mass = (isNTerm) ? dBion : dYion;
+                  int fragNumber = i + 1;
+
+                  // Add any conversion factor from different ion series (e.g. b -> a, or y -> z)
+                  mass += ionMassesRelative[ionSeries];
+
+                  double mz = (mass + (ctCharge - 1) * PROTON_MASS) / ctCharge;
+                  iTmp = BIN(mz);
+                  if (iTmp < g_staticParams.iArraySizeGlobal && pdTmpSpectrum[iTmp] > 0.0)
                   {
-                     if (iPrintDuplicateProteinCt >= g_staticParams.options.iMaxDuplicateProteins)
-                        break;
-                     comet_fseek(fp, (*itProt).lWhichProtein, SEEK_SET);
-                     if (fgets(szProteinName, 511, fp) == NULL)
-                     {
-                        // error
-                     }
-                     szProteinName[500] = '\0';
-                     while (strlen(szProteinName) > 0
-                        && (szProteinName[strlen(szProteinName) - 1] == '\n'
-                           || szProteinName[strlen(szProteinName) - 1] == '\r'))
-                     {
-                        szProteinName[strlen(szProteinName) - 1] = '\0';
-                     }
-                     vProteinDecoys.push_back(szProteinName);
-                     iPrintDuplicateProteinCt++;
+                     Fragment frag;
+                     frag.intensity = pdTmpSpectrum[iTmp];
+                     frag.mass = mass;
+                     frag.type = ionSeries;
+                     frag.number = fragNumber;
+                     frag.charge = ctCharge;
+                     frag.neutralLoss = false;
+                     frag.neutralLossMass = 0.0;
+                     eachMatchedFragments.push_back(frag);
                   }
-               }
-            }
 
-            // Build the protein string from targets and decoys
-            bool bPrintDelim = false;
-            for (auto itProt = vProteinTargets.begin(); itProt != vProteinTargets.end(); ++itProt)
-            {
-               if (bPrintDelim)
-                  eachStrReturnProtein += " ; ";
-               else
-                  bPrintDelim = true;
-
-               string sTmp = *itProt;
-               std::replace(sTmp.begin(), sTmp.end(), ';', ',');
-               eachStrReturnProtein += sTmp;
-            }
-
-            for (auto itProt = vProteinDecoys.begin(); itProt != vProteinDecoys.end(); ++itProt)
-            {
-               if (bPrintDelim)
-                  eachStrReturnProtein += " ; ";
-               else
-                  bPrintDelim = true;
-
-               string sTmp;
-               if ((*itProt).starts_with(g_staticParams.szDecoyPrefix))
-                  sTmp = *itProt;
-               else
-               {
-                  sTmp = g_staticParams.szDecoyPrefix;
-                  sTmp += *itProt;
-               }
-
-               std::replace(sTmp.begin(), sTmp.end(), ';', ',');
-               eachStrReturnProtein += sTmp;
-            }
-
-            score.xCorr = pOutput[iWhichResult].fXcorr;
-            score.dCn = pOutput[iWhichResult].fDeltaCn;
-            score.dSp = pOutput[iWhichResult].fScoreSp;
-            score.dExpect = pOutput[iWhichResult].dExpect;
-            score.mass = pOutput[iWhichResult].dPepMass - PROTON_MASS;
-            score.matchedIons = pOutput[iWhichResult].usiMatchedIons;
-            score.totalIons = pOutput[iWhichResult].usiTotalIons;
-            score.dAScorePro = pOutput[iWhichResult].fAScorePro;
-            score.sAScoreProSiteScores = pOutput[iWhichResult].sAScoreProSiteScores;
-
-            int iMinLength = g_staticParams.options.peptideLengthRange.iEnd;
-            for (int x = 0; x < iSize; ++x)
-            {
-               int iLen = (int)strlen(pOutput[x].szPeptide);
-               if (iLen == 0)
-                  break;
-               if (iLen < iMinLength)
-                  iMinLength = iLen;
-            }
-
-            // Conversion table from b/y ions to the other types (a,c,x,z)
-            const double ionMassesRelative[NUM_ION_SERIES] =
-            {
-               // N term relative
-               -(Carbon_Mono + Oxygen_Mono),                       // a (CO difference from b)
-               0,                                                  // b
-               (Nitrogen_Mono + (3 * Hydrogen_Mono)),              // c (NH3 difference from b)
-
-               // C Term relative
-               (Carbon_Mono + Oxygen_Mono - (2 * Hydrogen_Mono)),  // x (CO-2H difference from y)
-               0,                                                  // y
-               -(Nitrogen_Mono + (2 * Hydrogen_Mono)),             // z (NH2 difference from y)
-               -(Nitrogen_Mono + (3 * Hydrogen_Mono))              // z+1
-            };
-
-            // now deal with calculating b- and y-ions and returning most intense matches
-            double dBion = g_staticParams.precalcMasses.dNtermProton;
-            double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
-
-            if (pQuery->_pResults[iWhichResult].cPrevAA == '-')
-            {
-               dBion += g_staticParams.staticModifications.dAddNterminusProtein;
-            }
-            if (pQuery->_pResults[iWhichResult].cNextAA == '-')
-            {
-               dYion += g_staticParams.staticModifications.dAddCterminusProtein;
-            }
-
-            // mods at peptide length +1 and +2 are for n- and c-terminus
-            if (g_staticParams.variableModParameters.bVarModSearch
-               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] != 0))
-            {
-               dBion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide] - 1].dVarModMass;
-            }
-
-            if (g_staticParams.variableModParameters.bVarModSearch
-               && (pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] != 0))
-            {
-               dYion += g_staticParams.variableModParameters.varModList[pQuery->_pResults[iWhichResult].piVarModSites[pQuery->_pResults[iWhichResult].usiLenPeptide + 1] - 1].dVarModMass;
-            }
-
-            int iTmp;
-            bool bAddNtermFragmentNeutralLoss[VMODS];
-            bool bAddCtermFragmentNeutralLoss[VMODS];
-
-            for (int iMod = 0; iMod < VMODS; ++iMod)
-            {
-               bAddNtermFragmentNeutralLoss[iMod] = false;
-               bAddCtermFragmentNeutralLoss[iMod] = false;
-            }
-
-            // Generate pdAAforward for pQuery->_pResults[iWhichResult].szPeptide.
-            for (int i = 0; i < pQuery->_pResults[iWhichResult].usiLenPeptide - 1; ++i)
-            {
-               int iPos = pQuery->_pResults[iWhichResult].usiLenPeptide - i - 1;
-
-               dBion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[i]];
-               dYion += g_staticParams.massUtility.pdAAMassFragment[(int)pQuery->_pResults[iWhichResult].szPeptide[iPos]];
-
-               if (g_staticParams.variableModParameters.bVarModSearch)
-               {
-                  if (pQuery->_pResults[iWhichResult].piVarModSites[i] != 0)
-                     dBion += pQuery->_pResults[iWhichResult].pdVarModSites[i];
-
-                  if (pQuery->_pResults[iWhichResult].piVarModSites[iPos] != 0)
-                     dYion += pQuery->_pResults[iWhichResult].pdVarModSites[iPos];
-               }
-
-               for (int ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
-               {
-                  // calculate every ion series the user specified
-                  for (int ionSeries = 0; ionSeries < NUM_ION_SERIES; ++ionSeries)
+                  if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
                   {
-                     // skip ion series that are not enabled.
-                     if (!g_staticParams.ionInformation.iIonVal[ionSeries])
+                     for (int iMod = 0; iMod < VMODS; ++iMod)
                      {
-                        continue;
-                     }
-
-                     bool isNTerm = (ionSeries <= ION_SERIES_C);
-
-                     // get the fragment mass if it is n- or c-terminus
-                     double mass = (isNTerm) ? dBion : dYion;
-                     int fragNumber = i + 1;
-
-                     // Add any conversion factor from different ion series (e.g. b -> a, or y -> z)
-                     mass += ionMassesRelative[ionSeries];
-
-                     double mz = (mass + (ctCharge - 1) * PROTON_MASS) / ctCharge;
-                     iTmp = BIN(mz);
-                     if (iTmp < g_staticParams.iArraySizeGlobal && pdTmpSpectrum[iTmp] > 0.0)
-                     {
-                        Fragment frag;
-                        frag.intensity = pdTmpSpectrum[iTmp];
-                        frag.mass = mass;
-                        frag.type = ionSeries;
-                        frag.number = fragNumber;
-                        frag.charge = ctCharge;
-                        frag.neutralLoss = false;
-                        frag.neutralLossMass = 0.0;
-                        eachMatchedFragments.push_back(frag);
-                     }
-
-                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
-                     {
-                        for (int iMod = 0; iMod < VMODS; ++iMod)
+                        for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
                         {
-                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
+                           double dNLmass;
+
+                           if (iWhichNL == 0)
+                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
+                           else
+                              dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
+
+                           if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
                            {
-                              double dNLmass;
+                              continue;
+                           }
 
-                              if (iWhichNL == 0)
-                                 dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss;
-                              else
-                                 dNLmass = g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss2;
+                           if (isNTerm)
+                           {
+                              if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[i] == iMod + 1)
+                              {
+                                 bAddNtermFragmentNeutralLoss[iMod] = true;
+                              }
+                           }
+                           else
+                           {
+                              if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[iPos] == iMod + 1)
+                              {
+                                 bAddCtermFragmentNeutralLoss[iMod] = true;
+                              }
+                           }
 
-                              if (dNLmass == 0.0 || g_staticParams.variableModParameters.varModList[iMod].dVarModMass == 0.0)
-                              {
-                                 continue;
-                              }
+                           if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
+                              || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
+                           {
+                              continue;
+                           }
 
-                              if (isNTerm)
-                              {
-                                 if (!bAddNtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[i] == iMod + 1)
-                                 {
-                                    bAddNtermFragmentNeutralLoss[iMod] = true;
-                                 }
-                              }
-                              else
-                              {
-                                 if (!bAddCtermFragmentNeutralLoss[iMod] && pOutput[iWhichResult].piVarModSites[iPos] == iMod + 1)
-                                 {
-                                    bAddCtermFragmentNeutralLoss[iMod] = true;
-                                 }
-                              }
-
-                              if ((isNTerm && !bAddNtermFragmentNeutralLoss[iMod])
-                                 || (!isNTerm && !bAddCtermFragmentNeutralLoss[iMod]))
-                              {
-                                 continue;
-                              }
-
-                              double dNLfragMz = mz - (dNLmass / ctCharge);
-                              iTmp = BIN(dNLfragMz);
-                              if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
-                              {
-                                 Fragment frag;
-                                 frag.intensity = pdTmpSpectrum[iTmp];
-                                 frag.mass = mass - dNLmass;
-                                 frag.type = ionSeries;
-                                 frag.number = fragNumber;
-                                 frag.charge = ctCharge;
-                                 frag.neutralLoss = true;
-                                 frag.neutralLossMass = dNLmass;
-                                 eachMatchedFragments.push_back(frag);
-                              }
+                           double dNLfragMz = mz - (dNLmass / ctCharge);
+                           iTmp = BIN(dNLfragMz);
+                           if (iTmp < g_staticParams.iArraySizeGlobal && iTmp >= 0 && pdTmpSpectrum[iTmp] > 0.0)
+                           {
+                              Fragment frag;
+                              frag.intensity = pdTmpSpectrum[iTmp];
+                              frag.mass = mass - dNLmass;
+                              frag.type = ionSeries;
+                              frag.number = fragNumber;
+                              frag.charge = ctCharge;
+                              frag.neutralLoss = true;
+                              frag.neutralLossMass = dNLmass;
+                              eachMatchedFragments.push_back(frag);
                            }
                         }
                      }
@@ -3849,61 +3999,59 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
                }
             }
          }
-         else
-         {
-            eachStrReturnPeptide = "";
-            eachStrReturnProtein = "";
-            score.xCorr = -999;
-            score.dSp = 0;
-            score.dExpect = 999;
-            score.mass = 0;
-            score.matchedIons = 0;
-            score.totalIons = 0;
-            score.dAScorePro = 0;
-            score.dCn = 0;
-            score.sAScoreProSiteScores.clear();
-         }
-
-         if (false)  // set to true to enable debug mass check
-         {
-            // Compare peptide against input mz/charge mass
-            double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
-            for (int i = 0; i < pQuery->_pResults[0].usiLenPeptide; ++i)
-            {
-               dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[pQuery->_pResults[0].szPeptide[i]];
-               if (g_staticParams.variableModParameters.bVarModSearch)
-                  if (pQuery->_pResults[0].piVarModSites[i] != 0)
-                     dCalcPepMass += pQuery->_pResults[0].pdVarModSites[i];
-            }
-            if (g_staticParams.variableModParameters.bVarModSearch)
-            {
-               // n-term mod
-               if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0)
-                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide];
-               // c-term mod
-               if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
-                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide + 1];
-            }
-         }
-
-         strReturnPeptide.push_back(eachStrReturnPeptide);
-         strReturnProtein.push_back(eachStrReturnProtein);
-         matchedFragments.push_back(eachMatchedFragments);
-         scores.push_back(score);
+      }
+      else
+      {
+         eachStrReturnPeptide = "";
+         eachStrReturnProtein = "";
+         score.xCorr = -999;
+         score.dSp = 0;
+         score.dExpect = 999;
+         score.mass = 0;
+         score.matchedIons = 0;
+         score.totalIons = 0;
+         score.dAScorePro = 0;
+         score.dCn = 0;
+         score.sAScoreProSiteScores.clear();
       }
 
-      if (fp != NULL)
-         fclose(fp);
+      if (false)  // set to true to enable debug mass check
+      {
+         // Compare peptide against input mz/charge mass
+         double dCalcPepMass = g_staticParams.precalcMasses.dNtermProton + g_staticParams.precalcMasses.dCtermOH2Proton - PROTON_MASS;
+         for (int i = 0; i < pQuery->_pResults[0].usiLenPeptide; ++i)
+         {
+            dCalcPepMass += g_staticParams.massUtility.pdAAMassParent[pQuery->_pResults[0].szPeptide[i]];
+            if (g_staticParams.variableModParameters.bVarModSearch)
+               if (pQuery->_pResults[0].piVarModSites[i] != 0)
+                  dCalcPepMass += pQuery->_pResults[0].pdVarModSites[i];
+         }
+         if (g_staticParams.variableModParameters.bVarModSearch)
+         {
+            // n-term mod
+            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide] != 0)
+               dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide];
+            // c-term mod
+            if (pQuery->_pResults[0].piVarModSites[pQuery->_pResults[0].usiLenPeptide + 1] != 0)
+               dCalcPepMass += pQuery->_pResults[0].pdVarModSites[pQuery->_pResults[0].usiLenPeptide + 1];
+         }
+      }
+
+      strReturnPeptide.push_back(eachStrReturnPeptide);
+      strReturnProtein.push_back(eachStrReturnProtein);
+      matchedFragments.push_back(eachMatchedFragments);
+      scores.push_back(score);
    }
 
 cleanup_results:
 
-   // Clean up the thread-local Query* — its destructor frees spectral memory
+   // Clean up the thread-local Query* - its destructor frees spectral memory
    // (pfFastXcorrData, pfFastXcorrDataNL, etc.)
    // The _pResults and _pDecoys arrays were allocated by PreprocessSingleSpectrumCore.
-   delete pQuery;
-   pQuery = nullptr;
+   if (fp != NULL)
+      fclose(fp);
 
+   delete pQuery;
    delete[] pdTmpSpectrum;
 
    return bSucceeded;
@@ -3924,7 +4072,7 @@ bool CometSearchManager::DoMS1SearchMultiResults(const double dMaxMS1RTDiff,
    // InitializeSingleSpectrumMS1Search() must be called (and return) before
    // any thread calls DoMS1SearchMultiResults(). The C# Task.Run() scheduling
    // provides a happens-before guarantee for all writes made during init.
-   if (!singleSearchMS1InitializationComplete)
+   if (!singleSearchMS1InitializationComplete.load(std::memory_order_acquire))
    {
       string strErrorMsg = " Error - DoMS1SearchMultiResults() called before InitializeSingleSpectrumMS1Search() completed.\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
@@ -3937,29 +4085,26 @@ bool CometSearchManager::DoMS1SearchMultiResults(const double dMaxMS1RTDiff,
    if (iNumPeaks == 0)
       return false;
 
-   // Task 2.1: Create thread-local QueryMS1* — no global state touched.
+   // Task 2.1: Create thread-local QueryMS1* - no global state touched.
    QueryMS1* pQueryMS1 = CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(pdMass, pdInten, iNumPeaks);
 
    if (pQueryMS1 == nullptr)
       return false;
 
-   // Task 2.2: Run search using thread-local overload — reads only g_vSpecLib (immutable).
+   // Task 2.2: Run search using thread-local overload - reads only g_vSpecLib (immutable).
    vector<CometScoresMS1> localScores;
    bool bSucceeded = CometSearch::RunMS1Search(pQueryMS1, topN, dQueryRT, dMaxMS1RTDiff, dMaxSpecLibRT, dMaxQueryRT, localScores);
 
    if (bSucceeded && !localScores.empty())
    {
-      // Pass best RT match to regression aligner.
-      // pMS1Aligner is per-CometSearchManager instance state, but the C# code
-      // currently calls DoMS1SearchMultiResults from multiple threads.
-      // For now, protect with the existing g_pvQueryMutex since the aligner
-      // is lightweight and this serialization only affects the RT regression,
-      // not the scoring.
+      // Pass best RT match to the global regression aligner.
+      // pMS1Aligner accumulates RT history across all scans in the run, so it
+      // must be shared. Protect it with its dedicated mutex.
       double dMatchedSpecLibRT = localScores[0].fRTime;
 
-      Threading::LockMutex(g_pvQueryMutex);
+      Threading::LockMutex(g_ms1AlignerMutex);
       double dLinearRegressionRT = pMS1Aligner.processRetentionMatch(dQueryRT, dMatchedSpecLibRT);
-      Threading::UnlockMutex(g_pvQueryMutex);
+      Threading::UnlockMutex(g_ms1AlignerMutex);
 
       // Overwrite the RT with the regression-adjusted value
       localScores[0].fRTime = (float)dLinearRegressionRT;
@@ -3968,6 +4113,11 @@ bool CometSearchManager::DoMS1SearchMultiResults(const double dMaxMS1RTDiff,
    }
 
    // Task 2.3: Clean up thread-local QueryMS1*
+   if (pQueryMS1->pfFastXcorrData != nullptr)
+   {
+      delete[] pQueryMS1->pfFastXcorrData;
+      pQueryMS1->pfFastXcorrData = nullptr;
+   }
    delete pQueryMS1;
    pQueryMS1 = nullptr;
 

--- a/CometSearch/CometSearchManager.h
+++ b/CometSearch/CometSearchManager.h
@@ -21,6 +21,7 @@
 #include "CometInterfaces.h"
 #include "githubsha.h"           // blank hash that github workflows should populate
 
+#include <atomic>
 #include <errno.h>
 #include <string.h>
 #include <cstdio>
@@ -111,10 +112,9 @@ public:
 private:
    bool InitializeStaticParams();
    bool ReadProteinVarModFilterFile();
-   bool singleSearchInitializationComplete;
-   bool singleSearchMS1InitializationComplete;
+   std::atomic<bool> singleSearchInitializationComplete;
+   std::atomic<bool> singleSearchMS1InitializationComplete;
    bool staticParamsInitializationComplete;
-   int singleSearchThreadCount;
    std::map<std::string, CometParam*> _mapStaticParams;
 };
 

--- a/CometSearch/CometSearchManager.h
+++ b/CometSearch/CometSearchManager.h
@@ -56,7 +56,7 @@ public:
    virtual bool DoSearch();
    virtual bool InitializeSingleSpectrumSearch();
    virtual void FinalizeSingleSpectrumSearch();
-   virtual bool InitializeSingleSpectrumMS1Search();
+   virtual bool InitializeSingleSpectrumMS1Search(const double dMaxQueryRT);
    virtual void FinalizeSingleSpectrumMS1Search();
    virtual bool DoSingleSpectrumSearchMultiResults(const int topN,
                                                    int iPrecursorCharge,

--- a/CometSearch/CometSpecLib.cpp
+++ b/CometSearch/CometSpecLib.cpp
@@ -545,9 +545,10 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
       int iLen = (int)strlen(pszFileName);
       if (iLen > 4 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 4, ".raw"))
          iSpecLibInputType = InputType_RAW;
-      else if ((iLen > 6 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 6, ".mzXML"))
-         || (iLen > 5 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 5, ".mzML")))
+      else if (iLen > 6 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 6, ".mzXML"))
          iSpecLibInputType = InputType_MZXML;
+      else if (iLen > 5 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 5, ".mzML"))
+         iSpecLibInputType = InputType_MZML;
    }
 
    // Get the thread pool of threads that will preprocess the data.
@@ -573,7 +574,10 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
    // MS1 path LoadSpecLibMS1Raw is the first (and only) caller.
    if (!g_bCometPreprocessMemoryAllocated)
    {
-      if (!CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads))
+      // Note that g_staticParams.options.iNumThreads will be >= 1 at this call. It's not possible
+      // for g_staticParams.options.iNumThreads to be 0 or negative here as that is checked in
+      // InitializeStaticParams() and its value is set to be >= 1.
+      if (g_staticParams.options.iNumThreads <= 0 || !CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads))
       {
          string strErrorMsg = " Error - CometPreprocess::AllocateMemory failed in LoadSpecLibMS1Raw.\n";
          g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);

--- a/CometSearch/CometSpecLib.cpp
+++ b/CometSearch/CometSpecLib.cpp
@@ -341,6 +341,7 @@ bool CometSpecLib::ReadSpecLibRaw(string strSpecLibFile)
 
 */
 
+
 }
 
 
@@ -479,6 +480,12 @@ bool CometSpecLib::ReadSpecLibMSP(string strSpecLibFile)
    return true;
 }
 
+// NOTE (Phase 3 / Task 3.1 audit): After LoadSpecLibMS1Raw() returns and
+// g_bSpecLibRead is set to true, g_vSpecLib and all SpecLibStruct members
+// (pfUnitVector, fRTime, fScaleMaxInten, uiArraySizeMS1) are READ-ONLY.
+// No code path modifies g_vSpecLib during DoMS1SearchMultiResults().
+// This invariant is required for concurrent thread safety.
+
 // Loads all MS1 spectra from input file into g_vSpecLib.
 // Don't bother storing vSpecLibPeaks
 bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
@@ -522,10 +529,25 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
 
    if (iFileLastScan <= 0)
    {
-      string strErrorMsg = " Error - read iFileLastScan as " + std::to_string (iFileLastScan) + "%d.\n";
+      string strErrorMsg = " Error - read iFileLastScan as " + std::to_string(iFileLastScan) + ".\n";
       g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
       logerr(strErrorMsg);
       return false;
+   }
+
+   // Determine the input type of the spec lib file for the IsValidInputType check below.
+   // In the batch search path, g_staticParams.inputFile.iInputType is set by UpdateInputFile(),
+   // but in the single-spectrum MS1 path, inputFile is never configured for the spec lib file.
+   // We need to determine the type directly from the file extension.
+   int iSpecLibInputType = InputType_UNKNOWN;
+   {
+      const char* pszFileName = g_staticParams.speclibInfo.strSpecLibFile.c_str();
+      int iLen = (int)strlen(pszFileName);
+      if (iLen > 4 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 4, ".raw"))
+         iSpecLibInputType = InputType_RAW;
+      else if ((iLen > 6 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 6, ".mzXML"))
+         || (iLen > 5 && !STRCMP_IGNORE_CASE(pszFileName + iLen - 5, ".mzML")))
+         iSpecLibInputType = InputType_MZXML;
    }
 
    // Get the thread pool of threads that will preprocess the data.
@@ -545,6 +567,21 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
 
    auto tStartTime = chrono::steady_clock::now();
 
+   // Ensure the shared preprocessing memory pool is allocated before
+   // dispatching any PreprocessThreadProcMS1 jobs.  In the batch search
+   // path this is done by CometSearchManager, but in the single-spectrum
+   // MS1 path LoadSpecLibMS1Raw is the first (and only) caller.
+   if (!g_bCometPreprocessMemoryAllocated)
+   {
+      if (!CometPreprocess::AllocateMemory(g_staticParams.options.iNumThreads))
+      {
+         string strErrorMsg = " Error - CometPreprocess::AllocateMemory failed in LoadSpecLibMS1Raw.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
+   }
+
    // Load all input spectra.
    while (true)
    {
@@ -558,9 +595,6 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
       {
          mstReader.readFile(NULL, mstSpectrum);
       }
-
-//      if (iFileLastScan == -1)
-//         iFileLastScan = mstReader.getLastScan();
 
       if ((iFileLastScan != -1) && (iFileLastScan < iFirstScan))
       {
@@ -597,12 +631,18 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
 
             PreprocessThreadData* pPreprocessThreadDataMS1 = new PreprocessThreadData(mstSpectrum, iAnalysisType, iFileLastScan);
 
+            // Gate: wait for a free thread before queuing more work.
+            // Without this, jobs queue faster than pool slots are freed,
+            // and the memory-pool busy-wait inside PreprocessThreadProcMS1
+            // can deadlock or overrun.
+            pLoadSpecThreadPool->wait_for_available_thread();
+
             pLoadSpecThreadPool->doJob(std::bind(CometPreprocess::PreprocessThreadProcMS1, pPreprocessThreadDataMS1, pLoadSpecThreadPool, dMaxQueryRT, *dMaxSpecLibRT));
          }
 
          iTotalScans++;
       }
-      else if (CometPreprocess::IsValidInputType(g_staticParams.inputFile.iInputType))
+      else if (CometPreprocess::IsValidInputType(iSpecLibInputType))
       {
          bDoneProcessingAllSpectra = true;
          break;
@@ -623,12 +663,12 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
       iNumSpectraLoaded = (int)g_vSpecLib.size();
 
       if (CometPreprocess::CheckExit(iAnalysisType,
-                                     iScanNumber,
-                                     iTotalScans,
-                                     iFileLastScan,
-                                     mstReader.getLastScan(),
-                                     iNumSpectraLoaded,
-                                     1))
+         iScanNumber,
+         iTotalScans,
+         iFileLastScan,
+         mstReader.getLastScan(),
+         iNumSpectraLoaded,
+         1))
       {
          Threading::UnlockMutex(g_pvQueryMutex);
          break;
@@ -647,7 +687,7 @@ bool CometSpecLib::LoadSpecLibMS1Raw(ThreadPool* tp,
    cout << "100% (" << CometMassSpecUtils::ElapsedTime(tStartTime) << ")" << endl;
 
    g_bSpecLibRead = true;
-//   mstReader.closeFile();   //FIX when does this get closed?
+   //   mstReader.closeFile();   //FIX when does this get closed?
 
    printf("\n"); fflush(stdout);
 

--- a/CometSearch/CometWriteMzIdentML.cpp
+++ b/CometSearch/CometWriteMzIdentML.cpp
@@ -299,7 +299,7 @@ bool CometWriteMzIdentML::ParseTmpFile(FILE *fpout,
    bool bPrintSequences = false;
    if (g_staticParams.options.iOutputMzIdentMLFile == 2) // print sequences in DBSequence
    {
-      if (g_staticParams.iIndexDb)
+      if (g_staticParams.iDbType != DbType::FASTA_DB)
          bPrintSequences = false;
       else
          bPrintSequences = true;
@@ -1461,7 +1461,7 @@ void CometWriteMzIdentML::PrintTmpPSM(int iWhichQuery,
          std::vector<ProteinEntryStruct>::iterator it;
          if (pOutput[iWhichResult].pWhichProtein.size() > 0)
          {
-            if (g_staticParams.iIndexDb)
+            if (g_staticParams.iDbType != DbType::FASTA_DB)
             {
                comet_fileoffset_t lEntry = pOutput[iWhichResult].lProteinFilePosition;
 

--- a/CometSearch/Common.h
+++ b/CometSearch/Common.h
@@ -66,7 +66,7 @@ using namespace std;
 #include <iostream>
 #include <functional>
 
-#define comet_version   "2026.01 rev. 1"
+#define comet_version   "2026.02 rev. 0"
 #define copyright "(c) University of Washington"
 extern string g_sCometVersion;   // version string including git hash
 

--- a/CometSearch/Makefile
+++ b/CometSearch/Makefile
@@ -41,7 +41,7 @@ $(OBJDIR)/%.o: %.cpp %.h Common.h CometDataInternal.h BS_thread_pool.hpp | $(OBJ
 	${CXX} ${CXXFLAGS} $< -c -o $@
 
 # Add specific dependency rules for object files that require multiple headers
-$(OBJDIR)/CometSearch.o: CometSearch.cpp CometDataInternal.h CometFragmentIndex.h CometMassSpecUtils.h CometModificationsPermuter.h CometPeptideIndex.h \
+$(OBJDIR)/CometSearch.o: CometSearch.cpp CometDataInternal.h CometFragmentIndex.h CometFragmentIndexReader.h CometMassSpecUtils.h CometModificationsPermuter.h CometPeptideIndex.h \
                CometPostAnalysis.h CometSearch.h CometSearchManager.h CometSpecLib.h CometStatus.h Common.h ThreadPool.h BS_thread_pool.hpp | $(OBJDIR)
 	${CXX} ${CXXFLAGS} ${DEPFLAGS} CometSearch.cpp -c -o $@
 

--- a/CometSearch/ThreadPool.h
+++ b/CometSearch/ThreadPool.h
@@ -34,6 +34,12 @@
 class ThreadPool
 {
 public:
+   // Callback type for reporting task failures to the application error system.
+   // Set via setErrorHandler() so that doJob() can propagate exceptions without
+   // needing to #include CometStatus.h (which would create a circular include
+   // through Common.h -> ThreadPool.h -> CometStatus.h -> Common.h).
+   using ErrorHandler = std::function<void(const std::string&)>;
+
    ThreadPool() : pool_(nullptr), thread_count_(0)
    {
    }
@@ -49,45 +55,37 @@ public:
    ThreadPool(ThreadPool&&) = delete;
    ThreadPool& operator=(ThreadPool&&) = delete;
 
-   /// @brief Initialize the thread pool with the specified number of threads
-   /// @param threads Thread count: <0 = (CPU threads + threads), 0 = all CPU threads, >0 = exact count
+   /// @brief Register a callback invoked when a task throws an exception.
+   /// Typically set once after construction:
+   ///   tp->setErrorHandler([](const std::string& msg) {
+   ///       g_cometStatus.SetStatus(CometResult_Failed, msg);
+   ///   });
+   void setErrorHandler(ErrorHandler handler)
+   {
+      errorHandler_ = std::move(handler);
+   }
+
+   /// @brief Initialize the thread pool with the specified number of threads.
+   /// @param threads Must be >= 1. If <= 0, g_staticParams.options.iNumThreads was not set
+   ///        correctly by InitializeStaticParams(); throws std::invalid_argument.
    void fillPool(int threads)
    {
-      // Determine actual thread count based on input:
-      // - threads < 0: Use (CPU threads + threads). E.g., -1 on 8-core = 7 threads
-      // - threads == 0: Use all available CPU threads
-      // - threads > 0: Use exactly that many threads
-      int pool_threads = threads;
-
       if (threads <= 0)
       {
-         // Get hardware thread count
-         int hardware_threads = std::thread::hardware_concurrency();
-         if (hardware_threads == 0)
-         {
-            hardware_threads = 1; // Fallback if detection fails
-         }
-
-         if (threads == 0)
-         {
-            // Use all available CPU threads
-            pool_threads = hardware_threads;
-         }
-         else // threads < 0
-         {
-            // Use (CPU threads + threads). E.g., -1 on 8-core = 7 threads
-            pool_threads = hardware_threads + threads;
-
-            // Ensure at least 1 thread
-            if (pool_threads < 1)
-            {
-               pool_threads = 1;
-            }
-         }
+         throw std::invalid_argument(
+            "fillPool() called with invalid thread count " + std::to_string(threads)
+            + ". iNumThreads must be >= 1 after InitializeStaticParams().");
       }
 
-      thread_count_ = static_cast<size_t>(pool_threads);
-      pool_ = std::make_unique<BS::thread_pool<>>(pool_threads);
+      // Guard against calling fillPool when pool is already initialized.
+      // Drain existing pool first to avoid silently dropping in-flight tasks.
+      if (pool_)
+      {
+         drainPool();
+      }
+
+      thread_count_ = static_cast<size_t>(threads);
+      pool_ = std::make_unique<BS::thread_pool<>>(threads);
    }
 
    /// @brief Wait for all currently queued and running tasks to complete
@@ -166,19 +164,29 @@ public:
          throw std::logic_error("ThreadPool::doJob() called before fillPool() - work would be silently dropped");
       }
 
-      // Wrap the task with exception logging to preserve debuggability
-      auto wrapped_func = [func = std::move(func)]() {
+      // Capture the error handler by value so the lambda is self-contained.
+      // If no handler was set, exceptions are still logged to stderr.
+      ErrorHandler handler = errorHandler_;
+
+      auto wrapped_func = [func = std::move(func), handler = std::move(handler)]() {
          try
          {
             func();
          }
          catch (const std::exception& e)
          {
-            std::cerr << " Warning: Exception in thread pool task: " << e.what() << std::endl;
+            std::string strErrorMsg = " Error: Exception in thread pool task: "
+               + std::string(e.what()) + "\n";
+            std::cerr << strErrorMsg;
+            if (handler)
+               handler(strErrorMsg);
          }
          catch (...)
          {
-            std::cerr << " Warning: Unknown exception in thread pool task" << std::endl;
+            std::string strErrorMsg = " Error: Unknown exception in thread pool task\n";
+            std::cerr << strErrorMsg;
+            if (handler)
+               handler(strErrorMsg);
          }
          };
 
@@ -255,6 +263,7 @@ public:
 private:
    std::unique_ptr<BS::thread_pool<>> pool_;
    size_t thread_count_;  // Changed from int to size_t for consistency
+   ErrorHandler errorHandler_;  // Optional callback for propagating task errors
 };
 
 #endif // _THREAD_POOL_H_

--- a/CometSearch/ThreadPool.h
+++ b/CometSearch/ThreadPool.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <thread>
 #include <iostream>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/CometWrapper/CometDataWrapper.h
+++ b/CometWrapper/CometDataWrapper.h
@@ -88,10 +88,10 @@ namespace CometWrapper {
             }
         }
         
-        int get_dStart() {return (int)_pDoubleRange->dStart;}
+        double get_dStart() {return _pDoubleRange->dStart;}
         void set_dStart(double dStart) {_pDoubleRange->dStart = dStart;}
 
-        int get_dEnd() {return (int)_pDoubleRange->dEnd;}
+        double get_dEnd() {return _pDoubleRange->dEnd;}
         void set_dEnd(double dEnd) {_pDoubleRange->dEnd = dEnd;}
 
         DoubleRange* get_DoubleRangePtr() {return _pDoubleRange;}
@@ -366,7 +366,7 @@ namespace CometWrapper {
             double get() { return pScores->dExpect; }
         }
 
-        property double dAScoreScore
+        property double dAScorePro
         {
            double get() { return pScores->dAScorePro; }
         }

--- a/CometWrapper/CometWrapper.cpp
+++ b/CometWrapper/CometWrapper.cpp
@@ -87,13 +87,13 @@ void CometSearchManagerWrapper::FinalizeSingleSpectrumSearch()
     }
 }
 
-bool CometSearchManagerWrapper::InitializeSingleSpectrumMS1Search()
+bool CometSearchManagerWrapper::InitializeSingleSpectrumMS1Search(double dMaxQueryRT)
 {
    if (!_pSearchMgr)
    {
       return false;
    }
-   return _pSearchMgr->InitializeSingleSpectrumMS1Search();
+   return _pSearchMgr->InitializeSingleSpectrumMS1Search(dMaxQueryRT);
 }
 
 void CometSearchManagerWrapper::FinalizeSingleSpectrumMS1Search()

--- a/CometWrapper/CometWrapper.h
+++ b/CometWrapper/CometWrapper.h
@@ -40,7 +40,7 @@ namespace CometWrapper {
         bool DoSearch();
         bool InitializeSingleSpectrumSearch();
         void FinalizeSingleSpectrumSearch();
-        bool InitializeSingleSpectrumMS1Search();
+        bool InitializeSingleSpectrumMS1Search(double dMaxQueryRT);
         void FinalizeSingleSpectrumMS1Search();
         bool DoSingleSpectrumSearchMultiResults(int intValue1,                   // top N results
                                                 int intValue2,                   // precursor charge

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DEPS = CometSearch/CometData.h CometSearch/CometDataInternal.h CometSearch/Comet
 		 CometSearch/CometPostAnalysis.cpp CometSearch/CometSearchManager.cpp CometSearch/CometWritePercolator.cpp CometSearch/Threading.cpp\
 		 CometSearch/CometPreprocess.cpp CometSearch/CometWriteSqt.cpp CometSearch/CombinatoricsUtils.cpp\
 		 CometSearch/CometModificationsPermuter.cpp CometSearch/CometInterfaces.h CometSearch/CometInterfaces.cpp\
-		 CometSearch/CometFragmentIndex.cpp CometSearch/CometFragmentIndex.h\
+		 CometSearch/CometFragmentIndex.cpp CometSearch/CometFragmentIndex.h CometSearch/CometFragmentIndexReader.h\
 		 CometSearch/CometPeptideIndex.cpp CometSearch/CometPeptideIndex.h\
 		 CometSearch/CometSpecLib.cpp CometSearch/CometSpecLib.h\
 		 CometSearch/CometAlignment.cpp CometSearch/CometAlignment.h\

--- a/RealtimeSearch/RealtimeSearch.csproj
+++ b/RealtimeSearch/RealtimeSearch.csproj
@@ -107,6 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="THREADING_PLAN.md" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/RealtimeSearch/RealtimeSearch.csproj
+++ b/RealtimeSearch/RealtimeSearch.csproj
@@ -107,7 +107,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="THREADING_PLAN.md" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/RealtimeSearch/SearchMS1MS2.cs
+++ b/RealtimeSearch/SearchMS1MS2.cs
@@ -63,13 +63,14 @@
          }
 
          // Parse number of threads (default to processor count)
-         int numThreads = Environment.ProcessorCount;
+         int defaultNumThreads = Environment.ProcessorCount;
+         int numThreads = defaultNumThreads;
          if (args.Length >= 4)
          {
             if (!int.TryParse(args[3], out numThreads) || numThreads < 1)
             {
-               Console.WriteLine(" Warning: Invalid num_threads '{0}', using {1} threads", args[3], numThreads);
-               numThreads = Environment.ProcessorCount;
+               Console.WriteLine(" Warning: Invalid num_threads '{0}', using {1} threads", args[3], defaultNumThreads);
+               numThreads = defaultNumThreads;
             }
          }
 
@@ -104,179 +105,123 @@
             {
                try
                {
-                  // Open raw file ONCE
-                  IRawDataPlus rawFile = RawFileReaderAdapter.FileFactory(rawFileName);
-                  if (!rawFile.IsOpen || rawFile.IsError)
+                  // Open raw file ONCE; using ensures Dispose on all paths
+                  using (IRawDataPlus rawFile = RawFileReaderAdapter.FileFactory(rawFileName))
                   {
-                     Console.WriteLine(" Error: unable to access the RAW file using the RawFileReader class.");
-                     return;
-                  }
-
-                  rawFile.SelectInstrument(Device.MS, 1);
-
-                  // Get the first and last scan from the RAW file
-                  int iFirstScan = rawFile.RunHeaderEx.FirstSpectrum;
-                  int iLastScan = rawFile.RunHeaderEx.LastSpectrum;
-
-                  // Get MS1 mass range from first MS1 scan
-                  DoubleRangeWrapper MS1MassRange = null;
-
-                  for (int iScanNumber = iFirstScan; iScanNumber <= iLastScan; ++iScanNumber)
-                  {
-                     var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
-
-                     if (scanFilter.MSOrder == MSOrderType.Ms)
+                     if (!rawFile.IsOpen || rawFile.IsError)
                      {
-                        var stats1 = rawFile.GetScanStatsForScanNumber(iScanNumber);
-                        MS1MassRange = new DoubleRangeWrapper(stats1.LowMass, stats1.HighMass);
-                        break;
+                        Console.WriteLine(" Error: unable to access the RAW file using the RawFileReader class.");
+                        return;
                      }
-                  }
 
-                  if (MS1MassRange != null)
-                  {
-                     string MS1MassRangeString = MS1MassRange.get_dStart() + " " + MS1MassRange.get_dEnd();
-                     globalSearchMgr.SetParam("ms1_mass_range", MS1MassRangeString, MS1MassRange);
-                  }
+                     rawFile.SelectInstrument(Device.MS, 1);
 
-                  // MS1 RT parameters
-                  double dMaxMS1RTDiff = 300.0;    // maximum allowed retention time difference between query and reference, in seconds
-                  double dMaxQueryRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iLastScan);
+                     // Get the first and last scan from the RAW file
+                     int iFirstScan = rawFile.RunHeaderEx.FirstSpectrum;
+                     int iLastScan = rawFile.RunHeaderEx.LastSpectrum;
 
-                  int iPrintEveryScan = 1;
-                  int iMS2TopN = 1; // report up to topN hits per MS/MS query
-                  int iProteinLengthCutoff = 50;
+                     // Get MS1 mass range from first MS1 scan
+                     DoubleRangeWrapper MS1MassRange = null;
 
-                  bool bPerformMS1Search = false;
-                  bool bPerformMS2Search = true;
-
-                  // Thread-safe collections
-                  var scanQueue = new ConcurrentQueue<int>();
-                  var results = new ConcurrentBag<ScanResult>();
-                  var progressLock = new object();
-                  int scansProcessed = 0;
-                  int totalScans = iLastScan - iFirstScan + 1;
-
-                  // Initialize ONCE (before threading)
-                  if (bPerformMS1Search)
-                     globalSearchMgr.InitializeSingleSpectrumMS1Search(dMaxQueryRT);
-
-
-                  Stopwatch watchIndexCreate = new Stopwatch();
-                  watchIndexCreate.Start();
-                  if (bDatabaseSearch && bPerformMS2Search)
-                     globalSearchMgr.InitializeSingleSpectrumSearch();
-                  watchIndexCreate.Stop();
-
-                  // Populate scan queue
-                  for (int i = iFirstScan; i <= iLastScan; ++i)
-                     scanQueue.Enqueue(i);
-
-                  Stopwatch watchGlobal = new Stopwatch();
-                  watchGlobal.Start();
-
-                  // Simplified worker thread function
-                  void ProcessScans(int threadId)
-                  {
-                     Stopwatch watch = new Stopwatch();
-
-                     // Process scans from queue using SHARED resources
-                     while (scanQueue.TryDequeue(out int iScanNumber))
+                     for (int iScanNumber = iFirstScan; iScanNumber <= iLastScan; ++iScanNumber)
                      {
-                        try
+                        var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
+
+                        if (scanFilter.MSOrder == MSOrderType.Ms)
                         {
-                           // Use SHARED raw file reader (thread-safe)
-                           var scanStatistics = rawFile.GetScanStatsForScanNumber(iScanNumber);
-                           double dRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iScanNumber);
-                           var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
+                           var stats1 = rawFile.GetScanStatsForScanNumber(iScanNumber);
+                           MS1MassRange = new DoubleRangeWrapper(stats1.LowMass, stats1.HighMass);
+                           break;
+                        }
+                     }
 
-                           if (scanFilter.MSOrder != MSOrderType.Ms && scanFilter.MSOrder != MSOrderType.Ms2)
+                     if (MS1MassRange != null)
+                     {
+                        string MS1MassRangeString = MS1MassRange.get_dStart() + " " + MS1MassRange.get_dEnd();
+                        globalSearchMgr.SetParam("ms1_mass_range", MS1MassRangeString, MS1MassRange);
+                     }
+
+                     // MS1 RT parameters
+                     double dMaxMS1RTDiff = 300.0;    // maximum allowed retention time difference between query and reference, in seconds
+                     double dMaxQueryRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iLastScan);
+
+                     int iPrintEveryScan = 1;
+                     int iMS2TopN = 1; // report up to topN hits per MS/MS query
+                     int iProteinLengthCutoff = 50;
+
+                     bool bPerformMS1Search = false;
+                     bool bPerformMS2Search = true;
+
+                     // Thread-safe collections
+                     var scanQueue = new ConcurrentQueue<int>();
+                     var results = new ConcurrentBag<ScanResult>();
+                     var progressLock = new object();
+                     int scansProcessed = 0;
+                     int totalScans = iLastScan - iFirstScan + 1;
+
+                     // Initialize ONCE (before threading)
+                     if (bPerformMS1Search)
+                        globalSearchMgr.InitializeSingleSpectrumMS1Search(dMaxQueryRT);
+
+                     Stopwatch watchIndexCreate = new Stopwatch();
+                     watchIndexCreate.Start();
+                     if (bDatabaseSearch && bPerformMS2Search)
+                        globalSearchMgr.InitializeSingleSpectrumSearch();
+                     watchIndexCreate.Stop();
+
+                     // Populate scan queue
+                     for (int i = iFirstScan; i <= iLastScan; ++i)
+                        scanQueue.Enqueue(i);
+
+                     Stopwatch watchGlobal = new Stopwatch();
+                     watchGlobal.Start();
+
+                     // Simplified worker thread function
+                     void ProcessScans(int threadId)
+                     {
+                        Stopwatch watch = new Stopwatch();
+
+                        // Process scans from queue using SHARED resources
+                        while (scanQueue.TryDequeue(out int iScanNumber))
+                        {
+                           try
                            {
-                              // Update progress for non-searchable scans
-                              lock (progressLock)
+                              // Use SHARED raw file reader (thread-safe)
+                              var scanStatistics = rawFile.GetScanStatsForScanNumber(iScanNumber);
+                              double dRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iScanNumber);
+                              var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
+
+                              if (scanFilter.MSOrder != MSOrderType.Ms && scanFilter.MSOrder != MSOrderType.Ms2)
                               {
-                                 scansProcessed++;
-                              }
-                              continue;
-                           }
-
-                           // Get spectral data
-                           double[] pdMass;
-                           double[] pdInten;
-                           int iNumPeaks;
-
-                           if (scanStatistics.IsCentroidScan && (scanStatistics.SpectrumPacketType == SpectrumPacketType.FtCentroid))
-                           {
-                              var centroidStream = rawFile.GetCentroidStream(iScanNumber, false);
-                              iNumPeaks = centroidStream.Length;
-                              pdMass = centroidStream.Masses;
-                              pdInten = centroidStream.Intensities;
-                           }
-                           else
-                           {
-                              var segmentedScan = rawFile.GetSegmentedScanFromScanNumber(iScanNumber, scanStatistics);
-                              iNumPeaks = segmentedScan.Positions.Length;
-                              pdMass = segmentedScan.Positions;
-                              pdInten = segmentedScan.Intensities;
-                           }
-
-                           if (iNumPeaks < 10)  // don't bother searching sparse spectra
-                           {
-                              lock (progressLock)
-                              {
-                                 scansProcessed++;
-                              }
-                              continue;
-                           }
-
-                           ScanResult result = new ScanResult
-                           {
-                              ScanNumber = iScanNumber,
-                              ScanType = scanFilter.MSOrder,
-                              RT = dRT
-                           };
-
-                           // Perform search using SHARED manager (C++ is thread-safe via mutexes)
-                           if (bPerformMS1Search && scanFilter.MSOrder == MSOrderType.Ms)
-                           {
-                              int iMS1TopN = 1;
-                              watch.Restart();
-
-                              // Use SHARED globalSearchMgr (thread-safe on C++ side)
-                              globalSearchMgr.DoMS1SearchMultiResults(dMaxMS1RTDiff, dMaxQueryRT, iMS1TopN, dRT,
-                                 pdMass, pdInten, iNumPeaks, out List<ScoreWrapperMS1> vScores);
-
-                              watch.Stop();
-                              result.ScoresMS1 = vScores;
-                              result.ElapsedMs = (int)watch.ElapsedMilliseconds;
-                           }
-                           else if (bPerformMS2Search && scanFilter.MSOrder == MSOrderType.Ms2)
-                           {
-                              int iPrecursorCharge = 0;
-                              double dPrecursorMZ = rawFile.GetScanEventForScanNumber(iScanNumber).GetReaction(0).PrecursorMass;
-
-                              var trailerData = rawFile.GetTrailerExtraInformation(iScanNumber);
-                              for (int i = 0; i < trailerData.Length; ++i)
-                              {
-                                 if (trailerData.Labels[i] == "Monoisotopic M/Z:")
+                                 // Update progress for non-searchable scans
+                                 lock (progressLock)
                                  {
-                                    double dTmp = double.Parse(trailerData.Values[i]);
-                                    double dMassDiff = Math.Abs(dTmp - dPrecursorMZ);
-
-                                    if (dTmp != 0.0 && dMassDiff < 10.0)
-                                       dPrecursorMZ = dTmp;
+                                    scansProcessed++;
                                  }
-                                 else if (trailerData.Labels[i] == "Charge State:")
-                                    iPrecursorCharge = (int)double.Parse(trailerData.Values[i]);
+                                 continue;
                               }
 
-                              double dExpPepMass = (iPrecursorCharge * dPrecursorMZ) - (iPrecursorCharge - 1) * dProtonMass;
+                              // Get spectral data
+                              double[] pdMass;
+                              double[] pdInten;
+                              int iNumPeaks;
 
-                              result.ExpMass = dExpPepMass - dProtonMass;  // store neutral mass
-                              result.Charge = iPrecursorCharge;
-                              result.MZ = dPrecursorMZ;
+                              if (scanStatistics.IsCentroidScan && (scanStatistics.SpectrumPacketType == SpectrumPacketType.FtCentroid))
+                              {
+                                 var centroidStream = rawFile.GetCentroidStream(iScanNumber, false);
+                                 iNumPeaks = centroidStream.Length;
+                                 pdMass = centroidStream.Masses;
+                                 pdInten = centroidStream.Intensities;
+                              }
+                              else
+                              {
+                                 var segmentedScan = rawFile.GetSegmentedScanFromScanNumber(iScanNumber, scanStatistics);
+                                 iNumPeaks = segmentedScan.Positions.Length;
+                                 pdMass = segmentedScan.Positions;
+                                 pdInten = segmentedScan.Intensities;
+                              }
 
-                              if (dExpPepMass < dPeptideMassLow || dExpPepMass > dPeptideMassHigh)
+                              if (iNumPeaks < 10)  // don't bother searching sparse spectra
                               {
                                  lock (progressLock)
                                  {
@@ -285,194 +230,247 @@
                                  continue;
                               }
 
-                              watch.Restart();
-
-                              // Use SHARED globalSearchMgr (thread-safe on C++ side)
-                              globalSearchMgr.DoSingleSpectrumSearchMultiResults(iMS2TopN, iPrecursorCharge, dPrecursorMZ,
-                                 pdMass, pdInten, iNumPeaks,
-                                 out List<string> vPeptide,
-                                 out List<string> vProtein,
-                                 out List<List<FragmentWrapper>> vMatchingFragments,
-                                 out List<ScoreWrapper> vScores);
-
-                              watch.Stop();
-                              result.Peptides = vPeptide;
-                              result.Proteins = vProtein;
-                              result.Scores = vScores;
-                              result.ElapsedMs = (int)watch.ElapsedMilliseconds;
-                           }
-
-                           results.Add(result);
-
-                           // Update progress
-                           lock (progressLock)
-                           {
-                              scansProcessed++;
-                              if (scansProcessed % 100 == 0)
+                              ScanResult result = new ScanResult
                               {
-                                 double percentComplete = (double)scansProcessed / totalScans * 100.0;
-                                 Console.Write("\r Progress: {0:F1}% ({1}/{2} scans)", percentComplete, scansProcessed, totalScans);
+                                 ScanNumber = iScanNumber,
+                                 ScanType = scanFilter.MSOrder,
+                                 RT = dRT
+                              };
+
+                              // Perform search using SHARED manager (C++ is thread-safe via mutexes)
+                              if (bPerformMS1Search && scanFilter.MSOrder == MSOrderType.Ms)
+                              {
+                                 int iMS1TopN = 1;
+                                 watch.Restart();
+
+                                 // Use SHARED globalSearchMgr (thread-safe on C++ side)
+                                 globalSearchMgr.DoMS1SearchMultiResults(dMaxMS1RTDiff, dMaxQueryRT, iMS1TopN, dRT,
+                                    pdMass, pdInten, iNumPeaks, out List<ScoreWrapperMS1> vScores);
+
+                                 watch.Stop();
+                                 result.ScoresMS1 = vScores;
+                                 result.ElapsedMs = (int)watch.ElapsedMilliseconds;
+                              }
+                              else if (bPerformMS2Search && scanFilter.MSOrder == MSOrderType.Ms2)
+                              {
+                                 int iPrecursorCharge = 0;
+                                 double dPrecursorMZ = rawFile.GetScanEventForScanNumber(iScanNumber).GetReaction(0).PrecursorMass;
+
+                                 var trailerData = rawFile.GetTrailerExtraInformation(iScanNumber);
+                                 for (int i = 0; i < trailerData.Length; ++i)
+                                 {
+                                    if (trailerData.Labels[i] == "Monoisotopic M/Z:")
+                                    {
+                                       double dTmp = double.Parse(trailerData.Values[i]);
+                                       double dMassDiff = Math.Abs(dTmp - dPrecursorMZ);
+
+                                       if (dTmp != 0.0 && dMassDiff < 10.0)
+                                          dPrecursorMZ = dTmp;
+                                    }
+                                    else if (trailerData.Labels[i] == "Charge State:")
+                                       iPrecursorCharge = (int)double.Parse(trailerData.Values[i]);
+                                 }
+
+                                 double dExpPepMass = (iPrecursorCharge * dPrecursorMZ) - (iPrecursorCharge - 1) * dProtonMass;
+
+                                 result.ExpMass = dExpPepMass - dProtonMass;  // store neutral mass
+                                 result.Charge = iPrecursorCharge;
+                                 result.MZ = dPrecursorMZ;
+
+                                 if (dExpPepMass < dPeptideMassLow || dExpPepMass > dPeptideMassHigh)
+                                 {
+                                    lock (progressLock)
+                                    {
+                                       scansProcessed++;
+                                    }
+                                    continue;
+                                 }
+
+                                 watch.Restart();
+
+                                 // Use SHARED globalSearchMgr (thread-safe on C++ side)
+                                 globalSearchMgr.DoSingleSpectrumSearchMultiResults(iMS2TopN, iPrecursorCharge, dPrecursorMZ,
+                                    pdMass, pdInten, iNumPeaks,
+                                    out List<string> vPeptide,
+                                    out List<string> vProtein,
+                                    out List<List<FragmentWrapper>> vMatchingFragments,
+                                    out List<ScoreWrapper> vScores);
+
+                                 watch.Stop();
+                                 result.Peptides = vPeptide;
+                                 result.Proteins = vProtein;
+                                 result.Scores = vScores;
+                                 result.ElapsedMs = (int)watch.ElapsedMilliseconds;
+                              }
+
+                              results.Add(result);
+
+                              // Update progress
+                              lock (progressLock)
+                              {
+                                 scansProcessed++;
+                                 if (scansProcessed % 100 == 0)
+                                 {
+                                    double percentComplete = (double)scansProcessed / totalScans * 100.0;
+                                    Console.Write("\r Progress: {0:F1}% ({1}/{2} scans)", percentComplete, scansProcessed, totalScans);
+                                 }
+                              }
+                           }
+                           catch (Exception ex)
+                           {
+                              Console.WriteLine("\n Thread {0}: Error processing scan {1}: {2}", threadId, iScanNumber, ex.Message);
+                              lock (progressLock)
+                              {
+                                 scansProcessed++;
                               }
                            }
                         }
-                        catch (Exception ex)
+                     }
+
+                     // Launch worker threads
+                     Task[] tasks = new Task[numThreads];
+                     for (int i = 0; i < numThreads; ++i)
+                     {
+                        int threadId = i;
+                        tasks[i] = Task.Run(() => ProcessScans(threadId));
+                     }
+
+                     // Wait for all threads to complete
+                     Task.WaitAll(tasks);
+                     Console.WriteLine(); // newline after progress
+
+                     watchGlobal.Stop();
+                     TimeSpan elapsedGlobal = watchGlobal.Elapsed;
+
+                     // Cleanup ONCE
+                     if (bPerformMS2Search)
+                        globalSearchMgr.FinalizeSingleSpectrumSearch();
+                     if (bPerformMS1Search)
+                        globalSearchMgr.FinalizeSingleSpectrumMS1Search();
+
+                     // Process and display results
+                     var sortedResults = results.OrderBy(r => r.ScanNumber).ToList();
+
+                     // Create histograms
+                     int iMaxHistogramTime = 50;
+                     int[] piTimeSearchMS1 = new int[iMaxHistogramTime];
+                     int[] piTimeSearchMS2 = new int[iMaxHistogramTime];
+                     var slowestRuns = new List<(int TimeMs, string Peptide, int ScanNumber, double XCorr)>();
+
+                     foreach (var result in sortedResults)
+                     {
+                        int iTime = result.ElapsedMs;
+
+                        if (result.ScanType == MSOrderType.Ms && result.ScoresMS1 != null && result.ScoresMS1.Count > 0)
                         {
-                           Console.WriteLine("\n Thread {0}: Error processing scan {1}: {2}", threadId, iScanNumber, ex.Message);
-                           lock (progressLock)
+                           if (iTime >= iMaxHistogramTime)
+                              iTime = iMaxHistogramTime - 1;
+                           if (iTime >= 0)
+                              piTimeSearchMS1[iTime] += 1;
+
+                           if ((result.ScanNumber % iPrintEveryScan) == 0)
                            {
-                              scansProcessed++;
+                              string line = string.Format("*MS1 {0}  libscan {1}  queryRT {2:F2}  libRT {3:F2}  dotp {4:F3}  {5} ms",
+                                  result.ScanNumber, result.ScoresMS1[0].iScanNumber, result.RT,
+                                  result.ScoresMS1[0].fRTime, result.ScoresMS1[0].fDotProduct, iTime);
+                              //Console.WriteLine(line);
+                              rtsWriter.WriteLine(line);
+                           }
+                        }
+                        else if (result.ScanType == MSOrderType.Ms2 && result.Peptides != null && result.Peptides.Count > 0)
+                        {
+                           if (iTime >= iMaxHistogramTime)
+                              iTime = iMaxHistogramTime - 1;
+                           if (iTime >= 0)
+                              piTimeSearchMS2[iTime] += 1;
+
+                           if (result.Peptides[0].Length > 0)
+                           {
+                              slowestRuns.Add((iTime, result.Peptides[0], result.ScanNumber, result.Scores[0].xCorr));
+                              slowestRuns = slowestRuns.OrderByDescending(x => x.TimeMs).Take(5).ToList();
+                           }
+
+                           if ((result.ScanNumber % iPrintEveryScan) == 0)
+                           {
+                              string protein = result.Proteins[0];
+                              if (protein.Length > iProteinLengthCutoff)
+                                 protein = protein.Substring(0, iProteinLengthCutoff);
+
+                              // replace space with semicolon for easy parsing
+                              string sAScoreProSiteScores = result.Scores[0].sAScoreProSiteScores.Replace(' ', ';');
+
+                              string line = string.Format(" MS2 {0}\t{1}  {2:F4}  {3:0.##E+00}  z {10}  exp {4:F4}  calc {5:F4}  AScore {6:F2}  Sites '{7}'  {8} ms  prot '{9}'",
+                                  result.ScanNumber, result.Peptides[0], result.Scores[0].xCorr, result.Scores[0].dExpect,
+                                  result.ExpMass, result.Scores[0].mass,
+                                  result.Scores[0].dAScorePro, sAScoreProSiteScores,
+                                  iTime, protein, result.Charge);
+                              //Console.WriteLine(line);
+                              rtsWriter.WriteLine(line);
+
+                              if (Math.Abs(result.ExpMass - result.Scores[0].mass) > 5.0)
+                              {
+                                 string warn = string.Format(" **** Warning: large mass error for scan {0}: {1:F4} Da", result.ScanNumber, result.ExpMass - result.Scores[0].mass);
+                                 Console.WriteLine(warn);
+                                 rtsWriter.WriteLine(warn);
+                              }
                            }
                         }
                      }
-                  }
 
-                  // Launch worker threads
-                  Task[] tasks = new Task[numThreads];
-                  for (int i = 0; i < numThreads; ++i)
-                  {
-                     int threadId = i;
-                     tasks[i] = Task.Run(() => ProcessScans(threadId));
-                  }
-
-                  // Wait for all threads to complete
-                  Task.WaitAll(tasks);
-                  Console.WriteLine(); // newline after progress
-
-                  watchGlobal.Stop();
-                  TimeSpan elapsedGlobal = watchGlobal.Elapsed;
-
-                  // Cleanup ONCE
-                  if (bPerformMS2Search)
-                     globalSearchMgr.FinalizeSingleSpectrumSearch();
-                  if (bPerformMS1Search)
-                     globalSearchMgr.FinalizeSingleSpectrumMS1Search();
-
-                  // Process and display results
-                  var sortedResults = results.OrderBy(r => r.ScanNumber).ToList();
-
-                  // Create histograms
-                  int iMaxHistogramTime = 50;
-                  int[] piTimeSearchMS1 = new int[iMaxHistogramTime];
-                  int[] piTimeSearchMS2 = new int[iMaxHistogramTime];
-                  var slowestRuns = new List<(int TimeMs, string Peptide, int ScanNumber, double XCorr)>();
-
-                  foreach (var result in sortedResults)
-                  {
-                     int iTime = result.ElapsedMs;
-
-                     if (result.ScanType == MSOrderType.Ms && result.ScoresMS1 != null && result.ScoresMS1.Count > 0)
+                     // Write histogram
                      {
-                        if (iTime >= iMaxHistogramTime)
-                           iTime = iMaxHistogramTime - 1;
-                        if (iTime >= 0)
-                           piTimeSearchMS1[iTime] += 1;
-
-                        if ((result.ScanNumber % iPrintEveryScan) == 0)
+                        int iTot = 0;
+                        int iAbove5ms = 0;
+                        int iAbove10ms = 0;
+                        for (int i = 0; i < iMaxHistogramTime; ++i)
                         {
-                           string line = string.Format("*MS1 {0}  libscan {1}  queryRT {2:F2}  libRT {3:F2}  dotp {4:F3}  {5} ms",
-                               result.ScanNumber, result.ScoresMS1[0].iScanNumber, result.RT,
-                               result.ScoresMS1[0].fRTime, result.ScoresMS1[0].fDotProduct, iTime);
-                           //Console.WriteLine(line);
-                           rtsWriter.WriteLine(line);
-                           rtsWriter.Flush();
-                        }
-                     }
-                     else if (result.ScanType == MSOrderType.Ms2 && result.Peptides != null && result.Peptides.Count > 0)
-                     {
-                        if (iTime >= iMaxHistogramTime)
-                           iTime = iMaxHistogramTime - 1;
-                        if (iTime >= 0)
-                           piTimeSearchMS2[iTime] += 1;
+                           string line1 = $"histogram\t{i}\t{piTimeSearchMS1[i]}\t{piTimeSearchMS2[i]}";
+                           Console.WriteLine(line1);
+                           rtsWriter.WriteLine(line1);
 
-                        if (result.Peptides[0].Length > 0)
-                        {
-                           slowestRuns.Add((iTime, result.Peptides[0], result.ScanNumber, result.Scores[0].xCorr));
-                           slowestRuns = slowestRuns.OrderByDescending(x => x.TimeMs).Take(5).ToList();
+                           iTot += piTimeSearchMS2[i];
+                           if (i > 5)
+                              iAbove5ms += piTimeSearchMS2[i];
+                           if (i > 10)
+                              iAbove10ms += piTimeSearchMS2[i];
                         }
 
-                        if ((result.ScanNumber % iPrintEveryScan) == 0)
+                        Console.WriteLine("\n5 Slowest MS2 Runs:");
+                        rtsWriter.WriteLine("\n5 Slowest MS2 Runs:");
+                        Console.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
+                        rtsWriter.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
+                        foreach (var run in slowestRuns.OrderByDescending(x => x.TimeMs))
                         {
-                           string protein = result.Proteins[0];
-                           if (protein.Length > iProteinLengthCutoff)
-                              protein = protein.Substring(0, iProteinLengthCutoff);
-
-                           // replace space with semicolon for easy parsing
-                           string sAScoreProSiteScores = result.Scores[0].sAScoreProSiteScores.Replace(' ', ';');
-
-                           string line = string.Format(" MS2 {0}\t{1}  {2:F4}  {3:0.##E+00}  z {10}  exp {4:F4}  calc {5:F4}  AScore {6:F2}  Sites '{7}'  {8} ms  prot '{9}'",
-                               result.ScanNumber, result.Peptides[0], result.Scores[0].xCorr, result.Scores[0].dExpect,
-                               result.ExpMass, result.Scores[0].mass,
-                               result.Scores[0].dAScorePro, sAScoreProSiteScores,
-                               iTime, protein, result.Charge);
-                           //Console.WriteLine(line);
-                           rtsWriter.WriteLine(line);
-                           rtsWriter.Flush();
-
-                           if (Math.Abs(result.ExpMass - result.Scores[0].mass) > 5.0)
-                           {
-                              string warn = string.Format(" **** Warning: large mass error for scan {0}: {1:F4} Da", result.ScanNumber, result.ExpMass - result.Scores[0].mass);
-                              Console.WriteLine(warn);
-                              rtsWriter.WriteLine(warn);
-                              rtsWriter.Flush();
-                           }
+                           string line1 = $"{run.TimeMs}\t{run.ScanNumber}\t{run.Peptide}\t{run.XCorr:F4}";
+                           Console.WriteLine(line1);
+                           rtsWriter.WriteLine(line1);
                         }
-                     }
-                  }
 
-                  // Write histogram
-                  {
-                     int iTot = 0;
-                     int iAbove5ms = 0;
-                     int iAbove10ms = 0;
-                     for (int i = 0; i < iMaxHistogramTime; ++i)
-                     {
-                        string line1 = $"histogram\t{i}\t{piTimeSearchMS1[i]}\t{piTimeSearchMS2[i]}";
-                        Console.WriteLine(line1);
-                        rtsWriter.WriteLine(line1);
+                        string line = string.Format("\n<= 5 ms: {0}, > 5 ms: {1} ({3:F3}%), > 10ms {2} ({4:F3}%)\n",
+                           iTot - iAbove5ms, iAbove5ms, iAbove10ms,
+                           iTot > 0 ? ((double)iAbove5ms / iTot) * 100.0 : 0,
+                           iTot > 0 ? ((double)iAbove10ms / iTot) * 100.0 : 0);
+                        rtsWriter.WriteLine(line);
 
-                        iTot += piTimeSearchMS2[i];
-                        if (i > 5)
-                           iAbove5ms += piTimeSearchMS2[i];
-                        if (i > 10)
-                           iAbove10ms += piTimeSearchMS2[i];
-                     }
+                        line = string.Format("\nTotal elapsed time: {0:F2} minutes", elapsedGlobal.TotalMinutes);
+                        rtsWriter.WriteLine(line);
 
-                     Console.WriteLine("\n5 Slowest MS2 Runs:");
-                     rtsWriter.WriteLine("\n5 Slowest MS2 Runs:");
-                     Console.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
-                     rtsWriter.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
-                     foreach (var run in slowestRuns.OrderByDescending(x => x.TimeMs))
-                     {
-                        string line1 = $"{run.TimeMs}\t{run.ScanNumber}\t{run.Peptide}\t{run.XCorr:F4}";
-                        Console.WriteLine(line1);
-                        rtsWriter.WriteLine(line1);
+                        line = string.Format("Scans processed: {0}", scansProcessed);
+                        rtsWriter.WriteLine(line);
+
+                        line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessed);
+                        rtsWriter.WriteLine(line);
+
+                        line = string.Format("\nindex creation elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
+                        rtsWriter.WriteLine(line);
+                        Console.WriteLine(line);
+                        line = string.Format("search elapsed time: {0:F2} s\n", watchGlobal.Elapsed.TotalSeconds);
+                        rtsWriter.WriteLine(line);
+                        Console.WriteLine(line);
+
                      }
 
-                     string line = string.Format("\n<= 5 ms: {0}, > 5 ms: {1} ({3:F3}%), > 10ms {2} ({4:F3}%)\n",
-                        iTot - iAbove5ms, iAbove5ms, iAbove10ms,
-                        iTot > 0 ? ((double)iAbove5ms / iTot) * 100.0 : 0,
-                        iTot > 0 ? ((double)iAbove10ms / iTot) * 100.0 : 0);
-                     rtsWriter.WriteLine(line);
-
-                     line = string.Format("\nTotal elapsed time: {0:F2} minutes", elapsedGlobal.TotalMinutes);
-                     rtsWriter.WriteLine(line);
-
-                     line = string.Format("Scans processed: {0}", scansProcessed);
-                     rtsWriter.WriteLine(line);
-
-                     line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessed);
-                     rtsWriter.WriteLine(line);
-
-                     line = string.Format("\nindex creation elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
-                     rtsWriter.WriteLine(line);
-                     Console.WriteLine(line);
-                     line = string.Format("search elapsed time: {0:F2} s\n", watchGlobal.Elapsed.TotalSeconds);
-                     rtsWriter.WriteLine(line);
-                     Console.WriteLine(line);
-
-                  }
-
-                  rawFile.Dispose();
+                  } // end using rawFile — Dispose called automatically
                }
                catch (Exception rawSearchEx)
                {

--- a/RealtimeSearch/SearchMS1MS2.cs
+++ b/RealtimeSearch/SearchMS1MS2.cs
@@ -1,6 +1,7 @@
 ﻿namespace RealTimeSearch
 {
-   //using System.Threading.Tasks;
+   using System.Threading.Tasks;
+   using System.Collections.Concurrent;
 
    using CometWrapper;
    using System;
@@ -14,26 +15,40 @@
    using ThermoFisher.CommonCore.Data.FilterEnums;
    using ThermoFisher.CommonCore.Data.Interfaces;
    using ThermoFisher.CommonCore.RawFileReader;
-   
+
    /// <summary>
    /// Call CometWrapper to run searches, looping through scans in a Thermo RAW file
    /// </summary>
    class RealTimeSearch
    {
+      // Thread-safe storage for results
+      private class ScanResult
+      {
+         public int ScanNumber { get; set; }
+         public MSOrderType ScanType { get; set; }
+         public int ElapsedMs { get; set; }
+         public List<string> Peptides { get; set; }
+         public List<string> Proteins { get; set; }
+         public List<ScoreWrapper> Scores { get; set; }
+         public List<ScoreWrapperMS1> ScoresMS1 { get; set; }
+         public double RT { get; set; }
+         public double ExpMass { get; set; }
+         public double Charge { get; set; }
+         public double MZ { get; set; }
+
+      }
+
       static void Main(string[] args)
       {
          if (args.Length < 2)
          {
             Console.WriteLine(" RTS MS1/MS2\n");
-            Console.WriteLine("    USAGE:  {0} [query.raw] [MS1reference.raw] [database.idx]\n",
+            Console.WriteLine("    USAGE:  {0} [query.raw] [MS1reference.raw] [database.idx] [num_threads]\n",
                System.AppDomain.CurrentDomain.FriendlyName);
             return;
          }
 
          Console.WriteLine("\n RTS MS1/MS2\n");
-
-         CometSearchManagerWrapper SearchMgr = new CometSearchManagerWrapper();
-         SearchSettings searchParams = new SearchSettings();
 
          string rawFileName = args[0];       // raw file that will supply the query spectra
          string sRawFileReference = args[1]; // raw file containing MS1 scans to search for MS1 alignment
@@ -41,20 +56,40 @@
 
          bool bDatabaseSearch = false;
 
-         if (args.Length == 3)
+         if (args.Length >= 3)
          {
             sDB = args[2];
             bDatabaseSearch = true;
          }
 
+         // Parse number of threads (default to processor count)
+         int numThreads = Environment.ProcessorCount;
+         if (args.Length >= 4)
+         {
+            if (!int.TryParse(args[3], out numThreads) || numThreads < 1)
+            {
+               Console.WriteLine(" Warning: Invalid num_threads '{0}', using {1} threads", args[3], numThreads);
+               numThreads = Environment.ProcessorCount;
+            }
+         }
+
+         Console.WriteLine(" Using {0} search threads\n", numThreads);
+
+         // Create SINGLE global search manager
+         CometSearchManagerWrapper globalSearchMgr = new CometSearchManagerWrapper();
+         SearchSettings searchParams = new SearchSettings();
          double dPeptideMassLow = 0;
          double dPeptideMassHigh = 0;
-
          double dProtonMass = 1.00727646688;
 
-         // ConfigureInputSettings is an example of how to set search parameters.
-         // Will also read the index database and return dPeptideMassLow/dPeptideMassHigh mass range
-         searchParams.ConfigureInputSettings(SearchMgr, ref sRawFileReference, ref sDB, ref dPeptideMassLow, ref dPeptideMassHigh, bDatabaseSearch);
+         // Configure ONCE (before threading)
+         searchParams.ConfigureInputSettings(globalSearchMgr,
+            ref sRawFileReference,
+            ref sDB,
+            ref dPeptideMassLow,
+            ref dPeptideMassHigh,
+            ref numThreads,
+            bDatabaseSearch);
 
          if (File.Exists(rawFileName) && File.Exists(sRawFileReference))
          {
@@ -64,373 +99,386 @@
                Console.Write(" Indexed database: {0}  \n", sDB);
             Console.Write("\n");
 
-            try
+            string outputFile = "rts.out";
+            using (var rtsWriter = new StreamWriter(outputFile, append: false))
             {
-               IRawDataPlus rawFile = RawFileReaderAdapter.FileFactory(rawFileName);
-               if (!rawFile.IsOpen || rawFile.IsError)
+               try
                {
-                  Console.WriteLine(" Error: unable to access the RAW file using the RawFileReader class.");
-                  return;
-               }
-
-               rawFile.SelectInstrument(Device.MS, 1);
-
-               // Get the first and last scan from the RAW file
-               int iFirstScan = rawFile.RunHeaderEx.FirstSpectrum;
-               int iLastScan = rawFile.RunHeaderEx.LastSpectrum;
-
-               // Loop through to find first MS1 scan; get mass range from that
-               // Current assumption is that the MS1 mass range is fixed throughout
-               // the acquisition
-
-               for (int iScanNumber = iFirstScan; iScanNumber <= iLastScan; ++iScanNumber)
-               {
-                  // Get the scan filter for this scan number
-                  var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
-
-                  if (scanFilter.MSOrder == MSOrderType.Ms)
+                  // Open raw file ONCE
+                  IRawDataPlus rawFile = RawFileReaderAdapter.FileFactory(rawFileName);
+                  if (!rawFile.IsOpen || rawFile.IsError)
                   {
-                     var stats1 = rawFile.GetScanStatsForScanNumber(1);
-
-                     var MS1MassRange = new DoubleRangeWrapper(stats1.LowMass, stats1.HighMass);
-                     string MS1MassRangeString = stats1.LowMass.ToString() + " " + stats1.HighMass.ToString();
-                     SearchMgr.SetParam("ms1_mass_range", MS1MassRangeString, MS1MassRange);
-
-                     break;
-                  }
-               }
-
-               int iNumPeaks;
-               int iPrecursorCharge;
-               double dPrecursorMZ = 0;
-               double[] pdMass;
-               double[] pdInten;
-
-               Stopwatch watch = new Stopwatch();
-               Stopwatch watchGlobal = new Stopwatch();
-               TimeSpan elapsedGlobal;
-
-               int iMaxHistogramTime = 20;
-               int[] piTimeSearchMS1 = new int[iMaxHistogramTime];  // histogram of search times
-               int[] piTimeSearchMS2 = new int[iMaxHistogramTime];  // histogram of search times
-
-               for (int i = 0; i < iMaxHistogramTime; ++i)
-               {
-                  piTimeSearchMS1[i] = 0;
-                  piTimeSearchMS2[i] = 0;
-               } 
-
-               int iPass = 1;  // count number of passes/loops through raw file
-               int iTime;
-
-               double dMaxMS1RTDiff = 300.0;    // maximum allowed retention time difference between query and reference, in seconds
-                                                // set to 0.0 to not apply aka do not apply any RT restrictions
-
-               double dMaxQueryRT;  // this is the maximum RT in seconds for the query run, used to
-                                    // scale the query RTs against the reference run RTs which may
-                                    // have a different maximum RT value. Assumes a linear gradient.
-               dMaxQueryRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iLastScan);
-
-               int iPrintEveryScan = 1000;
-               int iMS2TopN = 1; // report up to topN hits per MS/MS query
-               int iMaxLoopIterations = 3; // set to >1 to loop multiple times through the raw file for testing
-               bool bContinuousLoop = true; // set to true to continuously loop through the raw file
-               bool bPrintHistogram = true;
-               bool bPrintMatchedFragmentIons = false;
-               bool bPerformMS1Search = false;
-               bool bPerformMS2Search = true;
-
-               int iProteinLengthCutoff = 50; // trim protein description to this many chars; set to large # to avoid trimming
-
-               if (bPerformMS1Search)
-               {
-                  SearchMgr.InitializeSingleSpectrumMS1Search();
-               }
-
-               if (bDatabaseSearch && bPerformMS2Search)
-               {
-                  // trigger loading the .idx database
-                  SearchMgr.InitializeSingleSpectrumSearch();
-               }
-
-               // Track max elapsed time for each scan range, for each loop iteration
-               int scanRangeSize = 5000;
-               int numScanRanges = ((iLastScan - iFirstScan) / scanRangeSize) + 1;
-               int[,] maxElapsedTimeByRange = new int[iMaxLoopIterations, numScanRanges];
-               for (int i = 0; i < iMaxLoopIterations; ++i)
-                  for (int j = 0; j < numScanRanges; ++j)
-                     maxElapsedTimeByRange[i, j] = 0;
-
-               // Track the slowest spectrum queries
-               var slowestRuns = new List<(int TimeMs, string Peptide, int ScanNumber, double XCorr)>();
-
-               watchGlobal.Start();
-
-               int iLoopCount = 0;
-
-               for (int iScanNumber = iFirstScan; iScanNumber <= iLastScan; ++iScanNumber)
-               {
-                  var scanStatistics = rawFile.GetScanStatsForScanNumber(iScanNumber);
-                  double dRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iScanNumber);
-
-                  // Get the scan filter for this scan number
-                  var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
-
-                  if (scanFilter.MSOrder == MSOrderType.Ms || scanFilter.MSOrder == MSOrderType.Ms2)
-                  {
-                     // Check to see if the scan has centroid data or profile data.  Depending upon the
-                     // type of data, different methods will be used to read the data.
-                     if (scanStatistics.IsCentroidScan && (scanStatistics.SpectrumPacketType == SpectrumPacketType.FtCentroid))
-                     {
-                        // Get the centroid (label) data from the RAW file for this scan
-                        var centroidStream = rawFile.GetCentroidStream(iScanNumber, false);
-                        iNumPeaks = centroidStream.Length;
-                        pdMass = new double[iNumPeaks];   // stores mass of spectral peaks
-                        pdInten = new double[iNumPeaks];  // stores inten of spectral peaks
-                        pdMass = centroidStream.Masses;
-                        pdInten = centroidStream.Intensities;
-                     }
-                     else
-                     {
-                        // Get the segmented (low res and profile) scan data
-                        var segmentedScan = rawFile.GetSegmentedScanFromScanNumber(iScanNumber, scanStatistics);
-                        iNumPeaks = segmentedScan.Positions.Length;
-                        pdMass = new double[iNumPeaks];   // stores mass of spectral peaks
-                        pdInten = new double[iNumPeaks];  // stores inten of spectral peaks
-                        pdMass = segmentedScan.Positions;
-                        pdInten = segmentedScan.Intensities;
-                     }
-
-                     if (iNumPeaks >= 10)  // don't bother searching sparse spectra
-                     {
-                        // now run the search on scan
-
-                        int iMS1TopN = 1; // report up to iMS1TopN hits per query; unused right now as only top matching MS1 scan is returned
-
-                        if (bPerformMS1Search && scanFilter.MSOrder == MSOrderType.Ms)
-                        {
-                           watch.Reset();
-                           watch.Start();
-                           SearchMgr.DoMS1SearchMultiResults(dMaxMS1RTDiff, dMaxQueryRT, iMS1TopN, dRT, pdMass, pdInten, iNumPeaks, out List<ScoreWrapperMS1> vScores);
-                           watch.Stop();
-
-                           if (vScores.Count > 0)
-                           {
-                              iTime = (int)watch.ElapsedMilliseconds;
-                              if (iTime >= iMaxHistogramTime)
-                                 iTime = iMaxHistogramTime - 1;
-                              if (iTime >= 0)
-                                 piTimeSearchMS1[iTime] += 1;
-
-                              if ((iScanNumber % iPrintEveryScan) == 0)
-                              {
-                                 for (int x = 0; x < 1; ++x)
-                                 {
-                                    Console.WriteLine("*MS1 {0}  libscan {1}  queryRT {2:F2}  libRT {3:F2}  dotp {4:F3}  {5} ms",
-                                       iScanNumber, vScores[x].iScanNumber, dRT, vScores[x].fRTime, vScores[x].fDotProduct, iTime);
-                                 }
-                              }
-                           }
-                        }
-                        else if (bPerformMS2Search && scanFilter.MSOrder == MSOrderType.Ms2)  // MS2 scan
-                        {
-                           iPrecursorCharge = 0;
-                           dPrecursorMZ = rawFile.GetScanEventForScanNumber(iScanNumber).GetReaction(0).PrecursorMass;
-
-                           var trailerData = rawFile.GetTrailerExtraInformation(iScanNumber);
-                           for (int i = 0; i < trailerData.Length; ++i)
-                           {
-                              if (trailerData.Labels[i] == "Monoisotopic M/Z:")
-                              {
-                                 double dTmp = double.Parse(trailerData.Values[i]);
-                                 double dMassDiff = Math.Abs(dTmp - dPrecursorMZ);
-
-                                 if (dTmp != 0.0 && dMassDiff < 10.0)
-                                    dPrecursorMZ = dTmp;
-                              }
-                              else if (trailerData.Labels[i] == "Charge State:")
-                                 iPrecursorCharge = (int)double.Parse(trailerData.Values[i]);
-                           }
-
-                           // skip analysis of spectrum if ion is outside of indexed db mass range
-                           double dExpPepMass = (iPrecursorCharge * dPrecursorMZ) - (iPrecursorCharge - 1) * dProtonMass;
-                           if (dExpPepMass < dPeptideMassLow || dExpPepMass > dPeptideMassHigh)
-                              continue;
-
-                           // now run the search on scan
-
-                           // these next variables store return value from search
-                           List<string> vPeptide = new List<string>();
-                           List<string> vProtein = new List<string>();
-
-                           watch.Reset();
-                           watch.Start();
-                           SearchMgr.DoSingleSpectrumSearchMultiResults(iMS2TopN, iPrecursorCharge, dPrecursorMZ, pdMass, pdInten, iNumPeaks,
-                              out vPeptide, out vProtein, out List<List<FragmentWrapper>> vMatchingFragments, out List<ScoreWrapper> vScores);
-                           watch.Stop();
-
-                           if ((vPeptide.Count > 0) && (vPeptide[0].Length > 0) && Math.Abs((dExpPepMass - dProtonMass) - vScores[0].mass) > 5.0)
-                           {
-                              Console.WriteLine("   WARNING: large mass difference: exp exp {0:F4}  calc {1:F4}", dExpPepMass - dProtonMass, vScores[0].mass);
-                           }
-
-                           if (vPeptide.Count > 0 && (iScanNumber % iPrintEveryScan) == 0)
-                           {
-                              if (vPeptide[0].Length > 0)
-                              {
-                                 for (int x = 0; x < 1; ++x)
-                                 {
-                                    if (vPeptide[x].Length > 0)
-                                    {
-                                       string protein = vProtein[x];
-                                       if (protein.Length > iProteinLengthCutoff)
-                                          protein = protein.Substring(0, iProteinLengthCutoff);  // trim to avoid printing long protein description string
-
-                                       Console.WriteLine(" MS2 {0}\t{1}  {2:F4}  {3:0.##E+00}  exp {4:F4}  calc {5:F4}  AScore {6:F2}  Sites '{7}'  {8} ms  prot '{9}'", 
-                                          iScanNumber, vPeptide[x], vScores[x].xCorr, vScores[x].dExpect,
-                                          dExpPepMass - dProtonMass, vScores[x].mass,
-                                          vScores[x].dAScoreScore, vScores[x].sAScoreProSiteScores,
-                                          watch.ElapsedMilliseconds, protein);
-
-                                       if ((dExpPepMass - dProtonMass) - vScores[x].mass > 4.0)
-                                       {
-                                          Console.WriteLine("   WARNING: large mass difference between precursor mass and peptide mass; possible missed modification or isotope error");
-                                       }
-
-                                       if (bPrintMatchedFragmentIons)
-                                       {
-                                          foreach (var myFragment in vMatchingFragments[x]) // print matched fragment ions
-                                          {
-                                             Console.WriteLine("\t{0:0.0000}\t{1:0.0}\t{2}+\t{3}-ion",
-                                                myFragment.Mass,
-                                                myFragment.Intensity,
-                                                myFragment.Charge,
-                                                myFragment.Type);
-                                          }
-                                       }
-
-                                    }
-                                 }
-                              }
-                           }
-
-                           if (vPeptide.Count > 0)
-                           {
-                              iTime = (int)watch.ElapsedMilliseconds;
-
-                              // Store info for slowest runs (use first/top hit for each scan)
-                              if (vPeptide[0].Length > 0 && vScores.Count > 0)
-                              {
-                                 slowestRuns.Add((iTime, vPeptide[0], iScanNumber, vScores[0].xCorr));
-                                 // Keep only the 5 slowest
-                                 slowestRuns = slowestRuns.OrderByDescending(x => x.TimeMs).Take(5).ToList();
-                              }
-
-                              // Determine scan range index
-                              int scanRangeIndex = (iScanNumber - iFirstScan) / scanRangeSize;
-                              if (scanRangeIndex < 0) scanRangeIndex = 0;
-                              if (scanRangeIndex >= numScanRanges) scanRangeIndex = numScanRanges - 1;
-
-                              // Update max elapsed time for this scan range and loop
-                              if (iTime > maxElapsedTimeByRange[iLoopCount, scanRangeIndex])
-                                 maxElapsedTimeByRange[iLoopCount, scanRangeIndex] = iTime;
-
-
-                              if (iTime >= iMaxHistogramTime)
-                                 iTime = iMaxHistogramTime - 1;
-                              if (iTime >= 0)
-                                 piTimeSearchMS2[iTime] += 1;
-                           }
-
-                        }
-                     }
+                     Console.WriteLine(" Error: unable to access the RAW file using the RawFileReader class.");
+                     return;
                   }
 
-                  if (bContinuousLoop && iScanNumber == iLastScan)
+                  rawFile.SelectInstrument(Device.MS, 1);
+
+                  // Get the first and last scan from the RAW file
+                  int iFirstScan = rawFile.RunHeaderEx.FirstSpectrum;
+                  int iLastScan = rawFile.RunHeaderEx.LastSpectrum;
+
+                  // Get MS1 mass range from first MS1 scan
+                  DoubleRangeWrapper MS1MassRange = null;
+
+                  for (int iScanNumber = iFirstScan; iScanNumber <= iLastScan; ++iScanNumber)
                   {
-                     iLoopCount++;
-                     if (iLoopCount >= iMaxLoopIterations)
+                     var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
+
+                     if (scanFilter.MSOrder == MSOrderType.Ms)
+                     {
+                        var stats1 = rawFile.GetScanStatsForScanNumber(iScanNumber);
+                        MS1MassRange = new DoubleRangeWrapper(stats1.LowMass, stats1.HighMass);
                         break;
-
-                     iScanNumber = iFirstScan - 1;
-                     elapsedGlobal = watchGlobal.Elapsed;
-                     Console.WriteLine("pass {0}, {1:F2} min", iPass, elapsedGlobal.TotalMinutes);
-                     iPass++;
+                     }
                   }
 
-               }
+                  if (MS1MassRange != null)
+                  {
+                     string MS1MassRangeString = MS1MassRange.get_dStart() + " " + MS1MassRange.get_dEnd();
+                     globalSearchMgr.SetParam("ms1_mass_range", MS1MassRangeString, MS1MassRange);
+                  }
 
-               SearchMgr.FinalizeSingleSpectrumSearch();
+                  // MS1 RT parameters
+                  double dMaxMS1RTDiff = 300.0;    // maximum allowed retention time difference between query and reference, in seconds
+                  double dMaxQueryRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iLastScan);
 
-               if (bPrintHistogram)
-               {
-                  // write out histogram of spectrum search times
-                  using (var writer = new StreamWriter("histogram.txt"))
+                  int iPrintEveryScan = 1;
+                  int iMS2TopN = 1; // report up to topN hits per MS/MS query
+                  int iProteinLengthCutoff = 50;
+
+                  bool bPerformMS1Search = false;
+                  bool bPerformMS2Search = true;
+
+                  // Thread-safe collections
+                  var scanQueue = new ConcurrentQueue<int>();
+                  var results = new ConcurrentBag<ScanResult>();
+                  var progressLock = new object();
+                  int scansProcessed = 0;
+                  int totalScans = iLastScan - iFirstScan + 1;
+
+                  // Initialize ONCE (before threading)
+                  if (bPerformMS1Search)
+                     globalSearchMgr.InitializeSingleSpectrumMS1Search(dMaxQueryRT);
+
+
+                  Stopwatch watchIndexCreate = new Stopwatch();
+                  watchIndexCreate.Start();
+                  if (bDatabaseSearch && bPerformMS2Search)
+                     globalSearchMgr.InitializeSingleSpectrumSearch();
+                  watchIndexCreate.Stop();
+
+                  // Populate scan queue
+                  for (int i = iFirstScan; i <= iLastScan; ++i)
+                     scanQueue.Enqueue(i);
+
+                  Stopwatch watchGlobal = new Stopwatch();
+                  watchGlobal.Start();
+
+                  // Simplified worker thread function
+                  void ProcessScans(int threadId)
+                  {
+                     Stopwatch watch = new Stopwatch();
+
+                     // Process scans from queue using SHARED resources
+                     while (scanQueue.TryDequeue(out int iScanNumber))
+                     {
+                        try
+                        {
+                           // Use SHARED raw file reader (thread-safe)
+                           var scanStatistics = rawFile.GetScanStatsForScanNumber(iScanNumber);
+                           double dRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iScanNumber);
+                           var scanFilter = rawFile.GetFilterForScanNumber(iScanNumber);
+
+                           if (scanFilter.MSOrder != MSOrderType.Ms && scanFilter.MSOrder != MSOrderType.Ms2)
+                           {
+                              // Update progress for non-searchable scans
+                              lock (progressLock)
+                              {
+                                 scansProcessed++;
+                              }
+                              continue;
+                           }
+
+                           // Get spectral data
+                           double[] pdMass;
+                           double[] pdInten;
+                           int iNumPeaks;
+
+                           if (scanStatistics.IsCentroidScan && (scanStatistics.SpectrumPacketType == SpectrumPacketType.FtCentroid))
+                           {
+                              var centroidStream = rawFile.GetCentroidStream(iScanNumber, false);
+                              iNumPeaks = centroidStream.Length;
+                              pdMass = centroidStream.Masses;
+                              pdInten = centroidStream.Intensities;
+                           }
+                           else
+                           {
+                              var segmentedScan = rawFile.GetSegmentedScanFromScanNumber(iScanNumber, scanStatistics);
+                              iNumPeaks = segmentedScan.Positions.Length;
+                              pdMass = segmentedScan.Positions;
+                              pdInten = segmentedScan.Intensities;
+                           }
+
+                           if (iNumPeaks < 10)  // don't bother searching sparse spectra
+                           {
+                              lock (progressLock)
+                              {
+                                 scansProcessed++;
+                              }
+                              continue;
+                           }
+
+                           ScanResult result = new ScanResult
+                           {
+                              ScanNumber = iScanNumber,
+                              ScanType = scanFilter.MSOrder,
+                              RT = dRT
+                           };
+
+                           // Perform search using SHARED manager (C++ is thread-safe via mutexes)
+                           if (bPerformMS1Search && scanFilter.MSOrder == MSOrderType.Ms)
+                           {
+                              int iMS1TopN = 1;
+                              watch.Restart();
+
+                              // Use SHARED globalSearchMgr (thread-safe on C++ side)
+                              globalSearchMgr.DoMS1SearchMultiResults(dMaxMS1RTDiff, dMaxQueryRT, iMS1TopN, dRT,
+                                 pdMass, pdInten, iNumPeaks, out List<ScoreWrapperMS1> vScores);
+
+                              watch.Stop();
+                              result.ScoresMS1 = vScores;
+                              result.ElapsedMs = (int)watch.ElapsedMilliseconds;
+                           }
+                           else if (bPerformMS2Search && scanFilter.MSOrder == MSOrderType.Ms2)
+                           {
+                              int iPrecursorCharge = 0;
+                              double dPrecursorMZ = rawFile.GetScanEventForScanNumber(iScanNumber).GetReaction(0).PrecursorMass;
+
+                              var trailerData = rawFile.GetTrailerExtraInformation(iScanNumber);
+                              for (int i = 0; i < trailerData.Length; ++i)
+                              {
+                                 if (trailerData.Labels[i] == "Monoisotopic M/Z:")
+                                 {
+                                    double dTmp = double.Parse(trailerData.Values[i]);
+                                    double dMassDiff = Math.Abs(dTmp - dPrecursorMZ);
+
+                                    if (dTmp != 0.0 && dMassDiff < 10.0)
+                                       dPrecursorMZ = dTmp;
+                                 }
+                                 else if (trailerData.Labels[i] == "Charge State:")
+                                    iPrecursorCharge = (int)double.Parse(trailerData.Values[i]);
+                              }
+
+                              double dExpPepMass = (iPrecursorCharge * dPrecursorMZ) - (iPrecursorCharge - 1) * dProtonMass;
+
+                              result.ExpMass = dExpPepMass - dProtonMass;  // store neutral mass
+                              result.Charge = iPrecursorCharge;
+                              result.MZ = dPrecursorMZ;
+
+                              if (dExpPepMass < dPeptideMassLow || dExpPepMass > dPeptideMassHigh)
+                              {
+                                 lock (progressLock)
+                                 {
+                                    scansProcessed++;
+                                 }
+                                 continue;
+                              }
+
+                              watch.Restart();
+
+                              // Use SHARED globalSearchMgr (thread-safe on C++ side)
+                              globalSearchMgr.DoSingleSpectrumSearchMultiResults(iMS2TopN, iPrecursorCharge, dPrecursorMZ,
+                                 pdMass, pdInten, iNumPeaks,
+                                 out List<string> vPeptide,
+                                 out List<string> vProtein,
+                                 out List<List<FragmentWrapper>> vMatchingFragments,
+                                 out List<ScoreWrapper> vScores);
+
+                              watch.Stop();
+                              result.Peptides = vPeptide;
+                              result.Proteins = vProtein;
+                              result.Scores = vScores;
+                              result.ElapsedMs = (int)watch.ElapsedMilliseconds;
+                           }
+
+                           results.Add(result);
+
+                           // Update progress
+                           lock (progressLock)
+                           {
+                              scansProcessed++;
+                              if (scansProcessed % 100 == 0)
+                              {
+                                 double percentComplete = (double)scansProcessed / totalScans * 100.0;
+                                 Console.Write("\r Progress: {0:F1}% ({1}/{2} scans)", percentComplete, scansProcessed, totalScans);
+                              }
+                           }
+                        }
+                        catch (Exception ex)
+                        {
+                           Console.WriteLine("\n Thread {0}: Error processing scan {1}: {2}", threadId, iScanNumber, ex.Message);
+                           lock (progressLock)
+                           {
+                              scansProcessed++;
+                           }
+                        }
+                     }
+                  }
+
+                  // Launch worker threads
+                  Task[] tasks = new Task[numThreads];
+                  for (int i = 0; i < numThreads; ++i)
+                  {
+                     int threadId = i;
+                     tasks[i] = Task.Run(() => ProcessScans(threadId));
+                  }
+
+                  // Wait for all threads to complete
+                  Task.WaitAll(tasks);
+                  Console.WriteLine(); // newline after progress
+
+                  watchGlobal.Stop();
+                  TimeSpan elapsedGlobal = watchGlobal.Elapsed;
+
+                  // Cleanup ONCE
+                  if (bPerformMS2Search)
+                     globalSearchMgr.FinalizeSingleSpectrumSearch();
+                  if (bPerformMS1Search)
+                     globalSearchMgr.FinalizeSingleSpectrumMS1Search();
+
+                  // Process and display results
+                  var sortedResults = results.OrderBy(r => r.ScanNumber).ToList();
+
+                  // Create histograms
+                  int iMaxHistogramTime = 50;
+                  int[] piTimeSearchMS1 = new int[iMaxHistogramTime];
+                  int[] piTimeSearchMS2 = new int[iMaxHistogramTime];
+                  var slowestRuns = new List<(int TimeMs, string Peptide, int ScanNumber, double XCorr)>();
+
+                  foreach (var result in sortedResults)
+                  {
+                     int iTime = result.ElapsedMs;
+
+                     if (result.ScanType == MSOrderType.Ms && result.ScoresMS1 != null && result.ScoresMS1.Count > 0)
+                     {
+                        if (iTime >= iMaxHistogramTime)
+                           iTime = iMaxHistogramTime - 1;
+                        if (iTime >= 0)
+                           piTimeSearchMS1[iTime] += 1;
+
+                        if ((result.ScanNumber % iPrintEveryScan) == 0)
+                        {
+                           string line = string.Format("*MS1 {0}  libscan {1}  queryRT {2:F2}  libRT {3:F2}  dotp {4:F3}  {5} ms",
+                               result.ScanNumber, result.ScoresMS1[0].iScanNumber, result.RT,
+                               result.ScoresMS1[0].fRTime, result.ScoresMS1[0].fDotProduct, iTime);
+                           //Console.WriteLine(line);
+                           rtsWriter.WriteLine(line);
+                           rtsWriter.Flush();
+                        }
+                     }
+                     else if (result.ScanType == MSOrderType.Ms2 && result.Peptides != null && result.Peptides.Count > 0)
+                     {
+                        if (iTime >= iMaxHistogramTime)
+                           iTime = iMaxHistogramTime - 1;
+                        if (iTime >= 0)
+                           piTimeSearchMS2[iTime] += 1;
+
+                        if (result.Peptides[0].Length > 0)
+                        {
+                           slowestRuns.Add((iTime, result.Peptides[0], result.ScanNumber, result.Scores[0].xCorr));
+                           slowestRuns = slowestRuns.OrderByDescending(x => x.TimeMs).Take(5).ToList();
+                        }
+
+                        if ((result.ScanNumber % iPrintEveryScan) == 0)
+                        {
+                           string protein = result.Proteins[0];
+                           if (protein.Length > iProteinLengthCutoff)
+                              protein = protein.Substring(0, iProteinLengthCutoff);
+
+                           // replace space with semicolon for easy parsing
+                           string sAScoreProSiteScores = result.Scores[0].sAScoreProSiteScores.Replace(' ', ';');
+
+                           string line = string.Format(" MS2 {0}\t{1}  {2:F4}  {3:0.##E+00}  z {10}  exp {4:F4}  calc {5:F4}  AScore {6:F2}  Sites '{7}'  {8} ms  prot '{9}'",
+                               result.ScanNumber, result.Peptides[0], result.Scores[0].xCorr, result.Scores[0].dExpect,
+                               result.ExpMass, result.Scores[0].mass,
+                               result.Scores[0].dAScorePro, sAScoreProSiteScores,
+                               iTime, protein, result.Charge);
+                           //Console.WriteLine(line);
+                           rtsWriter.WriteLine(line);
+                           rtsWriter.Flush();
+
+                           if (Math.Abs(result.ExpMass - result.Scores[0].mass) > 5.0)
+                           {
+                              string warn = string.Format(" **** Warning: large mass error for scan {0}: {1:F4} Da", result.ScanNumber, result.ExpMass - result.Scores[0].mass);
+                              Console.WriteLine(warn);
+                              rtsWriter.WriteLine(warn);
+                              rtsWriter.Flush();
+                           }
+                        }
+                     }
+                  }
+
+                  // Write histogram
                   {
                      int iTot = 0;
                      int iAbove5ms = 0;
                      int iAbove10ms = 0;
                      for (int i = 0; i < iMaxHistogramTime; ++i)
                      {
-                        string line = $"histogram\t{i}\t{piTimeSearchMS1[i]}\t{piTimeSearchMS2[i]}";
-                        Console.WriteLine(line);
-                        writer.WriteLine(line);
+                        string line1 = $"histogram\t{i}\t{piTimeSearchMS1[i]}\t{piTimeSearchMS2[i]}";
+                        Console.WriteLine(line1);
+                        rtsWriter.WriteLine(line1);
 
                         iTot += piTimeSearchMS2[i];
                         if (i > 5)
                            iAbove5ms += piTimeSearchMS2[i];
                         if (i > 10)
                            iAbove10ms += piTimeSearchMS2[i];
-
                      }
 
                      Console.WriteLine("\n5 Slowest MS2 Runs:");
-                     writer.WriteLine("\n5 Slowest MS2 Runs:");
+                     rtsWriter.WriteLine("\n5 Slowest MS2 Runs:");
                      Console.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
-                     writer.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
+                     rtsWriter.WriteLine("Time(ms)\tScan\tPeptide\tXcorr");
                      foreach (var run in slowestRuns.OrderByDescending(x => x.TimeMs))
                      {
-                        string line = $"{run.TimeMs}\t{run.ScanNumber}\t{run.Peptide}\t{run.XCorr:F4}";
-                        Console.WriteLine(line);
-                        writer.WriteLine(line);
+                        string line1 = $"{run.TimeMs}\t{run.ScanNumber}\t{run.Peptide}\t{run.XCorr:F4}";
+                        Console.WriteLine(line1);
+                        rtsWriter.WriteLine(line1);
                      }
 
-                     Console.WriteLine("\n<= 5 ms: {0}, > 5 ms: {1} ({3:F3}%), > 10ms {2} ({4:F3}%)\n",
-                        iTot - iAbove5ms, iAbove5ms, iAbove10ms, ((double)iAbove5ms / iTot)*100.0, ((double)iAbove10ms / iTot) * 100.0);
-                     writer.WriteLine("\n<= 5 ms: {0}, > 5 ms: {1} ({3:F3}%), > 10ms {2} ({4:F3}%)\n",
-                        iTot - iAbove5ms, iAbove5ms, iAbove10ms, ((double)iAbove5ms / iTot) * 100.0, ((double)iAbove10ms / iTot) * 100.0);
+                     string line = string.Format("\n<= 5 ms: {0}, > 5 ms: {1} ({3:F3}%), > 10ms {2} ({4:F3}%)\n",
+                        iTot - iAbove5ms, iAbove5ms, iAbove10ms,
+                        iTot > 0 ? ((double)iAbove5ms / iTot) * 100.0 : 0,
+                        iTot > 0 ? ((double)iAbove10ms / iTot) * 100.0 : 0);
+                     rtsWriter.WriteLine(line);
 
-                     // Export table of maximum run times for each scan range and loop iteration
-                     writer.WriteLine("\nMax elapsed run times (ms) by scan range and loop:");
-                     Console.WriteLine("\nMax elapsed run times (ms) by scan range and loop:");
+                     line = string.Format("\nTotal elapsed time: {0:F2} minutes", elapsedGlobal.TotalMinutes);
+                     rtsWriter.WriteLine(line);
 
-                     StringBuilder header = new StringBuilder("Loop\\Range");
-                     for (int r = 0; r < numScanRanges; ++r)
-                     {
-                        int rangeStart = iFirstScan + r * scanRangeSize;
-                        int rangeEnd = Math.Min(iLastScan, rangeStart + scanRangeSize - 1);
-                        header.Append($"\t{rangeStart}-{rangeEnd}");
-                     }
-                     Console.WriteLine(header.ToString());
-                     writer.WriteLine(header.ToString());
+                     line = string.Format("Scans processed: {0}", scansProcessed);
+                     rtsWriter.WriteLine(line);
 
-                     for (int loop = 0; loop < iMaxLoopIterations; ++loop)
-                     {
-                        StringBuilder row = new StringBuilder($"{loop + 1}");
-                        for (int r = 0; r < numScanRanges; ++r)
-                           row.Append($"\t{maxElapsedTimeByRange[loop, r]}");
-                        Console.WriteLine(row.ToString());
-                        writer.WriteLine(row.ToString());
-                     }
+                     line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessed);
+                     rtsWriter.WriteLine(line);
+
+                     line = string.Format("\nindex creation elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
+                     rtsWriter.WriteLine(line);
+                     Console.WriteLine(line);
+                     line = string.Format("search elapsed time: {0:F2} s\n", watchGlobal.Elapsed.TotalSeconds);
+                     rtsWriter.WriteLine(line);
+                     Console.WriteLine(line);
+
                   }
+
+                  rawFile.Dispose();
                }
-
-               rawFile.Dispose();
-            }
-
-            catch (Exception rawSearchEx)
-            {
-               Console.WriteLine(" Error: " + rawSearchEx.Message);
+               catch (Exception rawSearchEx)
+               {
+                  Console.WriteLine(" Error: " + rawSearchEx.Message);
+                  Console.WriteLine(" Stack trace: " + rawSearchEx.StackTrace);
+               }
             }
          }
          else
@@ -438,9 +486,7 @@
             Console.WriteLine("No raw file exists at that path.");
          }
 
-
          Console.WriteLine("{0} Done.{1}", Environment.NewLine, Environment.NewLine);
-         //Console.ReadLine();
          return;
       }
 
@@ -451,8 +497,9 @@
             ref string sDB,
             ref double dPeptideMassLow,
             ref double dPeptideMassHigh,
+            ref int numThreads,
             bool bDatabaseSearch)
-         {  
+         {
             String sTmp;
             int iTmp;
             double dTmp;
@@ -486,19 +533,17 @@
             sTmp = iTmp.ToString();
             SearchMgr.SetParam("max_index_runtime", sTmp, iTmp);
 
-            iTmp = 0;
-            sTmp = iTmp.ToString();
-            SearchMgr.SetParam("num_threads", sTmp, iTmp);
+            SearchMgr.SetParam("num_threads", numThreads.ToString(), numThreads);
 
-            dTmp = 1.0005; // fragment bin width
+            dTmp = 0.02; // fragment bin width
             sTmp = dTmp.ToString();
             SearchMgr.SetParam("fragment_bin_tol", sTmp, dTmp);
 
-            dTmp = 0.4;  // fragment bin offst
+            dTmp = 0.0;  // fragment bin offset
             sTmp = dTmp.ToString();
             SearchMgr.SetParam("fragment_bin_offset", sTmp, dTmp);
 
-            iTmp = 1; // 0=use flanking peaks, 1=M peak only
+            iTmp = 0; // 0=use flanking peaks, 1=M peak only
             sTmp = iTmp.ToString();
             SearchMgr.SetParam("theoretical_fragment_ions", sTmp, iTmp);
 
@@ -572,7 +617,7 @@
                      bool bFoundMassRange = false;
                      string strLine;
 
-                    while ((strLine = dbFile.ReadLine()) != null)
+                     while ((strLine = dbFile.ReadLine()) != null)
                      {
                         string[] strParsed = strLine.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                         if (strParsed[0].Equals("MassRange:"))
@@ -619,14 +664,14 @@
                   // .idx file does not exist so set appropriate parameters here for generating fragment ion indexing's plain peptide .idx
 
                   // digest mass range
-                  dPeptideMassLow  =  900.0;
-                  dPeptideMassHigh = 3000.0;
+                  dPeptideMassLow = 800.0;
+                  dPeptideMassHigh = 4000.0;
                   var digestMassRange = new DoubleRangeWrapper(dPeptideMassLow, dPeptideMassHigh);
                   string digestMassRangeString = dPeptideMassLow.ToString() + " " + dPeptideMassHigh.ToString();
                   SearchMgr.SetParam("digest_mass_range", digestMassRangeString, digestMassRange);
 
                   // digest length range
-                  int iLengthMin =  8;
+                  int iLengthMin = 8;
                   int iLengthMax = 40;
                   var peptideLengthRange = new IntRangeWrapper(iLengthMin, iLengthMax);
                   string peptideLengthRangeString = dPeptideMassLow.ToString() + " " + dPeptideMassHigh.ToString();
@@ -653,7 +698,7 @@
                   varMods.set_WhichTerm(0);
                   varMods.set_VarNeutralLoss(0.0);
                   SearchMgr.SetParam("variable_mod01", sTmp, varMods);
-/*
+
                   sTmp = "79.9663 STY 0 2 -1 0 0 97.976896";
                   varMods.set_VarModMass(79.9663);
                   varMods.set_VarModChar("STY");
@@ -664,7 +709,7 @@
                   varMods.set_WhichTerm(0);
                   varMods.set_VarNeutralLoss(97.976896);
                   SearchMgr.SetParam("variable_mod02", sTmp, varMods);
-*/
+
                   iTmp = 4;
                   sTmp = iTmp.ToString();
                   SearchMgr.SetParam("max_variable_mods_in_peptide", sTmp, iTmp);

--- a/planning_docs/20260224_THREADING_PLAN.md
+++ b/planning_docs/20260224_THREADING_PLAN.md
@@ -1,0 +1,220 @@
+﻿# Plan: Multithread `DoSingleSpectrumSearchMultiResults()` Calls
+
+## Goal
+Enable concurrent calls to `DoSingleSpectrumSearchMultiResults()` from `SearchMS1MS2.cs`
+by eliminating the `g_pvQuery` serialization bottleneck in the native C++ search engine.
+
+---
+
+## Problem Summary
+
+When `SearchMS1MS2.cs` launches N C# `Task` threads, they all call
+`globalSearchMgr.DoSingleSpectrumSearchMultiResults()` concurrently via `CometWrapper.dll`.
+Inside the native C++, every call serializes on `g_pvQueryMutex` because:
+
+1. Each call pushes a `Query*` into the global `g_pvQuery` vector.
+2. `CometSearch::RunSearch(ThreadPool*)` hardcodes `iWhichQuery = 0` into `g_pvQuery`.
+3. `SearchFragmentIndex()` reads `g_pvQuery.at(iWhichQuery)` — concurrent pushes break indices.
+4. Post-analysis (`CalculateSP`, `CalculateEValue`) also index into `g_pvQuery[0]`.
+5. `CometSearch::_ppbDuplFragmentArr` is a static shared scratch buffer indexed by thread pool slot.
+
+## What Is Already Thread-Safe (READ-ONLY After Init)
+
+| Global                     | Safe? | Notes                                      |
+|----------------------------|-------|--------------------------------------------|
+| `g_staticParams`           | ✅     | Set once in `InitializeSingleSpectrumSearch()` |
+| `g_iFragmentIndex`         | ✅     | Built once, never modified during search   |
+| `g_vFragmentPeptides`      | ✅     | Built once                                 |
+| `g_vRawPeptides`           | ✅     | Built once                                 |
+| `g_pvProteinNames`         | ✅     | Built once                                 |
+| `g_pvProteinsList`         | ✅     | Built once                                 |
+| `g_pvQuery`                | ❌     | **SHARED MUTABLE — the bottleneck**        |
+| `g_cometStatus`            | ❌     | Shared mutable error reporting             |
+| `_ppbDuplFragmentArr`      | ❌     | Static per-thread-pool-slot scratch arrays |
+
+---
+
+## Task List
+
+### Phase 1: Core C++ Changes — Eliminate `g_pvQuery` Dependency
+
+#### Task 1.1: Add `SearchFragmentIndex(Query*, bool*, time_point)` Overload
+- **File(s):** `CometSearch.h`, `CometSearch.cpp`
+- **Description:** Create a new overload of `SearchFragmentIndex` that accepts a `Query*`
+  directly instead of a `size_t iWhichQuery` index into `g_pvQuery`. The new overload
+  should replace every `g_pvQuery.at(iWhichQuery)` reference with the passed-in `Query*`.
+  The existing `SearchFragmentIndex(size_t, ThreadPool*)` remains unchanged for batch search.
+  Accepts a `time_point` parameter for timeout checking (Task 7.2).
+- **Key changes:**
+  - Replace `g_pvQuery.at(iWhichQuery)->` with `pQuery->` throughout.
+  - `pbDuplFragment` allocated per-call (already done in current `SearchFragmentIndex`).
+  - `XcorrScoreI` calls pass `pQuery` instead of `iWhichQuery`.
+  - Timeout checks use `tRealTimeStart` parameter instead of `g_staticParams.tRealTimeStart`.
+- **Status:** ✅ Complete — `SearchFragmentIndex(Query*, bool*, time_point)` declared in
+  `CometSearch.h` and implemented in `CometSearch.cpp`.
+
+#### Task 1.2: Add Thread-Local `XcorrScoreI` / `StorePeptideI` Overloads
+- **File(s):** `CometSearch.h`, `CometSearch.cpp`
+- **Description:** Add overloads (or modify existing) `XcorrScoreI` and `StorePeptideI`
+  to accept `Query*` instead of indexing `g_pvQuery`. The `pQuery->accessMutex` lock
+  is still needed since the `Query` object is local to the caller, but the global
+  `g_pvQueryMutex` is not.
+- **Key changes:**
+  - `XcorrScoreI(Query* pQuery, ...)` — replace `g_pvQuery.at(iWhichQuery)` with `pQuery`.
+  - `StorePeptideI(Query* pQuery, ...)` — same replacement.
+  - `CheckMassMatch(Query* pQuery, double dCalcPepMass)` — accept `Query*` directly.
+- **Status:** ✅ Complete — `XcorrScoreI(Query*, ...)`, `StorePeptideI(Query*, ...)`, and
+  `CheckMassMatch(Query*, double)` overloads all declared in `CometSearch.h` and implemented
+  in `CometSearch.cpp`.
+
+#### Task 1.3: Add Thread-Local `RunSearch(Query*, time_point)` Overload
+- **File(s):** `CometSearch.h`, `CometSearch.cpp`
+- **Description:** Add `static bool RunSearch(Query* pQuery, time_point tRealTimeStart)`
+  that creates a local `CometSearch` instance and calls the new
+  `SearchFragmentIndex(pQuery, ...)`. This is the entry point called by
+  `DoSingleSpectrumSearchMultiResults`. Accepts a `time_point` parameter for
+  timeout checking (Task 7.2).
+- **Status:** ✅ Complete — `RunSearch(Query*, time_point)` declared in `CometSearch.h`
+  and implemented in `CometSearch.cpp`. Allocates per-call `pbDuplFragment`, calls
+  `SearchFragmentIndex(pQuery, pbDuplFragment, tRealTimeStart)`, then frees the buffer.
+
+### Phase 2: Rewrite `DoSingleSpectrumSearchMultiResults` to Be Thread-Local
+
+#### Task 2.1: Create Thread-Local `Query` Object
+- **File(s):** `CometSearchManager.cpp`
+- **Description:** In `DoSingleSpectrumSearchMultiResults`, create a stack/heap-local
+  `Query` object instead of pushing to `g_pvQuery`. Populate it with the input spectrum
+  data (m/z arrays, charge, precursor mass, preprocessed xcorr data). After the search,
+  read results directly from the local `Query*` and populate output vectors.
+- **Key changes:**
+  - Remove `Threading::LockMutex(g_pvQueryMutex)` / `g_pvQuery.push_back()` / `pop_back()`.
+  - Call `CometPreprocess::PreprocessSingleSpectrumThreadLocal()` into the local `Query`.
+  - Call `CometSearch::RunSearch(pLocalQuery, tRealTimeStart)`.
+  - Call post-analysis on the local `Query*`.
+  - Extract results from `pLocalQuery->_pResults[]`.
+- **Status:** ✅ Complete — `DoSingleSpectrumSearchMultiResults` uses
+  `PreprocessSingleSpectrumThreadLocal()` to create a caller-owned `Query*`, calls
+  `CometSearch::RunSearch(pQuery, tRealTimeStart)`, and runs thread-local post-analysis.
+  No `g_pvQueryMutex` lock or `g_pvQuery` access remains on this path.
+
+#### Task 2.2: Add Thread-Local Post-Analysis Functions
+- **File(s):** `CometPostAnalysis.h`, `CometPostAnalysis.cpp`
+- **Description:** Add overloads of `CalculateSP`, `CalculateEValue`, and
+  `CalculateDeltaCn` that accept `Query*` directly instead of indexing `g_pvQuery`.
+- **Status:** ✅ Complete — `CalculateSP(Results*, Query*, int)`,
+  `CalculateEValue(Query*, bool)`, `CalculateDeltaCn(Query*)`, and
+  `CalculateAScorePro(Query*, AScoreDllInterface*)` overloads all declared in
+  `CometPostAnalysis.h` and implemented in `CometPostAnalysis.cpp`. Each delegates to
+  its `int iWhichQuery` counterpart's logic using the passed `Query*` directly.
+
+### Phase 3: Thread-Safe Scratch Memory
+
+#### Task 3.1: Per-Call `pbDuplFragment` Allocation
+- **File(s):** `CometSearch.cpp`
+- **Description:** The new `SearchFragmentIndex(Query*, ...)` already allocates
+  `pbDuplFragment` on the heap per-call (`new bool[g_staticParams.iArraySizeGlobal]`).
+  Verify this is correct and no static `_ppbDuplFragmentArr` is accessed.
+  The existing batch-search path continues using the static pool.
+- **Status:** ✅ Verified — `RunSearch(Query*, time_point)` in `CometSearch.cpp` allocates
+  `bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal]()` per-call, passes
+  it to `SearchFragmentIndex(pQuery, pbDuplFragment, tRealTimeStart)`, and `delete[]`s
+  it afterward. The static `_ppbDuplFragmentArr` is not accessed on this code path.
+
+### Phase 4: Wrapper Layer
+
+#### Task 4.1: Verify `CometWrapper.cpp` Needs No Changes
+- **File(s):** `CometWrapper.cpp`
+- **Description:** The existing wrapper already pins managed arrays, creates local native
+  vectors, and converts results per-call. No changes needed since threading happens at
+  the C# level. Confirm the wrapper method calls the (now thread-safe) native method.
+- **Status:** ✅ Verified — `CometWrapper.cpp` pins arrays with `pin_ptr`, creates
+  stack-local `std::vector` containers, calls through the `ICometSearchManager` virtual
+  interface (signature unchanged), and converts results to managed `List<>` objects.
+  No shared mutable state exists in the wrapper layer.
+
+### Phase 5: C# Caller
+
+#### Task 5.1: Fix `dAScoreScore` → `dAScorePro` in `SearchMS1MS2.cs`
+- **File(s):** `RealtimeSearch/SearchMS1MS2.cs`
+- **Description:** The C# code references `result.Scores[0].dAScoreScore` which should
+  be `result.Scores[0].dAScorePro` to match the corrected `ScoreWrapper` property name.
+- **Status:** ✅ Complete — No `dAScoreScore` references exist in the codebase. The
+  `ScoreWrapper` property is already named `dAScorePro` and all C# consumers use that name.
+
+#### Task 5.2: Fix `dAScoreScore` → `dAScorePro` in `CometDataWrapper.h`
+- **File(s):** `CometWrapper/CometDataWrapper.h`
+- **Description:** Rename property `dAScoreScore` to `dAScorePro` in `ScoreWrapper`.
+  The getter already correctly accesses `pScores->dAScorePro`.
+- **Status:** ✅ Complete — `ScoreWrapper` in `CometDataWrapper.h` already exposes
+  `property double dAScorePro` backed by `pScores->dAScorePro`. Also exposes
+  `property String^ sAScoreProSiteScores`. No stale naming exists.
+
+#### Task 5.3: Add Default Constructors and Setters to Wrapper Classes
+- **File(s):** `CometWrapper/CometDataWrapper.h`
+- **Description:** Add default constructors and property setters to `ScoreWrapper` and
+  `FragmentWrapper` so the wrapper code can use `gcnew ScoreWrapper()` and set fields.
+- **Status:** ✅ Not needed — `CometWrapper.cpp` constructs `ScoreWrapper` and
+  `FragmentWrapper` via their existing `const CometScores&` / `const Fragment&`
+  copy-constructors. No default construction or property setting is required by the
+  current wrapper conversion code.
+
+### Phase 6: Testing & Validation
+
+#### Task 6.1: Single-Threaded Correctness — Code Review
+- **Description:** Review the modified code path with `iNumThreads = 1` logic and verify
+  structural correctness against the original serial implementation.
+- **Status:** ✅ Complete — Code review confirmed:
+  - `Query` constructor properly initializes all fields including `iMinXcorrHisto = 0`.
+  - Thread-local path: `PreprocessSingleSpectrumThreadLocal()` → `RunSearch(Query*, time_point)` →
+    `CalculateSP/CalculateEValue/CalculateDeltaCn(Query*)` → result extraction →
+    `delete pQuery` — all use `pQuery->` throughout, never index `g_pvQuery`.
+  - E-value computation: `CalculateEValue(Query*)` → `GenerateXcorrDecoys(Query*)` uses
+    only `pQuery->` fields and the read-only static `decoyIons[]` array. Deterministic.
+  - Sort tiebreakers in `SortFnXcorr` use `strcmp` + `piVarModSites`, producing stable
+    deterministic ordering for identical XCorr scores.
+  - All post-analysis `Query*` overloads delegate to the same algorithmic logic as the
+    `int iWhichQuery` counterparts, just replacing `g_pvQuery.at(i)->` with `pQuery->`.
+
+#### Task 6.2: Multi-Threaded Safety — Code Review
+- **Description:** Review with N threads for data races, shared mutable state, and
+  determinism.
+- **Status:** ✅ Complete — Two data races identified and fixed in Phase 7:
+  1. **`g_massRange` concurrent writes** — Fixed in Task 7.1 (writes removed).
+  2. **`g_staticParams.tRealTimeStart` concurrent writes** — Fixed in Task 7.2
+     (now a local variable passed as parameter).
+  - All other shared state (`g_staticParams`, `g_iFragmentIndex`, `g_vFragmentPeptides`,
+    `g_vRawPeptides`, `g_pvProteinNames`, `g_pvProteinsList`, `decoyIons[]`) confirmed
+    read-only after initialization. ✅
+  - `g_cometStatus` has unsynchronized writes (pre-existing issue, not introduced by
+    threading changes). Low impact — only affects error reporting.
+  - Results are deterministic regardless of thread count: each thread operates on its
+    own `Query*` with no cross-thread data dependencies.
+
+#### Task 6.3: Memory Leak Check — Code Review
+- **Description:** Verify that per-call `Query` objects and `pbDuplFragment` arrays
+  are properly freed after each search call.
+- **Status:** ✅ Complete — All allocations have matching deallocations:
+  - `Query* pQuery` — `delete pQuery` at `cleanup_results` label. Destructor frees
+    `ppfSparseSpScoreData`, `ppfSparseFastXcorrData`, `ppfSparseFastXcorrDataNL`,
+    `_pResults[]`, `_pDecoys[]`, and destroys `accessMutex`.
+  - `double* pdTmpSpectrum` — `delete[] pdTmpSpectrum` at `cleanup_results` label.
+  - `bool* pbDuplFragment` — allocated in `RunSearch(Query*, time_point)`, freed with
+    `delete[]` after `SearchFragmentIndex` returns. Not accessible outside `RunSearch`.
+  - `FILE* fp` — opened per-call for protein name retrieval, `fclose(fp)` within the
+    result extraction block.
+  - All early-exit `goto cleanup_results` paths reach the deallocation code.
+
+### Phase 7: Fix Remaining Data Races
+
+#### Task 7.1: Remove vestigial `g_massRange` writes
+- **File(s):** `CometSearchManager.cpp`
+- **Description:** Remove the three `g_massRange` assignments from
+  `DoSingleSpectrumSearchMultiResults`. The `SearchFragmentIndex(Query*, bool*, time_point)`
+  overload reads mass range from `pQuery->_pepMassInfo` directly.
+- **Status:** ✅ Complete — Removed `g_massRange.dMinMass`, `g_massRange.dMaxMass`, and
+  `g_massRange.bNarrowMassRange` writes from `DoSingleSpectrumSearchMultiResults`.
+
+
+---
+
+## Architecture Diagram

--- a/planning_docs/20260226_MS1_THREADING_PLAN.md
+++ b/planning_docs/20260226_MS1_THREADING_PLAN.md
@@ -1,0 +1,255 @@
+﻿# Plan: Fix MS1 Search Threading for `DoMS1SearchMultiResults()`
+
+## Goal
+Ensure `LoadSpecLibMS1Raw()` loads the reference library exactly **once** into `g_vSpecLib`,
+then allow N concurrent C# threads to each call `DoMS1SearchMultiResults()` with their
+query MS1 spectra — comparing each query against the **shared, read-only** `g_vSpecLib`.
+
+---
+
+## Problem Summary
+
+When `SearchMS1MS2.cs` launches N C# `Task` threads, they all call
+`globalSearchMgr.DoMS1SearchMultiResults()` concurrently. Inside the native C++,
+`DoMS1SearchMultiResults()` currently:
+
+1. Calls `InitializeSingleSpectrumMS1Search()` — which creates a thread pool and calls
+   `LoadSpecLibMS1Raw()` to load the reference file into `g_vSpecLib`.
+2. **Each concurrent call** re-enters `DoMS1SearchMultiResults()` and finds
+   `g_bSpecLibRead == false`, so each thread independently calls `LoadSpecLibMS1Raw()`,
+   causing the reference file to be loaded N times simultaneously.
+3. Even after loading, `DoMS1SearchMultiResults()` uses shared mutable state
+   (`g_pvQueryMS1`) to preprocess the query spectrum, then calls `RunMS1Search()` which
+   iterates `g_pvQueryMS1` — a global vector that is not thread-safe for concurrent
+   push/read.
+4. The `fillPool(iNumThreads - 1)` call creates 0 worker threads when `num_threads=1`,
+   causing a deadlock in `LoadSpecLibMS1Raw()` (the `wait_on_threads` never completes
+   because no worker thread exists to process queued jobs).
+
+### Root Causes
+
+| Issue | Location | Description |
+|-------|----------|-------------|
+| **Redundant loading** | `DoMS1SearchMultiResults` | No guard prevents concurrent calls from each loading the reference file |
+| **Shared mutable `g_pvQueryMS1`** | `DoMS1SearchMultiResults`, `RunMS1Search`, `PreprocessMS1SingleSpectrum` | Query spectrum pushed into global vector; concurrent threads corrupt it |
+| **Thread pool deadlock** | `InitializeSingleSpectrumMS1Search` | `fillPool(0)` with 1 thread creates no workers; queued jobs never execute |
+
+## What Is Already Thread-Safe (READ-ONLY After Init)
+
+| Global | Safe After Init? | Notes |
+|--------|-----------------|-------|
+| `g_vSpecLib` | ✅ | Populated once by `LoadSpecLibMS1Raw()`, read-only during search |
+| `g_staticParams` | ✅ | Set once during initialization |
+| `g_bSpecLibRead` | ✅ | Written once during single-threaded init; .NET Task scheduling provides happens-before |
+| `g_pvQueryMS1` | ✅ (batch only) | No longer used by single-spectrum path; only batch `RunMS1Search(ThreadPool*)` |
+| `dMaxSpecLibRT` | ✅ | Written once during single-threaded init, read-only after |
+
+---
+
+## Architecture: Before vs. After
+
+### Before (Broken)
+---
+
+## Task List
+
+### Phase 1: Fix Reference Library Loading (Load Once)
+
+#### Task 1.1: Move `LoadSpecLibMS1Raw()` into `InitializeSingleSpectrumMS1Search()`
+- **File(s):** `CometSearchManager.cpp`
+- **Description:** `InitializeSingleSpectrumMS1Search()` is called **once** from C#
+  before any threads start. Move the `LoadSpecLibMS1Raw()` call here, along with the
+  `dMaxSpecLibRT` computation. Store `dMaxSpecLibRT` as a member variable of
+  `CometSearchManager` (or a new global) so `DoMS1SearchMultiResults()` can read it.
+- **Key changes:**
+  - Call `LoadSpecLibMS1Raw(tp, dMaxQueryRT, &dMaxSpecLibRT)` inside
+    `InitializeSingleSpectrumMS1Search()`.
+  - Store the resulting `dMaxSpecLibRT` value for later use.
+  - Remove the `LoadSpecLibMS1Raw()` call from `DoMS1SearchMultiResults()`.
+  - After loading, `g_vSpecLib` and `g_bSpecLibRead` are immutable.
+- **Status:** ✅ Complete
+
+#### Task 1.2: Fix Thread Pool Deadlock for `num_threads=1`
+- **File(s):** `CometSearchManager.cpp`
+- **Description:** In `InitializeSingleSpectrumMS1Search()`, the thread pool is created
+  with `fillPool(iNumThreads - 1)`. When `iNumThreads == 1`, this creates 0 worker
+  threads, causing `LoadSpecLibMS1Raw()` to deadlock on `wait_on_threads()`. Fix by
+  ensuring at least 1 worker thread.
+- **Key change:** `fillPool(max(1, iNumThreads - 1))`
+- **Status:** ✅ Complete
+
+### Phase 2: Make `DoMS1SearchMultiResults()` Thread-Local
+
+#### Task 2.1: Create Thread-Local Query Preprocessing
+- **File(s):** `CometSearchManager.cpp`, `CometPreprocess.h`, `CometPreprocess.cpp`
+- **Description:** Replace `PreprocessMS1SingleSpectrum()` (which pushes into global
+`g_pvQueryMS1`) with a thread-local version that returns a `QueryMS1*` without
+touching any global state. This mirrors the pattern already established for MS2
+with `PreprocessSingleSpectrumThreadLocal()`.
+- **Key changes:**
+- Added `static QueryMS1* PreprocessMS1SingleSpectrumThreadLocal(double* pdMass, double* pdInten, int iNumPeaks)` to `CometPreprocess`.
+- This function allocates a `QueryMS1*` on the heap, fills its `pfFastXcorrData`
+  array (unit vector), and returns it. No global state touched.
+- The existing `PreprocessMS1SingleSpectrum()` remains for backward compatibility
+  (batch path).
+- **Status:** ✅ Complete
+
+#### Task 2.2: Create Thread-Local `RunMS1Search` Overload
+- **File(s):** `CometSearch.h`, `CometSearch.cpp`
+- **Description:** Add a new overload `static bool RunMS1Search(QueryMS1* pQueryMS1, ...)` 
+that accepts a thread-local `QueryMS1*` and computes the dot product against
+`g_vSpecLib` entries within the RT window. Returns results via output parameters
+(or a `vector<CometScoresMS1>&`) instead of writing to any global.
+- **Key changes:**
+- The function iterates `g_vSpecLib` (read-only) to find entries within `dMaxMS1RTDiff`
+  of the query RT.
+- For each candidate, compute dot product between `pQueryMS1->pfFastXcorrData` and
+  `g_vSpecLib[i].pfUnitVector`.
+- Populate the output `vector<CometScoresMS1>` with top-N results.
+- No access to `g_pvQueryMS1` — everything is thread-local.
+- **Status:** ✅ Complete
+
+#### Task 2.3: Rewrite `DoMS1SearchMultiResults()` to Use Thread-Local Objects
+- **File(s):** `CometSearchManager.cpp`
+- **Description:** Rewrite `DoMS1SearchMultiResults()` to:
+1. Call `PreprocessMS1SingleSpectrumThreadLocal()` → heap-local `QueryMS1*`.
+2. Call `RunMS1Search(pQueryMS1, dRT, dMaxMS1RTDiff, ...)` → thread-local results.
+3. Populate output `vector<CometScoresMS1>& scores`.
+4. Delete `pQueryMS1`.
+5. No mutex locks, no global vector access.
+- **Key changes:**
+- Removed `g_pvQueryMS1.clear()` and `g_pvQueryMS1` usage entirely from this path.
+- Removed the `LoadSpecLibMS1Raw()` call (moved to init in Task 1.1).
+- Removed `InitializeSingleSpectrumMS1Search()` re-call (was being called per-invocation).
+- **Status:** ✅ Complete
+
+### Phase 3: Verify Existing `g_vSpecLib` Thread Safety
+
+#### Task 3.1: Audit `g_vSpecLib` Access After Loading
+- **File(s):** `CometSpecLib.cpp`, `CometSearch.cpp`
+- **Description:** Verify that after `LoadSpecLibMS1Raw()` completes and
+`g_bSpecLibRead = true`, no code path modifies `g_vSpecLib` or
+`SpecLibStruct::pfUnitVector`. All access during `DoMS1SearchMultiResults()`
+must be read-only.
+- **Checklist:**
+- [x] `g_vSpecLib.push_back()` only in `LoadSpecLibMS1Raw()` / `PreprocessThreadProcMS1()`
+- [x] `pfUnitVector` allocated once per entry, never modified after
+- [x] `fRTime`, `fScaleMaxInten`, `uiArraySizeMS1` set once during loading
+- [x] Dot product scoring in `RunMS1Search` only reads `pfUnitVector`
+- **Action:** Added documentation comment above `LoadSpecLibMS1Raw()` in `CometSpecLib.cpp`
+  codifying the read-only invariant for future maintainers.
+- **Status:** ✅ Complete (audit passed — no mutations after init)
+
+#### Task 3.2: Protect `g_bSpecLibRead` with Proper Synchronization
+- **File(s):** `CometSpecLib.cpp`, `CometSearchManager.cpp`
+- **Description:** `g_bSpecLibRead` is a plain `bool` set at the end of
+`LoadSpecLibMS1Raw()`. Since initialization is single-threaded (Task 1.1), this is
+safe as long as all threads see the write before they start. Verified that the C#
+`InitializeSingleSpectrumMS1Search()` call completes (and its side effects are
+visible) before `Task.Run()` launches worker threads. `Task.Run()` scheduling
+includes an implicit memory barrier guaranteeing visibility.
+- **Action:** Added early-return guard with error message at top of
+  `DoMS1SearchMultiResults()` checking `singleSearchMS1InitializationComplete`
+  as defense-in-depth. No atomic/mutex needed since init is single-threaded
+  and .NET Task scheduling provides the happens-before guarantee.
+- **Status:** ✅ Complete (no code change needed beyond defensive guard)
+
+### Phase 4: Cleanup
+
+#### Task 4.1: Remove `g_pvQueryMS1` from the MS1 Search Path
+- **File(s):** `CometSearchManager.cpp`, `CometSearch.cpp`
+- **Description:** After Tasks 2.1–2.3, `g_pvQueryMS1` is no longer used in the
+single-spectrum MS1 search path. The global vector declaration is retained because
+the batch search path (`RunMS1Search(ThreadPool*,...)` and
+`PreprocessMS1SingleSpectrum()`) still uses it. A documentation comment was added
+to the `g_pvQueryMS1` declaration in `CometSearchManager.cpp` to clarify that it is
+batch-path-only and must not be accessed from `DoMS1SearchMultiResults()`.
+- **Verification:**
+  - [x] `DoMS1SearchMultiResults()` uses only `PreprocessMS1SingleSpectrumThreadLocal()` and
+    `RunMS1Search(QueryMS1*,...)` — no `g_pvQueryMS1` references
+  - [x] `RunMS1Search(QueryMS1*,...)` thread-local overload does not read `g_pvQueryMS1`
+  - [x] `FinalizeSingleSpectrumMS1Search()` cleanup of `g_pvQueryMS1` is safe — vector
+    will be empty since `DoMS1SearchMultiResults()` never populates it
+  - [x] `g_pvQueryMS1` retained for batch path backward compatibility
+- **Status:** ✅ Complete
+
+#### Task 4.2: Verify Wrapper Layer
+- **File(s):** `CometWrapper.cpp`, `CometWrapper.h`
+- **Description:** Confirm the C++/CLI wrapper layer (`CometSearchManagerWrapper`)
+  requires no changes. The wrapper delegates directly to `ICometSearchManager`
+  methods without touching any global state.
+- **Verification:**
+  - [x] `CometWrapper::DoMS1SearchMultiResults()` only calls
+    `_pSearchMgr->DoMS1SearchMultiResults()` and converts outputs
+  - [x] No direct `g_pvQueryMS1` access in wrapper code
+  - [x] Pin pointers used correctly for array marshalling
+- **Status:** ✅ Complete
+
+---
+
+## Summary
+
+All phases complete. The MS1 single-spectrum search path is now fully thread-safe:
+- Reference library loaded once during `InitializeSingleSpectrumMS1Search()`
+- Each concurrent `DoMS1SearchMultiResults()` call uses thread-local `QueryMS1*`
+- No shared mutable state accessed during search
+- `g_pvQueryMS1` retained for batch path only, documented accordingly
+
+### Phase 5: Testing & Validation
+
+#### Task 5.1: Single-Thread MS1 Correctness
+- **Description:** Run with `num_threads=1` and verify:
+- Reference file loaded exactly once (single "loading MS1 scan" message).
+- Dotproduct scores match baseline.
+- No deadlock.
+- **Status:** ☐ Not started
+
+#### Task 5.2: Multi-Thread MS1 Correctness
+- **Description:** Run with N threads (e.g., 4) and verify:
+- Reference file loaded exactly once.
+- Results are identical regardless of thread count.
+- No crashes or data races.
+- **Status:** ☐ Not started
+
+#### Task 5.3: Combined MS1+MS2 Multi-Thread Test
+- **Description:** Run with both `bPerformMS1Search=true` and `bPerformMS2Search=true`,
+N threads. Verify both search types produce correct results concurrently.
+- **Status:** ☐ Not started
+
+#### Task 5.4: Memory Leak Check
+- **Description:** Verify that per-call `QueryMS1` objects and their `pfFastXcorrData`
+arrays are properly freed after each `DoMS1SearchMultiResults()` call.
+- **Status:** ☐ Not started
+
+---
+
+## File Change Summary
+
+| File | Changes |
+|------|---------|
+| `CometSearchManager.cpp` | Move `LoadSpecLibMS1Raw` to init; rewrite `DoMS1SearchMultiResults` to be thread-local; fix `fillPool` deadlock |
+| `CometPreprocess.h` | Declare `PreprocessMS1SingleSpectrumThreadLocal()` |
+| `CometPreprocess.cpp` | Implement `PreprocessMS1SingleSpectrumThreadLocal()` |
+| `CometSearch.h` | Declare `RunMS1Search(QueryMS1*, ...)` overload |
+| `CometSearch.cpp` | Implement thread-local `RunMS1Search(QueryMS1*, ...)` |
+| `CometWrapper.cpp` | No changes expected |
+| `SearchMS1MS2.cs` | No changes expected |
+
+---
+
+## Key Design Principles
+
+1. **Load once, search many.** The reference library (`g_vSpecLib`) is loaded exactly
+ once during `InitializeSingleSpectrumMS1Search()`. After that, it is immutable.
+
+2. **Thread-local query objects.** Each `DoMS1SearchMultiResults()` call creates a
+ heap-local `QueryMS1*`, preprocesses the query spectrum into it, scores against the
+ read-only `g_vSpecLib`, extracts results, and deletes it. Zero shared mutable state.
+
+3. **Same pattern as MS2.** This follows the identical architecturealready proven for
+ `DoSingleSpectrumSearchMultiResults()`: thread-local `Query*` via
+ `PreprocessSingleSpectrumThreadLocal()`, thread-local `RunSearch(Query*)`, and
+ thread-local post-analysis.
+
+4. **Minimal API surface change.** The `ICometSearchManager` interface signatures
+   remain unchanged. All changes are internal implementation details.


### PR DESCRIPTION
Attempt 2 at merging Add concurrent real-time search (RTS) for MS2 and MS1 paths:

Enable N concurrent C# Task threads to each call DoSingleSpectrumSearchMultiResults() and DoMS1SearchMultiResults() without serializing on global state.

MS2 RTS changes (CometSearch, CometPreprocess, CometPostAnalysis, CometSearchManager):
 - Add PreprocessSingleSpectrumCore() as a shared backend; both the existing batch path (PreprocessSingleSpectrum) and the new thread-local path (PreprocessSingleSpectrumThreadLocal) delegate to it
- Add RunSearch(Query*) overload that allocates its own pbDuplFragment scratch buffer and never accesses g_pvQuery or _ppbDuplFragmentArr
- Add SearchFragmentIndex(Query*, bool*) and SearchPeptideIndex(Query*, bool*) thread-local overloads; SearchFragmentIndex reads only g_massRange.uiMaxFragmentArrayIndex, which is set once during init
- Add XcorrScoreI(Query*, ...) / StorePeptideI(Query*, ...) / CheckMassMatch(Query*, double) overloads that accept Query* directly instead of indexing g_pvQuery
- Refactor CometPostAnalysis: CalculateSP, CalculateEValue, CalculateDeltaCn, and CalculateAScorePro now accept Query* directly; the old int iWhichQuery overloads are removed (batch path PostAnalysisThreadProc updated to resolve Query* from g_pvQuery once and pass it through)
- DoSingleSpectrumSearchMultiResults: remove g_pvQuery push/pop and g_pvQueryMutex lock; remove three g_massRange writes that caused data races; replace g_staticParams.tRealTimeStart with per-query pQuery->tSearchStart; replace g_cometStatus.IsError() check (which would poison other concurrent threads) with IsCancel() only; move FILE* fp declaration before cleanup_results label so all paths close it

MS1 RTS changes (CometPreprocess, CometSearch, CometSpecLib, CometSearchManager):
- Add PreprocessMS1SingleSpectrumThreadLocal() returning a heap-local QueryMS1* without touching g_pvQueryMS1
- Add RunMS1Search(QueryMS1*, ...) overload that scores against read-only g_vSpecLib and returns results via output vector
- Move LoadSpecLibMS1Raw() from DoMS1SearchMultiResults into InitializeSingleSpectrumMS1Search() so the library loads exactly once; fix fillPool(iNumThreads-1) deadlock when num_threads=1 by using max(1, iNumThreads-1)
- Add iSpecLibInputType detection from file extension so the spec lib can be opened in the single-spectrum MS1 path where inputFile is not configured; ensure CometPreprocess memory pool is allocated before dispatching PreprocessThreadProcMS1 jobs
- DoMS1SearchMultiResults: remove g_pvQueryMS1 access; protect the shared pMS1Aligner with g_ms1AlignerMutex; guard with singleSearchMS1InitializationComplete atomic flag using acquire/release ordering throughout

Thread-local infrastructure:
- Add CometFragmentIndexReader.h: read-only wrapper for fragment index globals (const pointers prevent accidental modification)
- singleSearchInitializationComplete and singleSearchMS1InitializationComplete are std::atomic<bool> with acquire/release semantics

 C# layer (SearchMS1MS2.cs):
- Rewrite to use a single CometSearchManagerWrapper shared across N concurrent Task.Run() workers; scans distributed via ConcurrentQueue, results collected in ConcurrentBag and sorted after WaitAll
- Accept optional [num_threads] argument (defaults to Environment.ProcessorCount)

CometWrapper fixes bundled in this branch:
- get_dStart() / get_dEnd() corrected from int to double return type (previously truncated mass range bounds silently)
- dAScoreScore property renamed to dAScorePro to match native struct
- InitializeSingleSpectrumMS1Search() gains dMaxQueryRT parameter

Build:
- CometSearch/Makefile: add CometFragmentIndexReader.h to CometSearch.o explicit dependency rule
- Makefile: add CometSearch/CometFragmentIndexReader.h to DEPS
- CometPostAnalysis.h: add missing final newline