### PR TITLE
code optimizations and cleanup

### DIFF
--- a/Comet.cpp
+++ b/Comet.cpp
@@ -941,10 +941,10 @@ compoundmods_file =                    # path to compound mods mass file (one ma
 #\n\
 fragindex_min_ions_score = 3           # minimum number of matched fragment ion index peaks for scoring\n\
 fragindex_min_ions_report = 3          # minimum number of matched fragment ion index peaks for reporting(>= fragindex_min_ions_score)\n\
-fragindex_num_spectrumpeaks = 100      # number of peaks from spectrum to use for fragment ion index matching\n\
+fragindex_num_spectrumpeaks = 150      # number of peaks from spectrum to use for fragment ion index matching\n\
 fragindex_min_fragmentmass = 200.0     # low mass cutoff for fragment ions\n\
 fragindex_max_fragmentmass = 2000.0    # high mass cutoff for fragment ions\n\
-fragindex_skipreadprecursors = 0       # 0=read precursors to limit fragment ion index, 1=skip reading precursors\n\n");
+fragindex_skipreadprecursors = 1       # 0=read precursors to limit fragment ion index, 1=skip reading precursors (default)\n\n");
    }
 
    fprintf(fp,

--- a/Comet.sln
+++ b/Comet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36327.8 d17.14
+VisualStudioVersion = 17.14.36327.8
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Comet", "Comet.vcxproj", "{EC89AD31-11AD-4CE2-AA1D-FFFFF716DE33}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/CometSearch/CometDataInternal.h
+++ b/CometSearch/CometDataInternal.h
@@ -143,7 +143,7 @@ struct Options
    bool bClipNtermAA;            // 0=leave peptide sequences as-is; 1=clip N-term amino acid from every peptide
    bool bMango;                  // 0=normal; 1=Mango x-link ms2 input
    bool bScaleFragmentNL;        // 0=no; 1=scale fragment NL for each modified residue contained in fragment
-   bool bCreateFragmentIndex;    // 0=normal search; 1=create fragment ion index file
+   bool bCreateFragmentIndex;    // 0=normal search; 1=create fragment ion index plain peptide file
    bool bCreatePeptideIndex;     // 0=normal search; 1=create peptide index file; only one of bCreateFragmentIndex and bCreatePeptideIndex can be 1
    bool bVerboseOutput;
    bool bExplicitDeltaCn;        // if set to 1, do not use sequence similarity logic
@@ -448,52 +448,52 @@ struct DBInfo
    }
 };
 
-// this duplicates PlainPeptideIndexStruct but with modsites and fixed peptide char string for simplified binary write/read
 struct DBIndex
 {
-   char szPeptide[MAX_PEPTIDE_LEN];
+   string sPeptide;                                      // peptide sequence
+   vector<char> pcVarModSites;                           // empty = unmodified; else [iLen+2] encoding var mods
+   comet_fileoffset_t lIndexProteinFilePosition;         // points to entry in g_pvProteinsList
+   double dPepMass;                                      // MH+ pep mass
+   unsigned short siVarModProteinFilter;                 // bitwise representation of mmapProtein
    char cPrevAA;
    char cNextAA;
-   char pcVarModSites[MAX_PEPTIDE_LEN_P2];        // encodes 0 to VMODS-1 indicating which var mod at which position
-   comet_fileoffset_t lIndexProteinFilePosition;  // points to entry in g_pvProteinsList
-   double dPepMass;                               // MH+ pep mass
-   unsigned short siVarModProteinFilter;          // bitwise representation of mmapProtein
 
    bool operator==(const DBIndex& rhs) const
    {
-      if (strcmp(szPeptide, rhs.szPeptide) != 0)
+      if (sPeptide != rhs.sPeptide)
          return false;
 
       if (fabs(dPepMass - rhs.dPepMass) > FLOAT_ZERO)
          return false;
 
-      int iLen = (int)strlen(szPeptide) + 2;
+      int iLen = (int)sPeptide.size() + 2;
       for (int i = 0; i < iLen; ++i)
       {
-         if (pcVarModSites[i] != rhs.pcVarModSites[i])
+         char l = pcVarModSites.empty()     ? 0 : pcVarModSites[i];
+         char r = rhs.pcVarModSites.empty() ? 0 : rhs.pcVarModSites[i];
+         if (l != r)
             return false;
       }
-
-      // optionally compare others if meaningful
-      // e.g., siVarModProteinFilter or lIndexProteinFilePosition
 
       return true;
    }
 
    bool operator<(const DBIndex& rhs) const
    {
-      int cmp = strcmp(szPeptide, rhs.szPeptide);
+      int cmp = sPeptide.compare(rhs.sPeptide);
       if (cmp != 0)
          return cmp < 0;
 
       if (fabs(dPepMass - rhs.dPepMass) > FLOAT_ZERO)
          return dPepMass < rhs.dPepMass;
 
-      int iLen = (int)strlen(szPeptide) + 2;
+      int iLen = (int)sPeptide.size() + 2;
       for (int i = 0; i < iLen; ++i)
       {
-         if (pcVarModSites[i] != rhs.pcVarModSites[i])
-            return pcVarModSites[i] < rhs.pcVarModSites[i];
+         char l = pcVarModSites.empty()     ? 0 : pcVarModSites[i];
+         char r = rhs.pcVarModSites.empty() ? 0 : rhs.pcVarModSites[i];
+         if (l != r)
+            return l < r;
       }
 
       // FINAL tie-breaker: lowest protein index first in order

--- a/CometSearch/CometDataInternal.h
+++ b/CometSearch/CometDataInternal.h
@@ -567,8 +567,8 @@ struct RetentionMatch
 };
 extern std::deque<RetentionMatch> RetentionMatchHistory;
 
-extern unsigned int** g_iFragmentIndex;           // 2D array [BIN[fragment mass)][which entries in g_vFragmentPeptides]
-extern unsigned int* g_iCountFragmentIndex;       // array of ints: [BIN(fragment mass)] count size of g_iFragmentIndex[][x]
+extern unsigned int* g_iFragmentIndex;            // CSR flat data: all posting lists concatenated [g_iFragmentIndexOffset[bin]..g_iFragmentIndexOffset[bin+1])
+extern unsigned int* g_iFragmentIndexOffset;      // CSR offsets [uiMaxFragmentArrayIndex+1]: g_iFragmentIndexOffset[b] = start of bin b in g_iFragmentIndex
 extern vector<struct FragmentPeptidesStruct> g_vFragmentPeptides;
 extern vector<PlainPeptideIndexStruct> g_vRawPeptides;
 extern bool* g_bIndexPrecursors;     // allocate an array of BIN(max_precursor, protonated) and use a bool to indicate if that precursor is present in input file(s)

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -467,8 +467,6 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
       // Store the current peptide; iWhichFragmentPeptide references this peptide entry
       // for use in the g_iFragmentIndex fragment index.  As this is a global list of
       // peptides, need to lock when updating to avoid thread conflicts
-
-//      Threading::LockMutex(_vFragmentPeptidesMutex);
       if (g_vFragmentPeptides.size() >= UINT_MAX)
       {
          printf(" Error in CometFragmentIndex; UINT_MAX (%d) peptides reached.\n", UINT_MAX);
@@ -476,7 +474,6 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
       }
       // store peptide representation based on sequence (iWhichPeptide), modification state (modNumIdx), and mass (dPepMass)
       g_vFragmentPeptides.push_back(sTmp);
-//      Threading::UnlockMutex(_vFragmentPeptidesMutex);
    }
 
 /*
@@ -828,15 +825,15 @@ bool CometFragmentIndex::WriteFIPlainPeptideIndex(ThreadPool *tp)
    // now permute mods on the peptides
    PermuteIndexPeptideMods(g_vRawPeptides);
  
-   unsigned long ulSizeModSeqs = (unsigned long)MOD_SEQS.size();              // size of MOD_SEQS
-   unsigned long ulSizevRawPeptides = (unsigned long)g_vRawPeptides.size();   // size of g_vRawPeptides
-   unsigned long ulModNumSize = (unsigned long)MOD_NUMBERS.size();            // size of MOD_NUMBERS
+   uint64_t ulSizeModSeqs = (uint64_t)MOD_SEQS.size();              // size of MOD_SEQS
+   uint64_t ulSizevRawPeptides = (uint64_t)g_vRawPeptides.size();   // size of g_vRawPeptides
+   uint64_t ulModNumSize = (uint64_t)MOD_NUMBERS.size();            // size of MOD_NUMBERS
 
    comet_fileoffset_t clPermutationsFilePos = comet_ftell(fp);
 
-   fwrite(&ulSizeModSeqs, sizeof(unsigned long), 1, fp);
-   fwrite(&ulSizevRawPeptides, sizeof(unsigned long), 1, fp);
-   fwrite(&ulModNumSize, sizeof(unsigned long), 1, fp);
+   fwrite(&ulSizeModSeqs, sizeof(uint64_t), 1, fp);
+   fwrite(&ulSizevRawPeptides, sizeof(uint64_t), 1, fp);
+   fwrite(&ulModNumSize, sizeof(uint64_t), 1, fp);
    fwrite(MOD_SEQ_MOD_NUM_START, sizeof(int), ulSizeModSeqs, fp);
    fwrite(MOD_SEQ_MOD_NUM_CNT, sizeof(int), ulSizeModSeqs, fp);
    fwrite(PEPTIDE_MOD_SEQ_IDXS, sizeof(int), ulSizevRawPeptides, fp);
@@ -894,6 +891,7 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
       printf(" Error - cannot open index file %s to read\n", strIndexFile.c_str());
       exit(1);
    }
+   setvbuf(fp, NULL, _IOFBF, 32 * 1024 * 1024);
 
    bool bFoundStatic = false;
    bool bFoundVariable= false;
@@ -1096,6 +1094,8 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
    comet_fileoffset_t clProteinsFilePos;      // file position of g_pvProteinsList
    comet_fileoffset_t clPermutationsFilePos;  // file position of permutations variables
 
+   comet_fseek(fp, 0, SEEK_END);
+   comet_fileoffset_t clFileSize = comet_ftell(fp);
    comet_fseek(fp, -clSizeCometFileOffset*3, SEEK_END);
    tTmp = fread(&clPeptidesFilePos, clSizeCometFileOffset, 1, fp);
    tTmp = fread(&clProteinsFilePos, clSizeCometFileOffset, 1, fp);
@@ -1106,58 +1106,66 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
    size_t tNumPeptides;
    tTmp = fread(&tNumPeptides, sizeof(size_t), 1, fp);  // read # of peptides
 
-   struct PlainPeptideIndexStruct sTmp;
-   int iLen;
-   char szPeptide[MAX_PEPTIDE_LEN];
-
-   g_vRawPeptides.clear();
-   for (size_t it = 0; it < tNumPeptides; ++it)
+   // Read entire raw peptides section in one shot, then parse from memory.
+   // This eliminates per-element fread lock overhead (~7 calls x 4M peptides).
    {
-      tTmp = fread(&iLen, sizeof(int), 1, fp);
-      tTmp = fread(szPeptide, sizeof(char), iLen, fp);
-      szPeptide[iLen] = '\0';
-      sTmp.sPeptide = szPeptide;
-      tTmp = fread(&(sTmp.cPrevAA), sizeof(char), 1, fp);
-      tTmp = fread(&(sTmp.cNextAA), sizeof(char), 1, fp);
-      tTmp = fread(&(sTmp.dPepMass), sizeof(double), 1, fp);
-      tTmp = fread(&(sTmp.siVarModProteinFilter), sizeof(unsigned short), 1, fp);
-      tTmp = fread(&(sTmp.lIndexProteinFilePosition), clSizeCometFileOffset, 1, fp);
+      size_t pepSectionSize = (size_t)(clProteinsFilePos - clPeptidesFilePos) - sizeof(size_t);
+      vector<char> pepBuf(pepSectionSize);
+      fread(pepBuf.data(), 1, pepSectionSize, fp);
+      const char* p = pepBuf.data();
 
-      g_vRawPeptides.push_back(sTmp);
-   }
-
-   comet_fseek(fp, clProteinsFilePos, SEEK_SET);  // should be at this file position here anyways already
-
-   // now read in: vector<vector<comet_fileoffset_t>> g_pvProteinsList
-   size_t tSize;
-   tTmp = fread(&tSize, clSizeCometFileOffset, 1, fp);
-   vector<comet_fileoffset_t> vTmp;
-
-   g_pvProteinsList.clear();
-   g_pvProteinsList.reserve(tSize);
-   for (size_t it = 0; it < tSize; ++it)
-   {
-      size_t tNumProteinOffsets;
-      tTmp = fread(&tNumProteinOffsets, clSizeCometFileOffset, 1, fp);
-      
-      vTmp.clear();
-      for (size_t it2 = 0; it2 < tNumProteinOffsets; ++it2)
+      struct PlainPeptideIndexStruct sTmp;
+      g_vRawPeptides.clear();
+      g_vRawPeptides.reserve(tNumPeptides);
+      for (size_t it = 0; it < tNumPeptides; ++it)
       {
-         tTmp = fread(&clTmp, clSizeCometFileOffset, 1, fp);
-         vTmp.push_back(clTmp);
+         int iLen;
+         memcpy(&iLen, p, sizeof(int));                                     p += sizeof(int);
+         sTmp.sPeptide.assign(p, iLen);                                     p += iLen;
+         sTmp.cPrevAA = *p++;
+         sTmp.cNextAA = *p++;
+         memcpy(&sTmp.dPepMass, p, sizeof(double));                         p += sizeof(double);
+         memcpy(&sTmp.siVarModProteinFilter, p, sizeof(unsigned short));     p += sizeof(unsigned short);
+         memcpy(&sTmp.lIndexProteinFilePosition, p, clSizeCometFileOffset);  p += clSizeCometFileOffset;
+         g_vRawPeptides.push_back(std::move(sTmp));
       }
-      g_pvProteinsList.push_back(vTmp);
    }
 
-   comet_fseek(fp, clPermutationsFilePos, SEEK_SET);  // should be at this file position here anyways already
+   // Read entire proteins list section in one shot, then parse from memory.
+   comet_fseek(fp, clProteinsFilePos, SEEK_SET);
+   {
+      size_t protSectionSize = (size_t)(clPermutationsFilePos - clProteinsFilePos);
+      vector<char> protBuf(protSectionSize);
+      fread(protBuf.data(), 1, protSectionSize, fp);
+      const char* p = protBuf.data();
 
-   unsigned long ulSizeModSeqs;        // size of MOD_SEQS
-   unsigned long ulSizevRawPeptides;   // size of g_vRawPeptides
-   unsigned long ulModNumSize;         // size of MOD_NUMBERS
+      size_t tSize;
+      memcpy(&tSize, p, sizeof(comet_fileoffset_t));
+      p += sizeof(comet_fileoffset_t);
 
-   tTmp = fread(&ulSizeModSeqs, sizeof(unsigned long), 1, fp);
-   tTmp = fread(&ulSizevRawPeptides, sizeof(unsigned long), 1, fp);
-   tTmp = fread(&ulModNumSize, sizeof(unsigned long), 1, fp);
+      g_pvProteinsList.clear();
+      g_pvProteinsList.reserve(tSize);
+      for (size_t it = 0; it < tSize; ++it)
+      {
+         size_t tNumProteinOffsets;
+         memcpy(&tNumProteinOffsets, p, sizeof(comet_fileoffset_t));
+         p += sizeof(comet_fileoffset_t);
+
+         const comet_fileoffset_t* src = reinterpret_cast<const comet_fileoffset_t*>(p);
+         g_pvProteinsList.emplace_back(src, src + tNumProteinOffsets);
+         p += tNumProteinOffsets * sizeof(comet_fileoffset_t);
+      }
+   }
+
+   comet_fseek(fp, clPermutationsFilePos, SEEK_SET);
+
+   uint64_t ulSizeModSeqs;        // size of MOD_SEQS
+   uint64_t ulSizevRawPeptides;   // size of g_vRawPeptides
+   uint64_t ulModNumSize;         // size of MOD_NUMBERS
+
+   tTmp = fread(&ulSizeModSeqs, sizeof(uint64_t), 1, fp);
+   tTmp = fread(&ulSizevRawPeptides, sizeof(uint64_t), 1, fp);
+   tTmp = fread(&ulModNumSize, sizeof(uint64_t), 1, fp);
 
    MOD_SEQ_MOD_NUM_START = new int[ulSizeModSeqs];
    MOD_SEQ_MOD_NUM_CNT = new int[ulSizeModSeqs];
@@ -1165,29 +1173,36 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
 
    tTmp = fread(MOD_SEQ_MOD_NUM_START, sizeof(int), ulSizeModSeqs, fp);
    tTmp = fread(MOD_SEQ_MOD_NUM_CNT, sizeof(int), ulSizeModSeqs, fp);
-   tTmp = fread(PEPTIDE_MOD_SEQ_IDXS, sizeof(int), ulSizevRawPeptides, fp);  //FIX, why??
+   tTmp = fread(PEPTIDE_MOD_SEQ_IDXS, sizeof(int), ulSizevRawPeptides, fp);
 
-   int iTmp;
-   char szTmp[MAX_PEPTIDE_LEN];
-   MOD_SEQS.clear();
-   for (unsigned long i = 0; i < ulSizeModSeqs; ++i)
+   // Read variable-length tail (MOD_SEQS + MOD_NUMBERS) in one shot.
    {
-      tTmp = fread(&iTmp, sizeof(int), 1, fp); // read length
-      tTmp = fread(szTmp, 1, iTmp, fp);
-      szTmp[iTmp]='\0';
-      MOD_SEQS.push_back(szTmp);
-   }
-   MOD_NUMBERS.clear();
-   for (unsigned long i = 0; i < ulModNumSize; ++i)
-   {
-      ModificationNumber sTmp;
-      tTmp = fread(&iTmp, sizeof(int), 1, fp); // read length
-      tTmp = fread(szTmp, 1, iTmp, fp);
-      szTmp[iTmp]='\0';
-      sTmp.modStringLen = iTmp;
-      sTmp.modifications = new char[iTmp];
-      memcpy(sTmp.modifications, szTmp, iTmp);
-      MOD_NUMBERS.push_back(sTmp);
+      comet_fileoffset_t clFooterPos = clFileSize - (comet_fileoffset_t)clSizeCometFileOffset * 3;
+      comet_fileoffset_t varDataStart = comet_ftell(fp);
+      size_t varDataSize = (size_t)(clFooterPos - varDataStart);
+      vector<char> varBuf(varDataSize);
+      fread(varBuf.data(), 1, varDataSize, fp);
+      const char* p = varBuf.data();
+
+      int iTmp;
+      MOD_SEQS.clear();
+      MOD_SEQS.reserve(ulSizeModSeqs);
+      for (uint64_t i = 0; i < ulSizeModSeqs; ++i)
+      {
+         memcpy(&iTmp, p, sizeof(int)); p += sizeof(int);
+         MOD_SEQS.emplace_back(p, iTmp); p += iTmp;
+      }
+
+      MOD_NUMBERS.clear();
+      MOD_NUMBERS.reserve(ulModNumSize);
+      for (uint64_t i = 0; i < ulModNumSize; ++i)
+      {
+         ModificationNumber mTmp;
+         memcpy(&mTmp.modStringLen, p, sizeof(int)); p += sizeof(int);
+         mTmp.modifications = new char[mTmp.modStringLen];
+         memcpy(mTmp.modifications, p, mTmp.modStringLen); p += mTmp.modStringLen;
+         MOD_NUMBERS.push_back(mTmp);
+      }
    }
 
    fclose(fp);

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -37,6 +37,10 @@ size_t tTmp;
 
 Mutex CometFragmentIndex::_vFragmentPeptidesMutex;
 
+// Temporary write-position array used only during the index fill pass.
+// Initialized to g_iFragmentIndexOffset[0..n-1] before filling, freed after.
+static unsigned int* s_iWritePos = nullptr;
+
 
 #ifdef _WIN32
 #ifdef _WIN64
@@ -68,8 +72,8 @@ bool CometFragmentIndex::CreateFragmentIndex(ThreadPool *tp)
    // - modification encoding index
    // - modification mass
 
-   g_iFragmentIndex = new unsigned int* [g_massRange.uiMaxFragmentArrayIndex];
-   g_iCountFragmentIndex = new unsigned int[g_massRange.uiMaxFragmentArrayIndex]();
+   // CSR layout: allocate offset array now (size+1 for sentinel); flat data allocated after counting.
+   g_iFragmentIndexOffset = new unsigned int[g_massRange.uiMaxFragmentArrayIndex + 1]();
 
    // generate the modified peptides to calculate the fragment index
    GenerateFragmentIndex(tp);
@@ -163,17 +167,24 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
    AddFragmentsThreadProc(1, pFragmentIndexPool);
    pFragmentIndexPool->wait_on_threads();
 
-   // now reserve memory for the fragment index vectors
-   for (unsigned int iMass = 0; iMass < g_massRange.uiMaxFragmentArrayIndex; ++iMass)
+   // Convert per-bin counts (stored in g_iFragmentIndexOffset[0..n-1] during count pass)
+   // to CSR prefix-sum offsets, then allocate the single flat data array.
    {
-      if (g_iCountFragmentIndex[iMass] > 0)
+      unsigned int uiTotal = 0;
+      for (unsigned int iMass = 0; iMass < g_massRange.uiMaxFragmentArrayIndex; ++iMass)
       {
-         g_iFragmentIndex[iMass] = new unsigned int[g_iCountFragmentIndex[iMass]];
-         g_iCountFragmentIndex[iMass] = 0;  // reset to zero as this will  be used to determine g_iFragmentIndex fill position
+         unsigned int uiCnt = g_iFragmentIndexOffset[iMass];
+         g_iFragmentIndexOffset[iMass] = uiTotal;
+         uiTotal += uiCnt;
       }
-      else
-         g_iFragmentIndex[iMass] = NULL;
+      g_iFragmentIndexOffset[g_massRange.uiMaxFragmentArrayIndex] = uiTotal;  // sentinel
+      g_iFragmentIndex = new unsigned int[uiTotal];
    }
+
+   // Initialize per-bin write positions as a copy of the base offsets.
+   s_iWritePos = new unsigned int[g_massRange.uiMaxFragmentArrayIndex];
+   memcpy(s_iWritePos, g_iFragmentIndexOffset, sizeof(unsigned int) * g_massRange.uiMaxFragmentArrayIndex);
+
    cout << CometMassSpecUtils::ElapsedTime(tStartTime) << endl;
 
    // now sort g_vFragmentPeptides by mass; this was filled in the above AddFragmentsThreadProc calls
@@ -206,14 +217,14 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
    pFragmentIndexPool->wait_on_threads();
    cout << CometMassSpecUtils::ElapsedTime(tStartTime) << endl;
 
+   // Write positions no longer needed after fill.
+   delete[] s_iWritePos;
+   s_iWritePos = nullptr;
+
    Threading::DestroyMutex(_vFragmentPeptidesMutex);
 
-   unsigned long long ullCount = 0;
-   for (unsigned int iMass = 0; iMass < g_massRange.uiMaxFragmentArrayIndex; ++iMass)
-   {
-      // count and report the # of entries in the fragment index
-      ullCount += g_iCountFragmentIndex[iMass];
-   }
+   // Total entry count is the CSR sentinel value.
+   unsigned long long ullCount = g_iFragmentIndexOffset[g_massRange.uiMaxFragmentArrayIndex];
 
    if (g_vFragmentPeptides.size() > 1e6)
       printf("   - %0.3e total peptides, ", (double)g_vFragmentPeptides.size());
@@ -531,13 +542,9 @@ if (!(iWhichPeptide%1000))
             }
 
             if (bCountOnly)
-               g_iCountFragmentIndex[iBinBion] += 1;
+               g_iFragmentIndexOffset[iBinBion] += 1;
             else
-            {
-               int iEntry = g_iCountFragmentIndex[iBinBion];
-               g_iFragmentIndex[iBinBion][iEntry] = static_cast<unsigned int>(iWhichFragmentPeptide);
-               g_iCountFragmentIndex[iBinBion] += 1;
-            }
+               g_iFragmentIndex[s_iWritePos[iBinBion]++] = static_cast<unsigned int>(iWhichFragmentPeptide);
          }
 
          if (dYion > g_staticParams.options.dFragIndexMinMass && dYion < g_staticParams.options.dFragIndexMaxMass)
@@ -551,13 +558,9 @@ if (!(iWhichPeptide%1000))
             }
 
             if (bCountOnly)
-               g_iCountFragmentIndex[iBinYion] += 1;
+               g_iFragmentIndexOffset[iBinYion] += 1;
             else
-            {
-               int iEntry = g_iCountFragmentIndex[iBinYion];
-               g_iFragmentIndex[iBinYion][iEntry] = static_cast<unsigned int>(iWhichFragmentPeptide);
-               g_iCountFragmentIndex[iBinYion] += 1;
-            }
+               g_iFragmentIndex[s_iWritePos[iBinYion]++] = static_cast<unsigned int>(iWhichFragmentPeptide);
          }
       }
    }

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -672,7 +672,7 @@ bool CometFragmentIndex::WriteFIPlainPeptideIndex(ThreadPool *tp)
       else
       {
          // each unique peptide will have the same list of matched proteins
-         if (!strcmp(g_pvDBIndex.at(i).szPeptide, g_pvDBIndex.at(i-1).szPeptide))
+         if (g_pvDBIndex.at(i).sPeptide == g_pvDBIndex.at(i-1).sPeptide)
          {
             // store protein as peptides are the same
             temp.push_back(g_pvDBIndex.at(i).lIndexProteinFilePosition);
@@ -772,18 +772,18 @@ bool CometFragmentIndex::WriteFIPlainPeptideIndex(ThreadPool *tp)
 
    for (std::vector<DBIndex>::iterator it = g_pvDBIndex.begin(); it != g_pvDBIndex.end(); ++it)
    {
-      int iLen = (int)strlen((*it).szPeptide);
+      int iLen = (int)(*it).sPeptide.size();
       struct PlainPeptideIndexStruct sTmp;
 
       fwrite(&iLen, sizeof(int), 1, fp);
-      fwrite((*it).szPeptide, sizeof(char), iLen, fp);
+      fwrite((*it).sPeptide.c_str(), sizeof(char), iLen, fp);
       fwrite(&((*it).cPrevAA), sizeof(char), 1, fp); // write prev AA
       fwrite(&((*it).cNextAA), sizeof(char), 1, fp); // write next AA
       fwrite(&((*it).dPepMass), sizeof(double), 1, fp);
       fwrite(&((*it).siVarModProteinFilter), sizeof(unsigned short), 1, fp);
       fwrite(&((*it).lIndexProteinFilePosition), clSizeCometFileOffset, 1, fp);
 
-      sTmp.sPeptide = (*it).szPeptide;
+      sTmp.sPeptide = (*it).sPeptide;
       sTmp.lIndexProteinFilePosition = (*it).lIndexProteinFilePosition;
       sTmp.dPepMass = (*it).dPepMass;
       sTmp.siVarModProteinFilter = (*it).siVarModProteinFilter;

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -160,7 +160,7 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
 
    // Sort the peptides by mass
 
-   cout <<  "   - storing peptide list and reserving memory ... "; fflush(stdout);
+   cout <<  "   - store peptide list and reserve memory ... "; fflush(stdout);
    auto tStartTime = chrono::steady_clock::now();
    // stupid workaround for Windows/Visual Studio performance ... first calculate all
    // fragments to find size of each fragment on index vector
@@ -189,7 +189,7 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
 
    // now sort g_vFragmentPeptides by mass; this was filled in the above AddFragmentsThreadProc calls
    tStartTime = chrono::steady_clock::now();
-   cout << "   - sorting peptides by mass ... "; fflush(stdout);
+   cout << "   - sort peptides by mass ... "; fflush(stdout);
    sort(g_vFragmentPeptides.begin(), g_vFragmentPeptides.end(), [](const FragmentPeptidesStruct& a, const FragmentPeptidesStruct& b)
       {
          return a.dPepMass < b.dPepMass;
@@ -208,7 +208,7 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
 
    // now populate the fragment index vector
    tStartTime = chrono::steady_clock::now();
-   cout <<  "   - populating index ... "; fflush(stdout);
+   cout <<  "   - populate index ... "; fflush(stdout);
    for (size_t iWhichFragmentPeptide = 0; iWhichFragmentPeptide < g_vFragmentPeptides.size(); ++iWhichFragmentPeptide)
    {
       auto& fp = g_vFragmentPeptides[iWhichFragmentPeptide];

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -1140,7 +1140,7 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
       const char* p = protBuf.data();
 
       size_t tSize;
-      memcpy(&tSize, p, sizeof(comet_fileoffset_t));
+      memcpy(&tSize, p, sizeof(comet_fileoffset_t));  // written with clSizeCometFileOffset
       p += sizeof(comet_fileoffset_t);
 
       g_pvProteinsList.clear();
@@ -1148,11 +1148,12 @@ bool CometFragmentIndex::ReadPlainPeptideIndex(void)
       for (size_t it = 0; it < tSize; ++it)
       {
          size_t tNumProteinOffsets;
-         memcpy(&tNumProteinOffsets, p, sizeof(comet_fileoffset_t));
-         p += sizeof(comet_fileoffset_t);
+         memcpy(&tNumProteinOffsets, p, sizeof(size_t));  // written with sizeof(size_t)
+         p += sizeof(size_t);
 
-         const comet_fileoffset_t* src = reinterpret_cast<const comet_fileoffset_t*>(p);
-         g_pvProteinsList.emplace_back(src, src + tNumProteinOffsets);
+         vector<comet_fileoffset_t> vTmp(tNumProteinOffsets);
+         memcpy(vTmp.data(), p, tNumProteinOffsets * sizeof(comet_fileoffset_t));
+         g_pvProteinsList.push_back(std::move(vTmp));
          p += tNumProteinOffsets * sizeof(comet_fileoffset_t);
       }
    }

--- a/CometSearch/CometFragmentIndexReader.h
+++ b/CometSearch/CometFragmentIndexReader.h
@@ -24,8 +24,8 @@ class FragmentIndexReader
 {
 public:
    FragmentIndexReader()
-      : m_iFragmentIndex(const_cast<const unsigned int* const*>(g_iFragmentIndex))
-      , m_iCountFragmentIndex(const_cast<const unsigned int*>(g_iCountFragmentIndex))
+      : m_iFragmentIndex(g_iFragmentIndex)
+      , m_iFragmentIndexOffset(g_iFragmentIndexOffset)
       , m_vFragmentPeptides(g_vFragmentPeptides)
       , m_vRawPeptides(g_vRawPeptides)
       , m_pvProteinsList(g_pvProteinsList)
@@ -35,12 +35,12 @@ public:
    // Const-only access methods
    inline unsigned int GetFragmentIndexEntry(unsigned int bin, size_t idx) const
    {
-      return m_iFragmentIndex[bin][idx];
+      return m_iFragmentIndex[m_iFragmentIndexOffset[bin] + idx];
    }
 
    inline unsigned int GetFragmentCount(unsigned int bin) const
    {
-      return m_iCountFragmentIndex[bin];
+      return m_iFragmentIndexOffset[bin + 1] - m_iFragmentIndexOffset[bin];
    }
 
    inline const FragmentPeptidesStruct& GetFragmentPeptide(size_t idx) const
@@ -60,8 +60,8 @@ public:
 
 private:
    // Const pointers prevent modification
-   const unsigned int* const* m_iFragmentIndex;
-   const unsigned int* m_iCountFragmentIndex;
+   const unsigned int* m_iFragmentIndex;
+   const unsigned int* m_iFragmentIndexOffset;
    const vector<struct FragmentPeptidesStruct>& m_vFragmentPeptides;
    const vector<PlainPeptideIndexStruct>& m_vRawPeptides;
    const vector<vector<comet_fileoffset_t>>& m_pvProteinsList;

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -471,7 +471,7 @@ string CometMassSpecUtils::ElapsedTime(std::chrono::time_point<std::chrono::stea
 bool CometMassSpecUtils::DBICompareByPeptide(const DBIndex& lhs,
                                              const DBIndex& rhs)
 {
-   if (!strcmp(lhs.szPeptide, rhs.szPeptide))
+   if (lhs.sPeptide == rhs.sPeptide)
    {
       // peptides are same here so look at mass next
       if (fabs(lhs.dPepMass - rhs.dPepMass) > FLOAT_ZERO)
@@ -486,17 +486,18 @@ bool CometMassSpecUtils::DBICompareByPeptide(const DBIndex& lhs,
       // FIX: if protein terminal mods are specified, address them
 
       // at this point, same peptide, same mass, same mods so return first protein
-      if (lhs.lIndexProteinFilePosition < rhs.lIndexProteinFilePosition)
-         return true;
-      else
-         return false;
+      if (lhs.lIndexProteinFilePosition != rhs.lIndexProteinFilePosition)
+         return lhs.lIndexProteinFilePosition < rhs.lIndexProteinFilePosition;
+
+      // same peptide, mass, and protein position so compare flanking residues
+      if (lhs.cPrevAA != rhs.cPrevAA)
+         return lhs.cPrevAA < rhs.cPrevAA;
+
+      return lhs.cNextAA < rhs.cNextAA;
    }
 
    // peptides are different
-   if (strcmp(lhs.szPeptide, rhs.szPeptide) < 0)
-      return true;
-   else
-      return false;
+   return lhs.sPeptide < rhs.sPeptide;
 };
 
 
@@ -515,18 +516,16 @@ bool CometMassSpecUtils::DBICompareByMass(const DBIndex& lhs,
 
    // at this point, peptides are same mass so next need to compare sequences
 
-   if (!strcmp(lhs.szPeptide, rhs.szPeptide))
+   if (lhs.sPeptide == rhs.sPeptide)
    {
       // same sequences and masses here so next look at mod state
-      for (unsigned int i = 0; i < strlen(lhs.szPeptide) + 2; ++i)
+      size_t iLen = lhs.sPeptide.size() + 2;
+      for (size_t i = 0; i < iLen; ++i)
       {
-         if (lhs.pcVarModSites[i] != rhs.pcVarModSites[i])
-         {
-            if (lhs.pcVarModSites[i] > rhs.pcVarModSites[i])
-               return true;
-            else
-               return false;
-         }
+         char l = lhs.pcVarModSites.empty()     ? 0 : lhs.pcVarModSites[i];
+         char r = rhs.pcVarModSites.empty()     ? 0 : rhs.pcVarModSites[i];
+         if (l != r)
+            return l > r;
       }
 
       // at this point, same peptide, same mass, same mods so return first protein
@@ -537,9 +536,6 @@ bool CometMassSpecUtils::DBICompareByMass(const DBIndex& lhs,
    }
 
    // if here, peptide sequences are different (but w/same mass) so sort alphabetically
-   if (strcmp(lhs.szPeptide, rhs.szPeptide) < 0)
-      return true;
-   else
-      return false;
+   return lhs.sPeptide < rhs.sPeptide;
 
 }

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -460,9 +460,9 @@ string CometMassSpecUtils::ElapsedTime(std::chrono::time_point<std::chrono::stea
 
    string sReturn;
    if (minutes > 0)
-      sReturn = std::to_string(minutes) + " min " + std::to_string(seconds) + " sec";
+      sReturn = std::to_string(minutes) + "m:" + std::to_string(seconds) + "s";
    else
-      sReturn = std::to_string(seconds) + " sec";
+      sReturn = std::to_string(seconds) + "s";
 
    return sReturn;
 }

--- a/CometSearch/CometPeptideIndex.cpp
+++ b/CometSearch/CometPeptideIndex.cpp
@@ -268,7 +268,7 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool* tp)
       {
          // each unique peptide, irregardless of mod state, will have the same list
          // of matched proteins
-         if (!strcmp(g_pvDBIndex.at(i).szPeptide, g_pvDBIndex.at(i - 1).szPeptide))
+         if (g_pvDBIndex.at(i).sPeptide == g_pvDBIndex.at(i - 1).sPeptide)
          {
             temp.push_back(g_pvDBIndex.at(i).lIndexProteinFilePosition);
             g_pvDBIndex.at(i).lIndexProteinFilePosition = lProtCount;
@@ -438,9 +438,9 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool* tp)
             lIndex[iPrevMass10] = comet_ftell(fptr);
       }
 
-      int iLen = (int)strlen((*it).szPeptide);
+      int iLen = (int)(*it).sPeptide.size();
       fwrite(&iLen, sizeof(int), 1, fptr);
-      fwrite((*it).szPeptide, sizeof(char), iLen, fptr);
+      fwrite((*it).sPeptide.c_str(), sizeof(char), iLen, fptr);
 
       fwrite(&((*it).cPrevAA), sizeof(char), 1, fptr);
       fwrite(&((*it).cNextAA), sizeof(char), 1, fptr);
@@ -448,10 +448,13 @@ bool CometPeptideIndex::WritePeptideIndex(ThreadPool* tp)
       // write out for char 0=no mod, N=mod.  If N, write out var mods as N pairs (pos,whichmod)
       int iLen2 = iLen + 2;
       unsigned char cNumMods = 0;
-      for (unsigned char x = 0; x < iLen2; x++)
+      if (!(*it).pcVarModSites.empty())
       {
-         if ((*it).pcVarModSites[x] != 0)
-            cNumMods++;
+         for (unsigned char x = 0; x < iLen2; x++)
+         {
+            if ((*it).pcVarModSites[x] != 0)
+               cNumMods++;
+         }
       }
       fwrite(&cNumMods, sizeof(unsigned char), 1, fptr);
 
@@ -518,9 +521,9 @@ bool CometPeptideIndex::ReadPeptideIndexEntry(struct DBIndex* sDBI, FILE* fp)
 
    tTmp = fread(&iLen, sizeof(int), 1, fp);
    if (tTmp != 1) return false;
-   tTmp = fread(sDBI->szPeptide, sizeof(char), iLen, fp);
+   sDBI->sPeptide.resize(iLen);
+   tTmp = fread(&sDBI->sPeptide[0], sizeof(char), iLen, fp);
    if (tTmp != (size_t)iLen) return false;
-   sDBI->szPeptide[iLen] = '\0';
 
    tTmp = fread(&(sDBI->cPrevAA), sizeof(char), 1, fp);
    if (tTmp != 1) return false;
@@ -531,10 +534,10 @@ bool CometPeptideIndex::ReadPeptideIndexEntry(struct DBIndex* sDBI, FILE* fp)
    tTmp = fread(&cNumMods, sizeof(unsigned char), 1, fp);  // read how many var mods are stored
    if (tTmp != 1) return false;
 
-   // Issue 3: Add parentheses for correct precedence: sizeof(unsigned char) * (iLen + 2)
-   memset(sDBI->pcVarModSites, 0, sizeof(unsigned char) * (iLen + 2));
+   sDBI->pcVarModSites.clear();
    if (cNumMods > 0)
    {
+      sDBI->pcVarModSites.assign(iLen + 2, 0);
       for (unsigned char x = 0; x < cNumMods; x++)
       {
          unsigned char cPosition;

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -1399,7 +1399,7 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
 
       if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
       {
-         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
+         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < g_staticParams.options.iFragIndexNumSpectrumPeaks)
          {
             pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
             iNumFragmentPeaks++;
@@ -2356,7 +2356,7 @@ bool CometPreprocess::LoadIons(struct Query *pScoring,
 
    int iNumFragmentPeaks = 0;
 
-   if (g_staticParams.iDbType != DbType::FASTA_DB && mstSpectrum.size() > FRAGINDEX_MAX_NUMPEAKS)
+   if (g_staticParams.iDbType != DbType::FASTA_DB && mstSpectrum.size() > g_staticParams.options.iFragIndexNumSpectrumPeaks)
    {
       // sorts spectrum in ascending order by intensity
       mstSpectrum.sortIntensity();
@@ -2376,7 +2376,7 @@ bool CometPreprocess::LoadIons(struct Query *pScoring,
 
       if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
       {
-         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < FRAGINDEX_MAX_NUMPEAKS)
+         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < g_staticParams.options.iFragIndexNumSpectrumPeaks)
          {
             // Store list of fragment masses for fragment index search
             // Intensities don't matter here. Note that peaks are sorted in

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -91,6 +91,46 @@ bool CometSearch::DeallocateMemory(int maxNumThreads)
 }
 
 
+// Spin-wait under g_searchMemoryPoolMutex until a free slot is found.
+// Returns the slot index (0..iNumThreads-1), or -1 on timeout.
+int CometSearch::AcquirePoolSlot()
+{
+   int i = -1;
+
+   Threading::LockMutex(g_searchMemoryPoolMutex);
+   auto tStartTime = std::chrono::high_resolution_clock::now();
+   const auto timeout_duration = std::chrono::seconds(240);
+
+   while (true)
+   {
+      for (i = 0; i < g_staticParams.options.iNumThreads; ++i)
+      {
+         if (_pbSearchMemoryPool[i] == false)
+         {
+            _pbSearchMemoryPool[i] = true;
+            break;
+         }
+      }
+
+      if (i < g_staticParams.options.iNumThreads)
+         break;
+
+      if (std::chrono::high_resolution_clock::now() - tStartTime > timeout_duration)
+      {
+         i = -1;
+         break;
+      }
+
+      Threading::UnlockMutex(g_searchMemoryPoolMutex);
+      std::this_thread::yield();
+      Threading::LockMutex(g_searchMemoryPoolMutex);
+   }
+   Threading::UnlockMutex(g_searchMemoryPoolMutex);
+
+   return i;
+}
+
+
 // Task 1.3: Thread-local overload.
 bool CometSearch::RunSearch(Query* pQuery)
 {
@@ -104,9 +144,14 @@ bool CometSearch::RunSearch(Query* pQuery)
          return false;
       }
 
-      bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal]();
-      SearchFragmentIndex(pQuery, pbDuplFragment);
-      delete[] pbDuplFragment;
+      int iSlot = AcquirePoolSlot();
+      if (iSlot < 0)
+      {
+         logerr(" Error - could not acquire memory pool slot for thread-local FI search.\n");
+         return false;
+      }
+      SearchFragmentIndex(pQuery, _ppbDuplFragmentArr[iSlot]);
+      _pbSearchMemoryPool[iSlot] = false;
    }
    else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
@@ -141,9 +186,14 @@ bool CometSearch::RunSearch(Query* pQuery)
          Threading::UnlockMutex(g_pvDBIndexMutex);
       }
 
-      bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal]();
-      SearchPeptideIndex(pQuery, pbDuplFragment);
-      delete[] pbDuplFragment;
+      int iSlot = AcquirePoolSlot();
+      if (iSlot < 0)
+      {
+         logerr(" Error - could not acquire memory pool slot for thread-local PI search.\n");
+         return false;
+      }
+      SearchPeptideIndex(pQuery, _ppbDuplFragmentArr[iSlot]);
+      _pbSearchMemoryPool[iSlot] = false;
    }
    else
    {
@@ -172,7 +222,14 @@ bool CometSearch::RunSearch(ThreadPool *tp)
          sqFI.CreateFragmentIndex(tp);
       }
 
-      sqSearch.SearchFragmentIndex(iWhichQuery, tp);
+      int iSlot = AcquirePoolSlot();
+      if (iSlot < 0)
+      {
+         logerr(" Error - could not acquire memory pool slot for single-query FI search.\n");
+         return false;
+      }
+      SearchFragmentIndex(g_pvQuery.at(iWhichQuery), _ppbDuplFragmentArr[iSlot]);
+      _pbSearchMemoryPool[iSlot] = false;
    }
    else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
@@ -215,9 +272,16 @@ bool CometSearch::RunSearch(int iPercentStart,
 
       for (size_t iWhichQuery = 0; iWhichQuery < iEnd; ++iWhichQuery)
       {
-         pSearchThreadPool->doJob(std::bind(
-            static_cast<void(*)(size_t, ThreadPool*)>(&CometSearch::SearchFragmentIndex),
-            iWhichQuery, pSearchThreadPool));
+         pSearchThreadPool->doJob([iWhichQuery]() {
+            int iSlot = AcquirePoolSlot();
+            if (iSlot < 0)
+            {
+               logerr(" Error - could not acquire memory pool slot for batch FI search thread.\n");
+               return;
+            }
+            SearchFragmentIndex(g_pvQuery.at(iWhichQuery), _ppbDuplFragmentArr[iSlot]);
+            _pbSearchMemoryPool[iSlot] = false;
+         });
       }
 
       pSearchThreadPool->wait_on_threads();
@@ -1419,419 +1483,6 @@ bool CometSearch::DoSearch(sDBEntry dbe,
 }
 
 
-void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
-                                      ThreadPool* tp)
-{
-   double pdAAforward[MAX_PEPTIDE_LEN];
-   double pdAAreverse[MAX_PEPTIDE_LEN];
-
-   std::map<comet_fileoffset_t, int> mPeptides;   // which peptide (fileoffset, and # matched fragments)
-   size_t lNumPeps = 0;
-   unsigned int uiFragmentMass;
-
-   unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
-   unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
-
-   bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal];
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
-
-/*
-   // print out fragment masses at each fragment index
-   int x=0;
-
-   for (unsigned int i = 0; i < g_massRange.uiMaxFragmentArrayIndex; ++i)
-   {
-      if (g_iFragmentIndexOffset[i + 1] > g_iFragmentIndexOffset[i])
-      {
-         for (size_t ii = 0; ii < g_iFragmentIndexOffset[i + 1] - g_iFragmentIndexOffset[i]; ++ii)
-         {
-            printf("%0.2f ", g_vFragmentPeptides[g_iFragmentIndex[g_iFragmentIndexOffset[i] + ii]].dPepMass);
-
-            if (ii==10)
-               break;
-         }
-         printf("\n");
-         x++;
-      }
-      if (x == 10)
-         break;
-   }
-*/
-
-   mPeptides.clear();
-
-   // Walk through the binned peaks in the spectrum and map them to the fragment index
-   // to count all peptides that contain each fragment peak.
-   for (auto it2 = pQuery->vfRawFragmentPeakMass.begin();
-      it2 != pQuery->vfRawFragmentPeakMass.end(); ++it2)
-   {
-      // We can consider higher charged fragments by simply assuming each fragment mass is
-      // higher charged and convert to singly charged to look into the 1+ paXionfileOffsets[].
-      // FIX: ideally deconvolute input spectrum to singly charged first
-      for (int iChg = 1; iChg <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++iChg)
-      {
-         uiFragmentMass = BIN((*it2) * iChg - (iChg - 1.0));
-
-         if (uiFragmentMass < g_massRange.uiMaxFragmentArrayIndex)
-         {
-            // number of peptides that contain this fragment mass
-            lNumPeps = (size_t)(g_iFragmentIndexOffset[uiFragmentMass + 1] - g_iFragmentIndexOffset[uiFragmentMass]);
-
-            if (lNumPeps > 0)
-            {
-               // g_vFragmentPeptides[g_iFragmentIndex[g_iFragmentIndexOffset[uiFragmentMass]+ix]].dPepMass
-               // is >= to g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus
-               // Each fragment index entry has lNumPeps peptides sort in increasing order by mass;
-               // find first entry that matches low tolerance of current query
-
-               size_t iFirst;
-
-               if (lNumPeps <= BINARYSEARCHCUTOFF)
-                  iFirst = 0;
-               else
-               {
-                  iFirst = BinarySearchIndexMass(0, lNumPeps,
-                     g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus, &uiFragmentMass);
-               }
-
-               unsigned int uiBinBase = g_iFragmentIndexOffset[uiFragmentMass];
-               for (size_t ix = iFirst; ix < lNumPeps; ++ix)
-               {
-                  int iTmp = g_iFragmentIndex[uiBinBase + ix];
-                  double dCalcPepMass = g_vFragmentPeptides[iTmp].dPepMass;
-
-                  if (dCalcPepMass >= g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus
-                     && dCalcPepMass <= g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus)
-                  {
-                     if (CheckMassMatch(iWhichQuery, dCalcPepMass))
-                        mPeptides[iTmp] += 1;
-                  }
-                  else if (dCalcPepMass > g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus)
-                     break;
-               }
-            }
-         }
-      }
-   }
-
-   // copy mPeptides map to a vector of pairs and sort in
-   // descending order of matched fragment ions
-   std::vector<std::pair<comet_fileoffset_t, int>> vPeptides;
-   for (auto ix = mPeptides.begin(); ix != mPeptides.end(); ++ix)
-   {
-      if (ix->second >= g_staticParams.options.iFragIndexMinIonsScore)
-         vPeptides.push_back(*ix);
-   }
-
-   mPeptides.clear();
-   sort(vPeptides.begin(), vPeptides.end(), [=](const std::pair<comet_fileoffset_t, int>& a, const std::pair<comet_fileoffset_t, int>& b) { return a.second > b.second; });
-
-   // Now that all peptides are determined based on mapping fragment ions,
-   // re-score highest matches with xcorr. Let use cutoff of at least
-   // g_staticParams.options.iFragIndexMinIonsScore fragment ion matches.
-
-   int iLenPeptide;
-   int iWhichIonSeries;
-   int ctCharge;
-   int ctIonSeries;
-   int ctLen;
-   int iLenMinus1;
-   char szPeptide[MAX_PEPTIDE_LEN];
-   int piVarModSites[MAX_PEPTIDE_LEN_P2];
-   int iPositionNLB[FRAGINDEX_VMODS];
-   int iPositionNLY[FRAGINDEX_VMODS];
-   int iCountNLB[FRAGINDEX_VMODS][MAX_PEPTIDE_LEN];  // sum/count of # of varmods counting from n-term at each residue position
-   int iCountNLY[FRAGINDEX_VMODS][MAX_PEPTIDE_LEN];  // sum/count of # of varmods counting from c-term at each position
-   int iStartPos = 0;
-   int iEndPos = 0;
-   unsigned int uiNumScored = 0;
-
-   for (auto ix = vPeptides.begin(); ix != vPeptides.end(); ++ix)
-   {
-      // ix->first references peptide entry in g_vFragmentPeptides[ix->first].iWhichPeptide/.modnumIdx
-      // ix->second is matched fragment count
-
-      if (ix->second >= g_staticParams.options.iFragIndexMinIonsScore)
-      {
-         int iFoundVariableMod = 0;
-
-         // calculate full xcorr here those that pass simple filter
-
-         strcpy(szPeptide, g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).sPeptide.c_str());
-         iLenPeptide = (int)strlen(szPeptide);
-
-         ModificationNumber modNum;
-         char* mods = NULL;
-         int modSeqIdx;
-         int modNumIdx = g_vFragmentPeptides[ix->first].modNumIdx;
-         size_t iWhichPeptide = g_vFragmentPeptides[ix->first].iWhichPeptide;
-         string modSeq;
-         double dCalcPepMass = g_vFragmentPeptides[ix->first].dPepMass;
-
-         iEndPos = iLenMinus1 = iLenPeptide - 1;
-
-         memset(piVarModSites, 0, sizeof(int) * (iLenPeptide + 2));
-
-         if (modNumIdx != -1)  // set modified peptide info
-         {
-            modNum = MOD_NUMBERS.at(modNumIdx);
-            mods = modNum.modifications;
-            modSeqIdx = PEPTIDE_MOD_SEQ_IDXS[iWhichPeptide];
-            modSeq = MOD_SEQS.at(modSeqIdx);
-
-            // now replicate piVarModSites[]
-
-            int j = 0;
-            for (int k = 0; k <= iEndPos; ++k)
-            {
-               if (szPeptide[k] == modSeq[j])
-               {
-                  if (mods[j] != -1)
-                  {
-                     // mods value of -1 means no mod
-                     // whereas piVarModSites value of 0 means no mod
-                     // so need to add 1 to mods when setting piVarModSites
-                     piVarModSites[k] = 1 + (int)mods[j];
-                  }
-                  j++;
-               }
-            }
-         }
-
-         double dBion = g_staticParams.precalcMasses.dNtermProton;
-         double dYion = g_staticParams.precalcMasses.dCtermOH2Proton;
-
-         // set terminal mods
-         if (g_vFragmentPeptides[ix->first].cNtermMod > -1)
-         {
-            piVarModSites[iLenPeptide] = g_vFragmentPeptides[ix->first].cNtermMod + 1;
-            dBion += g_staticParams.variableModParameters.varModList[g_vFragmentPeptides[ix->first].cNtermMod].dVarModMass;
-            iFoundVariableMod = 1;
-         }
-         if (g_vFragmentPeptides[ix->first].cCtermMod > -1)
-         {
-            piVarModSites[iLenPeptide + 1] = g_vFragmentPeptides[ix->first].cCtermMod + 1;
-            dYion += g_staticParams.variableModParameters.varModList[g_vFragmentPeptides[ix->first].cCtermMod].dVarModMass;
-            iFoundVariableMod = 1;
-         }
-
-         //FIX: set fragment neutral loss correctly
-         if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
-         {
-            memset(iCountNLB, 0, sizeof(iCountNLB));
-            memset(iCountNLY, 0, sizeof(iCountNLY));
-
-            for (int i = 0; i < FRAGINDEX_VMODS; ++i)
-            {
-               iPositionNLB[i] = 999;    // default to greater than last residue position
-               iPositionNLY[i] = -1;     // default to less that first residue position
-            }
-         }
-
-         // Generate pdAAforward for szPeptide
-         for (int i = 0; i < iLenMinus1; ++i)
-         {
-            int iPosForward = i;
-            int iPosReverse = iLenMinus1 - i;
-
-            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
-            {
-               if (i > iStartPos)
-               {
-                  for (int x = 0; x < FRAGINDEX_VMODS; ++x)
-                  {
-                     iCountNLB[x][iPosForward] = iCountNLB[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i
-                     iCountNLY[x][iPosForward] = iCountNLY[x][iPosForward - 1]; // running sum/count of # of var mods contained at position i (R to L in sequence)
-                  }
-               }
-            }
-
-            dBion += g_staticParams.massUtility.pdAAMassFragment[(int)szPeptide[i]];
-
-            if (piVarModSites[iPosForward] > 0)
-            {
-               int iMod = piVarModSites[iPosForward] - 1;
-
-               dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosForward] - 1].dVarModMass;
-
-               iFoundVariableMod = 1;
-
-               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
-               {
-                  iFoundVariableMod = 2;
-
-                  if (iPositionNLB[iMod] == 999)
-                     iPositionNLB[iMod] = iPosForward;
-
-                  if (g_staticParams.options.bScaleFragmentNL)
-                     iCountNLB[iMod][iPosForward] += 1;
-                  else
-                     iCountNLB[iMod][iPosForward] = 1;
-               }
-            }
-
-            dYion += g_staticParams.massUtility.pdAAMassFragment[(int)szPeptide[iPosReverse]];
-            if (piVarModSites[iPosReverse] > 0)
-            {
-               int iPosReverseModSite = iPosReverse;
-
-               int iMod = piVarModSites[iPosReverseModSite] - 1;
-
-               dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosReverse] - 1].dVarModMass;
-
-               iFoundVariableMod = 1;
-
-               if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss
-                  && g_staticParams.variableModParameters.varModList[iMod].dNeutralLoss != 0.0)
-               {
-                  iFoundVariableMod = 2;
-
-                  if (iPositionNLY[iMod] == -1)
-                     iPositionNLY[iMod] = iPosReverseModSite;
-
-                  if (g_staticParams.options.bScaleFragmentNL)
-                     iCountNLY[iMod][iPosForward] += 1;
-                  else
-                     iCountNLY[iMod][iPosForward] = 1;
-               }
-            }
-
-            pdAAforward[iPosForward] = dBion;
-            pdAAreverse[iPosForward] = dYion;
-         }
-
-         int iMaxFragmentCharge = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiMaxFragCharge;
-         if (iMaxFragmentCharge > 2)   // ony use up to 2+ fragments for the fragment index query
-            iMaxFragmentCharge = 2;
-
-         // Now get the set of binned fragment ions once to compare this peptide against all matching spectra.
-         // First initialize pbDuplFragment and _uiBinnedIonMasses
-
-         memset(pbDuplFragment, 0, sizeof(bool) * g_staticParams.iArraySizeGlobal);
-         memset(uiBinnedIonMasses, 0, sizeof(uiBinnedIonMasses));
-         if (g_staticParams.iPrecursorNLSize > 0)
-            memset(uiBinnedPrecursorNL, 0, sizeof(uiBinnedPrecursorNL));
-
-         // set pbDuplFragment[bin] to true for each fragment ion bin
-         for (ctCharge = 1; ctCharge <= g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
-         {
-            for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
-            {
-               iWhichIonSeries = g_staticParams.ionInformation.piSelectedIonSeries[ctIonSeries];
-
-               // As both _pdAAforward and _pdAAreverse are increasing, loop through
-               // iLenPeptide-1 to complete set of internal fragment ions.
-               for (ctLen = 0; ctLen < iLenMinus1; ++ctLen)
-               {
-                  double dFragMass = CometMassSpecUtils::GetFragmentIonMass(iWhichIonSeries, ctLen, ctCharge, pdAAforward, pdAAreverse);
-                  int iVal = BIN(dFragMass);
-
-                  if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
-                  {
-                     uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0] = iVal;
-                     pbDuplFragment[iVal] = true;
-
-                     if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss)
-                     {
-                        for (int x = 0; x < FRAGINDEX_VMODS; ++x)
-                        {
-                           for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
-                           {
-                              if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss == 0.0)
-                                 continue;
-                              else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 == 0.0)
-                                 continue;
-
-                              if ((iWhichIonSeries <= 2 && ctLen >= iPositionNLB[x])  // 0/1/2 is a/b/c ions
-                                 || (iWhichIonSeries >= 3 && iWhichIonSeries <= 5 && iLenMinus1 - ctLen <= iPositionNLY[x])) // 3/4/5 is x/y/z ions
-                              {
-                                 int iScaleFactor;
-
-                                 if (iWhichIonSeries <= 2)
-                                    iScaleFactor = iCountNLB[x][ctLen];
-                                 else
-                                    iScaleFactor = iCountNLY[x][ctLen];
-
-                                 double dNewMass;
-
-                                 if (iWhichNL == 0)
-                                    dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss / ctCharge);
-                                 else
-                                    dNewMass = dFragMass - (iScaleFactor * g_staticParams.variableModParameters.varModList[x].dNeutralLoss2 / ctCharge);
-
-                                 if (dNewMass >= 0.0)
-                                 {
-                                    iVal = BIN(dNewMass);
-
-                                    if (iVal > 0 && iVal < g_staticParams.iArraySizeGlobal && pbDuplFragment[iVal] == false)
-                                    {
-                                       uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][x + 1 + iWhichNL] = iVal;
-                                       pbDuplFragment[iVal] = true;
-                                       iFoundVariableMod = 2;
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     }
-                  }
-               }
-            }
-         }
-
-         struct sDBEntry dbe;
-
-         char cPrevAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cPrevAA;
-         char cNextAA = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).cNextAA;
-         char szProtein[MAX_PEPTIDE_LEN_P2];
-
-         if (cPrevAA == '-')
-         {
-            iStartPos = 0;
-            strcpy(szProtein, szPeptide);
-         }
-         else
-         {
-            iStartPos = 1;
-            snprintf(szProtein, sizeof(szProtein), "%c%s", cPrevAA, szPeptide);
-         }
-
-         if (cNextAA == '-')
-         {
-            iEndPos = strlen(szProtein) - 1;
-         }
-         else
-         {
-            size_t iCurLen = strlen(szProtein);
-            if (iCurLen + 1 < sizeof(szProtein))
-            {
-               szProtein[iCurLen] = cNextAA;
-               szProtein[iCurLen + 1] = '\0';
-            }
-            iEndPos = strlen(szProtein) - 2;
-         }
-
-         dbe.strName = "";
-         dbe.strSeq = szProtein;
-         // this lProteinFilePosition is actually the entry in g_pvProteinsList that contains the list of proteins for that peptide
-         dbe.lProteinFilePosition = g_vRawPeptides.at(g_vFragmentPeptides[ix->first].iWhichPeptide).lIndexProteinFilePosition;
-
-         XcorrScoreI(szProtein, iStartPos, iEndPos, iFoundVariableMod, dCalcPepMass, false, iWhichQuery,
-            iLenPeptide, piVarModSites, &dbe, uiBinnedIonMasses, uiBinnedPrecursorNL, ix->second);
-
-         uiNumScored++;
-         if (uiNumScored >= FRAGINDEX_MAX_NUMSCORED)
-            break;
-      }
-   }
-
-   delete[] pbDuplFragment;
-}
-
-
-// Task 1.1: Thread-local overload.
 void CometSearch::SearchFragmentIndex(Query* pQuery,
                                       bool* pbDuplFragment)
 {
@@ -2192,7 +1843,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          else
          {
             iStartPos = 1;
-            sprintf(szProtein, "%c%s", cPrevAA, szPeptide);
+            snprintf(szProtein, sizeof(szProtein), "%c%s", cPrevAA, szPeptide);
          }
          if (cNextAA == '-')
          {
@@ -3593,7 +3244,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          else
          {
             iStartPos = 1;
-            sprintf(szProtein, "%c%s", cPrevAA, sDBI.sPeptide.c_str());
+            snprintf(szProtein, sizeof(szProtein), "%c%s", cPrevAA, sDBI.sPeptide.c_str());
          }
 
          if (cNextAA == '-')
@@ -3602,7 +3253,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          }
          else
          {
-            sprintf(szProtein, "%s%c", szProtein, cNextAA);
+            snprintf(szProtein, sizeof(szProtein), "%s%c", szProtein, cNextAA);
             iEndPos = strlen(szProtein) - 2;
          }
 
@@ -5510,148 +5161,6 @@ void CometSearch::XcorrScore(char* szProteinSeq,
 }
 
 
-// Compares sequence to MSMS spectrum by matching ion intensities.
-void CometSearch::XcorrScoreI(char* szProteinSeq,
-                              int iStartPos,
-                              int iEndPos,
-                              int iFoundVariableMod,    // 0=no mods, 1 has variable mod, 2=phospho mod use NL peaks
-                              double dCalcPepMass,
-                              bool bDecoyPep,
-                              size_t iWhichQuery,
-                              int iLenPeptide,
-                              int* piVarModSites,
-                              struct sDBEntry* dbe,
-                              unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2],
-                              unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
-                              int iNumMatchedFragmentIons)
-{
-   int ctLen,
-       ctIonSeries,
-       ctCharge;
-   double dXcorr = 0.0;
-   int iLenPeptideMinus1 = iLenPeptide - 1;
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
-
-   // iMax is largest x-value allowed as iMax+1 is allocated and we're 0-index
-   int iMax = pQuery->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE;
-
-   int bin, x, y;
-
-   float** ppSparseFastXcorrData = pQuery->ppfSparseFastXcorrData;
-
-   for (ctCharge = 1; ctCharge <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++ctCharge)
-   {
-      for (ctIonSeries = 0; ctIonSeries < g_staticParams.ionInformation.iNumIonSeriesUsed; ++ctIonSeries)
-      {
-         for (ctLen = 0; ctLen < iLenPeptideMinus1; ++ctLen)
-         {
-            //MH: newer sparse matrix converts bin to sparse matrix bin
-            bin = uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][0];
-
-            x = bin / SPARSE_MATRIX_SIZE;
-
-            if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
-            {
-               y = bin - (x * SPARSE_MATRIX_SIZE);
-               dXcorr += ppSparseFastXcorrData[x][y];
-            }
-
-            if (g_staticParams.variableModParameters.bUseFragmentNeutralLoss && iFoundVariableMod == 2)
-            {
-               for (int ii = 0; ii < VMODS; ++ii)
-               {
-                  if (g_staticParams.iDbType == DbType::FI_DB && ii >= FRAGINDEX_VMODS)
-                     break;
-
-                  for (int iWhichNL = 0; iWhichNL < 2; ++iWhichNL)
-                  {
-                     if (iWhichNL == 0 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss == 0.0)
-                        continue;
-                     else if (iWhichNL == 1 && g_staticParams.variableModParameters.varModList[ii].dNeutralLoss2 == 0.0)
-                        continue;
-
-                     //x+1 here as 0 is the base fragment ion series
-                     // *(*(*(*(*p_uiBinnedIonMasses + ctCharge)+ctIonSeries)+ctLen)+NL) gives uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][NL].
-                     bin = uiBinnedIonMasses[ctCharge][ctIonSeries][ctLen][ii + 1 + iWhichNL];
-
-                     x = bin / SPARSE_MATRIX_SIZE;
-
-                     if (!(bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL)) // x should never be > iMax so this is just a safety check
-                     {
-                        y = bin - (x * SPARSE_MATRIX_SIZE);
-                        dXcorr += ppSparseFastXcorrData[x][y];
-                     }
-                  }
-               }
-            }
-         }
-      }
-   }
-
-   // precursor NL
-   for (int ctNL = 0; ctNL < g_staticParams.iPrecursorNLSize; ++ctNL)
-   {
-      for (int ctZ = g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiChargeState; ctZ >= 1; --ctZ)
-      {
-         bin = uiBinnedPrecursorNL[ctNL][ctZ];
-
-         x = bin / SPARSE_MATRIX_SIZE;
-
-         if (bin <= 0 || x > iMax || ppSparseFastXcorrData[x] == NULL) // x should never be > iMax so this is just a safety check
-            continue;
-
-         y = bin - (x * SPARSE_MATRIX_SIZE);
-
-         dXcorr += ppSparseFastXcorrData[x][y];
-      }
-   }
-
-   dXcorr *= 0.005;  // Scale intensities to 50 and divide score by 1E4.
-
-   dXcorr = std::round(dXcorr * 1000.0) / 1000.0;  // round to 3 decimal points
-
-   Threading::LockMutex(pQuery->accessMutex);
-
-   // Increment matched peptide counts.
-   if (bDecoyPep && g_staticParams.options.iDecoySearch == 2)
-      pQuery->_uliNumMatchedDecoyPeptides++;
-   else
-      pQuery->_uliNumMatchedPeptides++;
-
-   if (g_staticParams.options.bPrintExpectScore
-      || g_staticParams.options.bOutputPepXMLFile
-      || g_staticParams.options.bOutputPercolatorFile
-      || g_staticParams.options.bOutputTxtFile)
-   {
-      int iTmp;
-
-      iTmp = (int)(dXcorr * 10.0 + 0.5);
-
-      if (iTmp < 0) // possible for CRUX compiled option to have a negative xcorr
-         iTmp = 0;  // lump these all in the mininum score bin of the histogram
-
-      // lump some zero decoy entries into iMinXcorrHisto bin
-      if (szProteinSeq[iStartPos] >= 'A' && szProteinSeq[iStartPos] <= 'H' && iTmp < pQuery->iMinXcorrHisto)
-         iTmp = pQuery->iMinXcorrHisto;
-
-      if (iTmp >= HISTO_SIZE)
-         iTmp = HISTO_SIZE - 1;
-
-      pQuery->iXcorrHistogram[iTmp] += 1;
-      pQuery->uiHistogramCount += 1;
-   }
-
-   if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
-   {
-      StorePeptideI(iWhichQuery, iStartPos, iEndPos, iFoundVariableMod, szProteinSeq,
-         dCalcPepMass, dXcorr, bDecoyPep, piVarModSites, dbe);
-   }
-
-   Threading::UnlockMutex(pQuery->accessMutex);
-}
-
-
 void CometSearch::StorePeptide(size_t iWhichQuery,
                                int iStartResidue,
                                int iStartPos,
@@ -6096,124 +5605,6 @@ void CometSearch::StorePeptide(size_t iWhichQuery,
 
       pQuery->siLowestXcorrScoreIndex = siLowestXcorrScoreIndex;
    }
-}
-
-
-void CometSearch::StorePeptideI(size_t iWhichQuery,
-                                int iStartPos,
-                                int iEndPos,
-                                int iFoundVariableMod,
-                                char* szProteinSeq,
-                                double dCalcPepMass,
-                                double dXcorr,
-                                bool bDecoyPep,
-                                int* piVarModSites,
-                                struct sDBEntry* dbe)
-{
-   int iLenPeptide = iEndPos - iStartPos + 1;
-   int iLenProteinMinus1 = (int)strlen(szProteinSeq) - 1;
-
-   Query* pQuery = g_pvQuery.at(iWhichQuery);
-
-   short siLowestXcorrScoreIndex = pQuery->siLowestXcorrScoreIndex;
-
-   pQuery->iMatchPeptideCount++;
-   pQuery->_pResults[siLowestXcorrScoreIndex].usiLenPeptide = iLenPeptide;
-
-   memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide, szProteinSeq + iStartPos, iLenPeptide * sizeof(char));
-   pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide[iLenPeptide] = '\0';
-   pQuery->_pResults[siLowestXcorrScoreIndex].dPepMass = dCalcPepMass;
-
-   if (pQuery->_spectrumInfoInternal.usiChargeState > 2)
-   {
-      pQuery->_pResults[siLowestXcorrScoreIndex].usiTotalIons = (iLenPeptide - 1)
-         * pQuery->_spectrumInfoInternal.usiMaxFragCharge
-         * g_staticParams.ionInformation.iNumIonSeriesUsed;
-   }
-   else
-   {
-      pQuery->_pResults[siLowestXcorrScoreIndex].usiTotalIons = (iLenPeptide - 1)
-         * g_staticParams.ionInformation.iNumIonSeriesUsed;
-   }
-
-   pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr = (float)dXcorr;
-
-   if (iStartPos == 0)
-      pQuery->_pResults[siLowestXcorrScoreIndex].cPrevAA = '-';
-   else
-      pQuery->_pResults[siLowestXcorrScoreIndex].cPrevAA = szProteinSeq[iStartPos - 1];
-
-   if (iEndPos == iLenProteinMinus1)
-      pQuery->_pResults[siLowestXcorrScoreIndex].cNextAA = '-';
-   else
-      pQuery->_pResults[siLowestXcorrScoreIndex].cNextAA = szProteinSeq[iEndPos + 1];
-
-   pQuery->_pResults[siLowestXcorrScoreIndex].iPeffOrigResiduePosition = NO_PEFF_VARIANT;
-   pQuery->_pResults[siLowestXcorrScoreIndex].sPeffOrigResidues.clear();
-   pQuery->_pResults[siLowestXcorrScoreIndex].iPeffNewResidueCount = 0;
-
-   pQuery->_pResults[siLowestXcorrScoreIndex].pWhichProtein.clear();
-   pQuery->_pResults[siLowestXcorrScoreIndex].pWhichDecoyProtein.clear();
-   pQuery->_pResults[siLowestXcorrScoreIndex].lProteinFilePosition = dbe->lProteinFilePosition;
-
-   pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_None;
-
-   int iSizepiVarModSites = sizeof(int) * MAX_PEPTIDE_LEN_P2;
-   int iSizepdVarModSites = sizeof(double) * MAX_PEPTIDE_LEN_P2;
-
-   if (g_staticParams.variableModParameters.bVarModSearch)
-   {
-      if (!iFoundVariableMod)  // Normal peptide in variable mod search.
-      {
-         memset(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, 0, iSizepiVarModSites);
-         memset(pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites, 0, iSizepdVarModSites);
-      }
-      else
-      {
-         memcpy(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, piVarModSites, iSizepiVarModSites);
-
-         int iVal;
-         for (int i = 0; i < iLenPeptide + 2; ++i)
-         {
-            iVal = pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites[i];
-
-            if (iVal > 0)
-            {
-               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = g_staticParams.variableModParameters.varModList[iVal - 1].dVarModMass;
-
-               if (g_staticParams.options.iPrintAScoreProScore == -1
-                  || (g_staticParams.options.iPrintAScoreProScore > 0 && iVal == g_AScoreOptions.getSymbol() - '0'))
-               {
-                  pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_AScorePro;
-               }
-               else if (pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod == HasVariableModType_None)
-                  pQuery->_pResults[siLowestXcorrScoreIndex].cHasVariableMod = HasVariableModType_True;
-            }
-            else
-               pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites[i] = 0.0;
-         }
-      }
-   }
-   else
-   {
-      memset(pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites, 0, iSizepiVarModSites);
-      memset(pQuery->_pResults[siLowestXcorrScoreIndex].pdVarModSites, 0, iSizepdVarModSites);
-   }
-
-   // Get new lowest score.
-   pQuery->dLowestXcorrScore = pQuery->_pResults[0].fXcorr;
-   siLowestXcorrScoreIndex = 0;
-
-   for (int i = g_staticParams.options.iNumStored - 1; i > 0; --i)
-   {
-      if (pQuery->_pResults[i].fXcorr < pQuery->dLowestXcorrScore || pQuery->_pResults[i].usiLenPeptide == 0)
-      {
-         pQuery->dLowestXcorrScore = pQuery->_pResults[i].fXcorr;
-         siLowestXcorrScoreIndex = i;
-      }
-   }
-
-   pQuery->siLowestXcorrScoreIndex = siLowestXcorrScoreIndex;
 }
 
 

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -152,7 +152,9 @@ bool CometSearch::RunSearch(Query* pQuery)
          return false;
       }
       SearchFragmentIndex(pQuery, _ppbDuplFragmentArr[iSlot]);
+      Threading::LockMutex(g_searchMemoryPoolMutex);
       _pbSearchMemoryPool[iSlot] = false;
+      Threading::UnlockMutex(g_searchMemoryPoolMutex);
    }
    else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
@@ -194,7 +196,9 @@ bool CometSearch::RunSearch(Query* pQuery)
          return false;
       }
       SearchPeptideIndex(pQuery, _ppbDuplFragmentArr[iSlot]);
+      Threading::LockMutex(g_searchMemoryPoolMutex);
       _pbSearchMemoryPool[iSlot] = false;
+      Threading::UnlockMutex(g_searchMemoryPoolMutex);
    }
    else
    {
@@ -230,7 +234,9 @@ bool CometSearch::RunSearch(ThreadPool *tp)
          return false;
       }
       SearchFragmentIndex(g_pvQuery.at(iWhichQuery), _ppbDuplFragmentArr[iSlot]);
+      Threading::LockMutex(g_searchMemoryPoolMutex);
       _pbSearchMemoryPool[iSlot] = false;
+      Threading::UnlockMutex(g_searchMemoryPoolMutex);
    }
    else if (g_staticParams.iDbType == DbType::PI_DB)  // peptide index
    {
@@ -281,7 +287,9 @@ bool CometSearch::RunSearch(int iPercentStart,
                return;
             }
             SearchFragmentIndex(g_pvQuery.at(iWhichQuery), _ppbDuplFragmentArr[iSlot]);
+            Threading::LockMutex(g_searchMemoryPoolMutex);
             _pbSearchMemoryPool[iSlot] = false;
+            Threading::UnlockMutex(g_searchMemoryPoolMutex);
          });
       }
 
@@ -1583,7 +1591,11 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          return;
    }
 
-   sort(vPeptides.begin(), vPeptides.end(), [](const std::pair<unsigned int, int>& a, const std::pair<unsigned int, int>& b) { return a.second > b.second; });
+   sort(vPeptides.begin(), vPeptides.end(), [](const std::pair<unsigned int, int>& a, const std::pair<unsigned int, int>& b)
+   {
+      if (a.second != b.second) return a.second > b.second;
+      return a.first < b.first;  // tie-break by peptide index for deterministic output
+   });
 
    int iLenPeptide;
    int iWhichIonSeries;

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -15,6 +15,7 @@
 #include "Common.h"
 #include "CometSearch.h"
 #include "CometFragmentIndexReader.h"
+#include <unordered_map>
 
 
 #define BINARYSEARCHCUTOFF 20                // do linear search through FI if # entries is this or less
@@ -1489,7 +1490,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
    double pdAAforward[MAX_PEPTIDE_LEN];
    double pdAAreverse[MAX_PEPTIDE_LEN];
 
-   std::map<comet_fileoffset_t, int> mPeptides;   // which peptide (fileoffset, and # matched fragments)
+   std::unordered_map<unsigned int, int> mPeptides;   // which peptide (index into g_vFragmentPeptides, and # matched fragments)
    size_t lNumPeps = 0;
    unsigned int uiFragmentMass;
 
@@ -1527,7 +1528,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
                unsigned int uiBinBase = g_iFragmentIndexOffset[uiFragmentMass];
                for (size_t ix = iFirst; ix < lNumPeps; ++ix)
                {
-                  int iTmp = g_iFragmentIndex[uiBinBase + ix];
+                  unsigned int iTmp = g_iFragmentIndex[uiBinBase + ix];
                   double dCalcPepMass = g_vFragmentPeptides[iTmp].dPepMass;
 
                   if (dCalcPepMass >= pQuery->_pepMassInfo.dPeptideMassToleranceMinus
@@ -1565,7 +1566,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          return;
    }
 
-   std::vector<std::pair<comet_fileoffset_t, int>> vPeptides;
+   std::vector<std::pair<unsigned int, int>> vPeptides;
    for (auto ix = mPeptides.begin(); ix != mPeptides.end(); ++ix)
    {
       if (ix->second >= g_staticParams.options.iFragIndexMinIonsScore)
@@ -1582,7 +1583,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
          return;
    }
 
-   sort(vPeptides.begin(), vPeptides.end(), [=](const std::pair<comet_fileoffset_t, int>& a, const std::pair<comet_fileoffset_t, int>& b) { return a.second > b.second; });
+   sort(vPeptides.begin(), vPeptides.end(), [](const std::pair<unsigned int, int>& a, const std::pair<unsigned int, int>& b) { return a.second > b.second; });
 
    int iLenPeptide;
    int iWhichIonSeries;

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -1440,11 +1440,11 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
 
    for (unsigned int i = 0; i < g_massRange.uiMaxFragmentArrayIndex; ++i)
    {
-      if (g_iCountFragmentIndex[i] > 0)
+      if (g_iFragmentIndexOffset[i + 1] > g_iFragmentIndexOffset[i])
       {
-         for (size_t ii = 0; ii < g_iCountFragmentIndex[i]; ++ii)
+         for (size_t ii = 0; ii < g_iFragmentIndexOffset[i + 1] - g_iFragmentIndexOffset[i]; ++ii)
          {
-            printf("%0.2f ", g_vFragmentPeptides[g_iFragmentIndex[i][ii]].dPepMass);
+            printf("%0.2f ", g_vFragmentPeptides[g_iFragmentIndex[g_iFragmentIndexOffset[i] + ii]].dPepMass);
 
             if (ii==10)
                break;
@@ -1474,11 +1474,11 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
          if (uiFragmentMass < g_massRange.uiMaxFragmentArrayIndex)
          {
             // number of peptides that contain this fragment mass
-            lNumPeps = (size_t)g_iCountFragmentIndex[uiFragmentMass];
+            lNumPeps = (size_t)(g_iFragmentIndexOffset[uiFragmentMass + 1] - g_iFragmentIndexOffset[uiFragmentMass]);
 
             if (lNumPeps > 0)
             {
-               // g_vFragmentPeptides[g_iFragmentIndex[uiFragmentMass][ix]].dPepMass
+               // g_vFragmentPeptides[g_iFragmentIndex[g_iFragmentIndexOffset[uiFragmentMass]+ix]].dPepMass
                // is >= to g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus
                // Each fragment index entry has lNumPeps peptides sort in increasing order by mass;
                // find first entry that matches low tolerance of current query
@@ -1493,16 +1493,17 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
                      g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus, &uiFragmentMass);
                }
 
+               unsigned int uiBinBase = g_iFragmentIndexOffset[uiFragmentMass];
                for (size_t ix = iFirst; ix < lNumPeps; ++ix)
                {
-                  int iTmp = g_iFragmentIndex[uiFragmentMass][ix];
+                  int iTmp = g_iFragmentIndex[uiBinBase + ix];
                   double dCalcPepMass = g_vFragmentPeptides[iTmp].dPepMass;
 
                   if (dCalcPepMass >= g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassToleranceMinus
                      && dCalcPepMass <= g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus)
                   {
                      if (CheckMassMatch(iWhichQuery, dCalcPepMass))
-                        mPeptides[g_iFragmentIndex[uiFragmentMass][ix]] += 1;
+                        mPeptides[iTmp] += 1;
                   }
                   else if (dCalcPepMass > g_pvQuery.at(iWhichQuery)->_pepMassInfo.dPeptideMassTolerancePlus)
                      break;
@@ -1856,7 +1857,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
 
          if (uiFragmentMass < g_massRange.uiMaxFragmentArrayIndex)
          {
-            lNumPeps = (size_t)g_iCountFragmentIndex[uiFragmentMass];
+            lNumPeps = (size_t)(g_iFragmentIndexOffset[uiFragmentMass + 1] - g_iFragmentIndexOffset[uiFragmentMass]);
 
             if (lNumPeps > 0)
             {
@@ -1870,16 +1871,17 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
                      pQuery->_pepMassInfo.dPeptideMassToleranceMinus, &uiFragmentMass);
                }
 
+               unsigned int uiBinBase = g_iFragmentIndexOffset[uiFragmentMass];
                for (size_t ix = iFirst; ix < lNumPeps; ++ix)
                {
-                  int iTmp = g_iFragmentIndex[uiFragmentMass][ix];
+                  int iTmp = g_iFragmentIndex[uiBinBase + ix];
                   double dCalcPepMass = g_vFragmentPeptides[iTmp].dPepMass;
 
                   if (dCalcPepMass >= pQuery->_pepMassInfo.dPeptideMassToleranceMinus
                      && dCalcPepMass <= pQuery->_pepMassInfo.dPeptideMassTolerancePlus)
                   {
                      if (CheckMassMatch(pQuery, dCalcPepMass))
-                        mPeptides[g_iFragmentIndex[uiFragmentMass][ix]] += 1;
+                        mPeptides[iTmp] += 1;
                   }
                   else if (dCalcPepMass > pQuery->_pepMassInfo.dPeptideMassTolerancePlus)
                      break;
@@ -4916,7 +4918,8 @@ size_t CometSearch::BinarySearchIndexMass(size_t start,
    // the array into two pieces.
    size_t middle = start + ((end - start) / 2);
 
-   double dArrayMass = g_vFragmentPeptides[g_iFragmentIndex[*uiFragmentMass][middle]].dPepMass;
+   unsigned int uiBinBase = g_iFragmentIndexOffset[*uiFragmentMass];
+   double dArrayMass = g_vFragmentPeptides[g_iFragmentIndex[uiBinBase + middle]].dPepMass;
 
    if (dArrayMass > dQueryMass)
    {
@@ -4931,7 +4934,7 @@ size_t CometSearch::BinarySearchIndexMass(size_t start,
       // always walk backwards now until ArrayMass is < dQueryMass
       // as there may be multiple entries in the mass vector with the same ArrayMass so
       // need to start at the first one (or the entry before the first one)
-      while (middle > 0 && g_vFragmentPeptides[g_iFragmentIndex[*uiFragmentMass][middle]].dPepMass >= dQueryMass)
+      while (middle > 0 && g_vFragmentPeptides[g_iFragmentIndex[uiBinBase + middle]].dPepMass >= dQueryMass)
       {
          middle--;
       }

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -1434,6 +1434,8 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
 
    bool* pbDuplFragment = new bool[g_staticParams.iArraySizeGlobal];
 
+   Query* pQuery = g_pvQuery.at(iWhichQuery);
+
 /*
    // print out fragment masses at each fragment index
    int x=0;
@@ -1461,13 +1463,13 @@ void CometSearch::SearchFragmentIndex(size_t iWhichQuery,
 
    // Walk through the binned peaks in the spectrum and map them to the fragment index
    // to count all peptides that contain each fragment peak.
-   for (auto it2 = g_pvQuery.at(iWhichQuery)->vfRawFragmentPeakMass.begin();
-      it2 != g_pvQuery.at(iWhichQuery)->vfRawFragmentPeakMass.end(); ++it2)
+   for (auto it2 = pQuery->vfRawFragmentPeakMass.begin();
+      it2 != pQuery->vfRawFragmentPeakMass.end(); ++it2)
    {
       // We can consider higher charged fragments by simply assuming each fragment mass is
       // higher charged and convert to singly charged to look into the 1+ paXionfileOffsets[].
       // FIX: ideally deconvolute input spectrum to singly charged first
-      for (int iChg = 1; iChg <= g_pvQuery.at(iWhichQuery)->_spectrumInfoInternal.usiMaxFragCharge; ++iChg)
+      for (int iChg = 1; iChg <= pQuery->_spectrumInfoInternal.usiMaxFragCharge; ++iChg)
       {
          uiFragmentMass = BIN((*it2) * iChg - (iChg - 1.0));
 
@@ -2517,7 +2519,7 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
                                       bool* pbDuplFragment,
                                       struct sDBEntry* dbe)
 {
-   int iLenPeptide = (int)strlen(sDBI.szPeptide);
+   int iLenPeptide = (int)sDBI.sPeptide.size();
    int iLenMinus1 = iLenPeptide - 1;
    int iStartPos;
    int iEndPos;
@@ -2537,11 +2539,14 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
 
    // Convert pcVarModSites (char) -> piVarModSites (int) element-by-element
    memset(piVarModSites, 0, sizeof(int) * MAX_PEPTIDE_LEN_P2);
-   for (int i = 0; i < iLenPeptide + 2; ++i)
+   if (!sDBI.pcVarModSites.empty())
    {
-      piVarModSites[i] = (int)sDBI.pcVarModSites[i];
-      if (piVarModSites[i] != 0)
-         iFoundVariableMod = 1;
+      for (int i = 0; i < iLenPeptide + 2; ++i)
+      {
+         piVarModSites[i] = (int)sDBI.pcVarModSites[i];
+         if (piVarModSites[i] != 0)
+            iFoundVariableMod = 1;
+      }
    }
 
    double dBion = g_staticParams.precalcMasses.dNtermProton;
@@ -2564,7 +2569,7 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
    }
    iStartPos = iPos;
 
-   memcpy(szProtein + iPos, sDBI.szPeptide, iLenPeptide);
+   memcpy(szProtein + iPos, sDBI.sPeptide.c_str(), iLenPeptide);
    iPos += iLenPeptide;
    iEndPos = iPos - 1;
 
@@ -2619,26 +2624,29 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
          iPositionNLY[i] = -1;
       }
 
-      for (int i = 0; i < iLenMinus1; ++i)
+      if (!sDBI.pcVarModSites.empty())
       {
-         if (sDBI.pcVarModSites[i] > 0)
+         for (int i = 0; i < iLenMinus1; ++i)
          {
-            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            if (sDBI.pcVarModSites[i] > 0)
             {
-               iPositionNLB[sDBI.pcVarModSites[i] - 1] = i;
-               break;
+               if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLB[sDBI.pcVarModSites[i] - 1] = i;
+                  break;
+               }
             }
          }
-      }
 
-      for (int i = iLenMinus1; i >= 0; --i)
-      {
-         if (sDBI.pcVarModSites[i] > 0)
+         for (int i = iLenMinus1; i >= 0; --i)
          {
-            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            if (sDBI.pcVarModSites[i] > 0)
             {
-               iPositionNLY[sDBI.pcVarModSites[i] - 1] = i;
-               break;
+               if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLY[sDBI.pcVarModSites[i] - 1] = i;
+                  break;
+               }
             }
          }
       }
@@ -2649,7 +2657,7 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
    {
       int iPosReverse = iLenMinus1 - i;
 
-      dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[i]];
+      dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.sPeptide[i]];
       if (piVarModSites[i] > 0)
       {
          dBion += g_staticParams.variableModParameters.varModList[piVarModSites[i] - 1].dVarModMass;
@@ -2662,7 +2670,7 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
          }
       }
 
-      dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[iPosReverse]];
+      dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.sPeptide[iPosReverse]];
       if (piVarModSites[iPosReverse] > 0)
       {
          dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPosReverse] - 1].dVarModMass;
@@ -2842,20 +2850,20 @@ void CometSearch::AnalyzePeptideIndex(Query* pQuery,
          // Last residue stays the same:  ABCDEK -> EDCBAK
          for (int i = iLenPeptide - 2; i >= 0; --i)
          {
-            szDecoyPeptide[iLenPeptide - 2 - i] = sDBI.szPeptide[i];
+            szDecoyPeptide[iLenPeptide - 2 - i] = sDBI.sPeptide[i];
             piVarModSitesDecoy[iLenPeptide - 2 - i] = piVarModSites[i];
          }
-         szDecoyPeptide[iLenPeptide - 1] = sDBI.szPeptide[iLenPeptide - 1];
+         szDecoyPeptide[iLenPeptide - 1] = sDBI.sPeptide[iLenPeptide - 1];
          piVarModSitesDecoy[iLenPeptide - 1] = piVarModSites[iLenPeptide - 1];
       }
       else
       {
          // First residue stays the same:  ABCDEK -> AKEDCB
-         szDecoyPeptide[0] = sDBI.szPeptide[0];
+         szDecoyPeptide[0] = sDBI.sPeptide[0];
          piVarModSitesDecoy[0] = piVarModSites[0];
          for (int i = iLenPeptide - 1; i >= 1; --i)
          {
-            szDecoyPeptide[iLenPeptide - i] = sDBI.szPeptide[i];
+            szDecoyPeptide[iLenPeptide - i] = sDBI.sPeptide[i];
             piVarModSitesDecoy[iLenPeptide - i] = piVarModSites[i];
          }
       }
@@ -3068,7 +3076,7 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
    int ctIonSeries;
    int ctLen;
    int ctCharge;
-   int iLenPeptide = (int)strlen(sDBI.szPeptide);
+   int iLenPeptide = (int)sDBI.sPeptide.size();
    int iStartPos = 0;
    int iEndPos = iLenPeptide - 1;
    int iUnused = 0;
@@ -3095,26 +3103,29 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          iPositionNLY[i] = -1;     // default to less that first residue position
       }
 
-      for (i = 0; i < iEndPos; i++)
+      if (!sDBI.pcVarModSites.empty())
       {
-         if (sDBI.pcVarModSites[i] > 0)
+         for (i = 0; i < iEndPos; i++)
          {
-            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            if (sDBI.pcVarModSites[i] > 0)
             {
-               iPositionNLB[sDBI.pcVarModSites[i] - 1] = i;
-               break;
+               if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLB[sDBI.pcVarModSites[i] - 1] = i;
+                  break;
+               }
             }
          }
-      }
 
-      for (i = iEndPos; i >= 0; i--)
-      {
-         if (sDBI.pcVarModSites[i] > 0)
+         for (i = iEndPos; i >= 0; i--)
          {
-            if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+            if (sDBI.pcVarModSites[i] > 0)
             {
-               iPositionNLY[sDBI.pcVarModSites[i] - 1] = i;
-               break;
+               if (g_staticParams.variableModParameters.varModList[sDBI.pcVarModSites[i] - 1].dNeutralLoss != 0.0)
+               {
+                  iPositionNLY[sDBI.pcVarModSites[i] - 1] = i;
+                  break;
+               }
             }
          }
       }
@@ -3137,8 +3148,12 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          int piVarModSitesDecoy[MAX_PEPTIDE_LEN_P2];
 
          int iLen2 = iLenPeptide + 2;
-         for (int x = 0; x < iLen2; x++)
-            piVarModSites[x] = sDBI.pcVarModSites[x];
+         memset(piVarModSites, 0, sizeof(int) * iLen2);
+         if (!sDBI.pcVarModSites.empty())
+         {
+            for (int x = 0; x < iLen2; x++)
+               piVarModSites[x] = sDBI.pcVarModSites[x];
+         }
 
          // Calculate ion series just once to compare against all relevant query spectra.
          if (bFirstTimeThroughLoopForPeptide)
@@ -3174,20 +3189,20 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
                iFoundVariableMod = 1;
             }
 
-            // Generate pdAAforward for sDBI.szPeptide
+            // Generate pdAAforward for sDBI.sPeptide
             for (int i = iStartPos; i < iEndPos; i++)
             {
                int iPos = i - iStartPos;
                int iPos2 = iEndPos - i + iStartPos;
 
-               dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[i]];
+               dBion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.sPeptide[i]];
                if (piVarModSites[iPos] > 0)
                {
                   dBion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos] - 1].dVarModMass;
                   iFoundVariableMod = 1;
                }
 
-               dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.szPeptide[iPos2]];
+               dYion += g_staticParams.massUtility.pdAAMassFragment[(int)sDBI.sPeptide[iPos2]];
                if (piVarModSites[iPos2] > 0)
                {
                   dYion += g_staticParams.variableModParameters.varModList[piVarModSites[iPos2] - 1].dVarModMass;
@@ -3350,11 +3365,11 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
                   for (i = iEndPos - 1; i >= iStartPos; i--)
                   {
-                     szDecoyPeptide[iEndPos - i - 1] = sDBI.szPeptide[i - iStartPos];
+                     szDecoyPeptide[iEndPos - i - 1] = sDBI.sPeptide[i - iStartPos];
                      piVarModSitesDecoy[iEndPos - i - 1] = piVarModSites[i - iStartPos];
                   }
 
-                  szDecoyPeptide[iEndPos] = sDBI.szPeptide[iEndPos];  // last residue stays same
+                  szDecoyPeptide[iEndPos] = sDBI.sPeptide[iEndPos];  // last residue stays same
                   piVarModSitesDecoy[iLenPeptide - 1] = piVarModSites[iLenPeptide - 1];
                }
                else
@@ -3363,11 +3378,11 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
 
                   for (i = iEndPos; i > iStartPos; i--)
                   {
-                     szDecoyPeptide[iEndPos - i + 1] = sDBI.szPeptide[i - iStartPos];
+                     szDecoyPeptide[iEndPos - i + 1] = sDBI.sPeptide[i - iStartPos];
                      piVarModSitesDecoy[iEndPos - i + 1] = piVarModSites[i - iStartPos];
                   }
 
-                  szDecoyPeptide[iStartPos] = sDBI.szPeptide[iStartPos];  // first residue stays same
+                  szDecoyPeptide[iStartPos] = sDBI.sPeptide[iStartPos];  // first residue stays same
                   piVarModSitesDecoy[iStartPos] = piVarModSites[iStartPos];
                }
                szDecoyPeptide[iEndPos - iStartPos + 1] = '\0';
@@ -3573,12 +3588,12 @@ void CometSearch::AnalyzePeptideIndex(int iWhichQuery,
          if (cPrevAA == '-')
          {
             iStartPos = 0;
-            strcpy(szProtein, sDBI.szPeptide);
+            strcpy(szProtein, sDBI.sPeptide.c_str());
          }
          else
          {
             iStartPos = 1;
-            sprintf(szProtein, "%c%s", cPrevAA, sDBI.szPeptide);
+            sprintf(szProtein, "%c%s", cPrevAA, sDBI.sPeptide.c_str());
          }
 
          if (cNextAA == '-')
@@ -3867,18 +3882,17 @@ bool CometSearch::SearchForPeptides(struct sDBEntry dbe,
                DBIndex sEntry;
                sEntry.dPepMass = dCalcPepMass;  //MH+ mass
 
-               strncpy(sEntry.szPeptide, szProteinSeq + iStartPos, iLenPeptide);
-               sEntry.szPeptide[iLenPeptide] = '\0';
+               sEntry.sPeptide.assign(szProteinSeq + iStartPos, iLenPeptide);
                sEntry.cPrevAA = (iStartPos == iFirstResiduePosition) ? '-' : szProteinSeq[iStartPos - 1];
                sEntry.cNextAA = (iEndPos == iProteinSeqLengthMinus1) ? '-' : szProteinSeq[iEndPos + 1] ;
                sEntry.siVarModProteinFilter = siVarModProteinFilter;
 
                // little sanity check here to not include peptides with '*' in them
                // although mass check above should've caught these before
-               if (!strchr(sEntry.szPeptide, '*'))
+               if (sEntry.sPeptide.find('*') == string::npos)
                {
                   sEntry.lIndexProteinFilePosition = _proteinInfo.lProteinFilePosition;
-                  memset(sEntry.pcVarModSites, 0, sizeof(char) * (iLenPeptide + 2));
+                  sEntry.pcVarModSites.clear();  // empty = unmodified
 
                   if (g_staticParams.options.bCreateFragmentIndex
                      || (g_staticParams.options.bCreatePeptideIndex && dCalcPepMass >= g_massRange.dMinMass && dCalcPepMass <= g_massRange.dMaxMass))
@@ -8117,8 +8131,7 @@ bool CometSearch::MergeVarMods(char* szProteinSeq,
             // add to DBIndex vector
             DBIndex sDBTmp;
             sDBTmp.dPepMass = dCalcPepMass;  //MH+ mass
-            strncpy(sDBTmp.szPeptide, szProteinSeq + _varModInfo.iStartPos, iLenPeptide);
-            sDBTmp.szPeptide[iLenPeptide] = '\0';
+            sDBTmp.sPeptide.assign(szProteinSeq + _varModInfo.iStartPos, iLenPeptide);
 
             if (_varModInfo.iStartPos == 0)
                sDBTmp.cPrevAA = '-';
@@ -8132,10 +8145,9 @@ bool CometSearch::MergeVarMods(char* szProteinSeq,
 
             sDBTmp.lIndexProteinFilePosition = _proteinInfo.lProteinFilePosition;
 
-            memset(sDBTmp.pcVarModSites, 0, sizeof(sDBTmp.pcVarModSites));
-
+            sDBTmp.pcVarModSites.assign(iLen2, 0);
             for (int x = 0; x < iLen2; x++)  // +2 for n/c term mods
-               sDBTmp.pcVarModSites[x] = piVarModSites[x];
+               sDBTmp.pcVarModSites[x] = static_cast<char>(piVarModSites[x]);
 
             try
             {

--- a/CometSearch/CometSearch.h
+++ b/CometSearch/CometSearch.h
@@ -186,21 +186,6 @@ private:
                    int iLenPeptide,
                    int *piVarModSites,
                    struct sDBEntry *dbe);
-   // Existing batch-path overload (indexes g_pvQuery)
-   static void XcorrScoreI(char *szProteinSeq,
-                           int iStartPos,
-                           int iEndPos,
-                           int iFoundVariableMod,
-                           double dCalcPepMass,
-                           bool bDecoyPep,
-                           size_t iWhichQuery,
-                           int iLenPeptide,
-                           int *piVarModSites,
-                           struct sDBEntry *dbe,
-                           unsigned int uiBinnedIonMasses[MAX_FRAGMENT_CHARGE+1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS+2],
-                           unsigned int uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE],
-                           int iNumMatchedFragmentIons);
-   // Task 1.2: Thread-local overload accepting Query* directly.
    static void XcorrScoreI(char *szProteinSeq,
                            int iStartPos,
                            int iEndPos,
@@ -243,18 +228,6 @@ private:
                      bool bStoreSeparateDecoy,
                      int *piVarModSites,
                      struct sDBEntry *dbe);
-   // Existing batch-path overload (indexes g_pvQuery)
-   static void StorePeptideI(size_t iWhichQuery,
-                             int iStartPos,
-                             int iEndPos,
-                             int iFoundVariableMod,
-                             char *szProteinSeq,
-                             double dCalcPepMass,
-                             double dXcorr,
-                             bool bStoreSeparateDecoy,
-                             int *piVarModSites,
-                             struct sDBEntry *dbe);
-   // Task 1.2: Thread-local overload accepting Query* directly.
    static void StorePeptideI(Query* pQuery,
                              int iStartPos,
                              int iEndPos,
@@ -298,12 +271,6 @@ private:
                        int iLenPeptide,
                        struct sDBEntry* dbe);
    
-   // Existing batch-path overload (indexes g_pvQuery)
-   static void SearchFragmentIndex(size_t iWhichQuery,
-                                   ThreadPool* tp);
-
-   // Thread-local overload: searches a caller-owned Query* with
-   // a per-call pbDuplFragment buffer. Does not access g_pvQuery.
    static void SearchFragmentIndex(Query* pQuery,
                                    bool* pbDuplFragment);
 
@@ -402,6 +369,8 @@ private:
    unsigned int       _uiBinnedIonMassesDecoy[MAX_FRAGMENT_CHARGE + 1][NUM_ION_SERIES][MAX_PEPTIDE_LEN][VMODS + 2];
    unsigned int       _uiBinnedPrecursorNL[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
    unsigned int       _uiBinnedPrecursorNLDecoy[MAX_PRECURSOR_NL_SIZE][MAX_PRECURSOR_CHARGE];
+
+   static int  AcquirePoolSlot();       // Spin-wait for a free slot; returns index or -1 on timeout
 
    static bool *_pbSearchMemoryPool;    // Pool of memory to be shared by search threads
    static bool **_ppbDuplFragmentArr;   // Number of arrays equals number of threads

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -3098,7 +3098,7 @@ cleanup_results:
                   + std::string(buf) + " ms/spec (";
 
                std::snprintf(buf, sizeof(buf), "%.0f", 1000.0 / dTimePerSpectra);
-               strOut += std::string(buf) + "Hz)";
+               strOut += std::string(buf) + " Hz)";
 
                size_t peakKB = GetPeakMemoryKB();
                if (peakKB > 0)

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -33,8 +33,8 @@
 #include "AScoreOptions.h"
 #include "AScoreFactory.h"
 
-
 #include <sstream>
+#include <cstdio>
 
 #ifdef _WIN32
 #pragma comment(lib, "psapi.lib")
@@ -3091,17 +3091,28 @@ cleanup_results:
                else
                   strOut = "";
 
+               char buf[128];
+
+               std::snprintf(buf, sizeof(buf), "%.2f", dTimePerSpectra);
                strOut += CometMassSpecUtils::ElapsedTime(tBeginTime) + ", " + std::to_string(iTotalSpectraSearched) + " spectra, "
-                  + std::format("{:.2f}", dTimePerSpectra) + " ms/spec ("
-                  + std::format("{:.0f}", 1000.0 / dTimePerSpectra) + "Hz)";
+                  + std::string(buf) + " ms/spec (";
+
+               std::snprintf(buf, sizeof(buf), "%.0f", 1000.0 / dTimePerSpectra);
+               strOut += std::string(buf) + "Hz)";
 
                size_t peakKB = GetPeakMemoryKB();
                if (peakKB > 0)
                {
                   if (peakKB >= 1024 * 1024)
-                     strOut += ", " + std::format("{:.1f}", (peakKB / (1024.0 * 1024.0))) + "GB peak";
+                  {
+                     std::snprintf(buf, sizeof(buf), "%.1f", (peakKB / (1024.0 * 1024.0)));
+                     strOut += ", " + std::string(buf) + "GB peak";
+                  }
                   else
-                     strOut += ", " + std::format("{:.1f}", (peakKB / 1024.0)) + "MB peak";
+                  {
+                     std::snprintf(buf, sizeof(buf), "%.1f", (peakKB / 1024.0));
+                     strOut += ", " + std::string(buf) + "MB peak";
+                  }
                }
                strOut += "\n";
                logout(strOut);

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -36,7 +36,31 @@
 
 #include <sstream>
 
-#undef PERF_DEBUG
+#ifdef _WIN32
+#pragma comment(lib, "psapi.lib")
+#include <psapi.h>
+#else
+#include <sys/resource.h>
+#endif
+
+// Returns peak resident set size for the process in KB, or 0 on failure.
+static size_t GetPeakMemoryKB()
+{
+#ifdef _WIN32
+   PROCESS_MEMORY_COUNTERS pmc = {};
+   if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+      return pmc.PeakWorkingSetSize / 1024;
+#elif defined(__APPLE__)
+   struct rusage ru;
+   if (getrusage(RUSAGE_SELF, &ru) == 0)
+      return (size_t)ru.ru_maxrss / 1024;   // macOS returns bytes
+#else
+   struct rusage ru;
+   if (getrusage(RUSAGE_SELF, &ru) == 0)
+      return (size_t)ru.ru_maxrss;           // Linux returns KB
+#endif
+   return 0;
+}
 
 extern comet_fileoffset_t clSizeCometFileOffset;
 
@@ -2199,18 +2223,6 @@ bool CometSearchManager::DoSearch()
 
    bool bSucceeded = true;
 
-#ifdef PERF_DEBUG
-   // print set search parameters
-   std::map<std::string, CometParam*> mapParams = GetParamsMap();
-   for (std::map<std::string, CometParam*>::iterator it = mapParams.begin(); it != mapParams.end(); ++it)
-   {
-      if (it->first != "[COMET_ENZYME_INFO]")
-      {
-         printf("OK parameter name=\"%s\" value=\"%s\"\n", it->first.c_str(), it->second->GetStringValue().c_str());
-      }
-   }
-#endif
-
    // add git hash to version string if present
    // repeated here from Comet main() as main() is skipped when search invoked via DLL
    if (strlen(GITHUBSHA) > 0)
@@ -2386,7 +2398,7 @@ bool CometSearchManager::DoSearch()
 
       time_t tStartTime;
       time(&tStartTime);
-      strftime(g_staticParams.szDate, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tStartTime));
+      strftime(g_staticParams.szDate, 26, "%Y/%m/%d, %I:%M:%S %p", localtime(&tStartTime));
 
       if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
       {
@@ -2851,31 +2863,11 @@ bool CometSearchManager::DoSearch()
          while (!CometPreprocess::DoneProcessingAllSpectra()) // Loop through iMaxSpectraPerSearch
          {
             iBatchNum++;
-#ifdef PERF_DEBUG
-            time_t tTotalSearchStartTime;
-            time_t tTotalSearchEndTime;
-            time_t tLoadAndPreprocessSpectraStartTime;
-            time_t tLoadAndPreprocessSpectraEndTime;
-            time_t tRunSearchStartTime;
-            time_t tRunSearchEndTime;
-            time_t tPostAnalysisStartTime;
-            time_t tPostAnalysisEndTime;
 
-            char szTimeBuffer[32];
-            szTimeBuffer[0] = '\0';
-#endif
             // Load and preprocess all the spectra.
             if (!g_staticParams.options.bOutputSqtStream && g_staticParams.iDbType == DbType::FASTA_DB)
             {
                logout("   - Load spectra:");
-
-#ifdef PERF_DEBUG
-               time(&tLoadAndPreprocessSpectraStartTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tLoadAndPreprocessSpectraStartTime));
-               strOut = "\n >> Start LoadAndPreprocessSpectra:  " + string(szTimeBuffer) + "\n";
-               logout(strOut);
-#endif
-
                fflush(stdout);
             }
 
@@ -2892,20 +2884,6 @@ bool CometSearchManager::DoSearch()
 
             iPercentStart = iPercentEnd;
             iPercentEnd = mstReader.getPercent();
-
-#ifdef PERF_DEBUG
-            if (!g_staticParams.options.bOutputSqtStream)
-            {
-               time(&tLoadAndPreprocessSpectraEndTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tLoadAndPreprocessSpectraEndTime));
-               strOut = "\n >> End LoadAndPreprocessSpectra:  " + string(szTimeBuffer) + string("\n");
-               logout(strOut);
-               int iElapsedTime = (int)difftime(tLoadAndPreprocessSpectraEndTime, tLoadAndPreprocessSpectraStartTime);
-               strOut = "\n >> Time spent in LoadAndPreprocessSpectra:  " + iElapsedTime + string(" seconds\n");
-               logout(strOut);
-               fflush(stdout);
-            }
-#endif
 
             if (g_pvQuery.empty())
                continue;    //FIX make sure continue instead of break makes sense
@@ -2960,17 +2938,6 @@ bool CometSearchManager::DoSearch()
             else
                g_massRange.bNarrowMassRange = false;
 
-#ifdef PERF_DEBUG
-            if (!g_staticParams.options.bOutputSqtStream)
-            {
-               time(&tRunSearchStartTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tRunSearchStartTime));
-               strOut = "\n >> Start RunSearch:  " + string(szTimeBuffer) + string("\n");
-               logout(strOut);
-               fflush(stdout);
-            }
-#endif
-
             bSucceeded = !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
             if (!bSucceeded)
                goto cleanup_results;
@@ -2985,27 +2952,6 @@ bool CometSearchManager::DoSearch()
 
             if (!bSucceeded)
                goto cleanup_results;
-
-#ifdef PERF_DEBUG
-            if (!g_staticParams.options.bOutputSqtStream)
-            {
-               time(&tRunSearchEndTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tRunSearchEndTime));
-               strOut = "\n >> End RunSearch:  " + string(szTimeBuffer) + string("\n");
-               logout(strOut);
-
-               int iElapsedTime=(int)difftime(tRunSearchEndTime, tRunSearchStartTime);
-               strOut = "\n >> Time spent in RunSearch:  " + std::to_string(iElapsedTime) + string("seconds \n");
-               logout(strOut);
-
-               time(&tPostAnalysisStartTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tPostAnalysisStartTime));
-               strOut = "\n >> Start PostAnalysis:  " + string(szTimeBuffer) + string("\n");
-               logout(strOut);
-
-               fflush(stdout);
-            }
-#endif
 
             bSucceeded = !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
             if (!bSucceeded)
@@ -3028,20 +2974,6 @@ bool CometSearchManager::DoSearch()
             if (!bSucceeded)
                goto cleanup_results;
 
-#ifdef PERF_DEBUG
-            if (g_bPerformDatabaseSearch && !g_staticParams.options.bOutputSqtStream)
-            {
-               time(&tPostAnalysisEndTime);
-               strftime(szTimeBuffer, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tPostAnalysisEndTime));
-               strOut = "\n >> End PostAnalysis:  " + string(szTimeBuffer) + string("\n");
-               logout(strOut);
-
-               int iElapsedTime=(int)difftime(tPostAnalysisEndTime, tPostAnalysisStartTime);
-               strOut = "\n >> Time spent in PostAnalysis:  " + std::to_string(iElapsedTime) + string("seconds \n");
-               logout(strOut);
-               fflush(stdout);
-            }
-#endif
             // Sort g_pvQuery vector by scan.
             std::sort(g_pvQuery.begin(), g_pvQuery.end(), compareByScanNumber);
 
@@ -3086,13 +3018,6 @@ cleanup_results:
 
             if (!bSucceeded)
                break;
-         }
-
-         if (g_bPerformDatabaseSearch && g_staticParams.iDbType != DbType::FASTA_DB)
-         {
-            const auto duration = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - tBeginTime);
-            double dTimePerSpectra = (double)duration.count() / (double)iTotalSpectraSearched;
-            cout << CometMassSpecUtils::ElapsedTime(tBeginTime) << " (" << iTotalSpectraSearched << " spectra searched, " << std::fixed << std::setprecision(2) << dTimePerSpectra << " ms/spectrum, " << 1000.0 / dTimePerSpectra << " Hz)" << endl;
          }
 
          if (bSucceeded)
@@ -3151,22 +3076,37 @@ cleanup_results:
                time(&tEndTime);
                int iElapsedTime = (int)difftime(tEndTime, tStartTime);
 
-               strftime(g_staticParams.szDate, 26, "%m/%d/%Y, %I:%M:%S %p", localtime(&tEndTime));
+               strftime(g_staticParams.szDate, 26, "%Y/%m/%d, %I:%M:%S %p", localtime(&tEndTime));
                strOut = " Search end:    " + string(g_staticParams.szDate);
-
-               int hours, mins, secs;
-
-               hours = (int)(iElapsedTime/3600);
-               mins = (int)(iElapsedTime/60) - (hours*60);
-               secs = (int)(iElapsedTime%60);
-
-               if (hours)
-                  strOut += ", " + std::to_string(hours) + "h:" + std::to_string(mins) + "m:" + std::to_string(secs) + "s\n\n";
-               else
-                  strOut += ", " + std::to_string(mins) + "m:" + std::to_string(secs) + "s\n\n";
-
                logout(strOut);
             }
+
+            if (!g_staticParams.options.bOutputSqtStream)
+            {
+               const auto duration = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - tBeginTime);
+               double dTimePerSpectra = (double)duration.count() / (double)iTotalSpectraSearched;
+
+               if (g_staticParams.iDbType == DbType::FASTA_DB)
+                  strOut = ", ";
+               else
+                  strOut = "";
+
+               strOut += CometMassSpecUtils::ElapsedTime(tBeginTime) + ", " + std::to_string(iTotalSpectraSearched) + " spectra, "
+                  + std::format("{:.2f}", dTimePerSpectra) + " ms/spec ("
+                  + std::format("{:.0f}", 1000.0 / dTimePerSpectra) + "Hz)";
+
+               size_t peakKB = GetPeakMemoryKB();
+               if (peakKB > 0)
+               {
+                  if (peakKB >= 1024 * 1024)
+                     strOut += ", " + std::format("{:.1f}", (peakKB / (1024.0 * 1024.0))) + "GB peak";
+                  else
+                     strOut += ", " + std::format("{:.1f}", (peakKB / 1024.0)) + "MB peak";
+               }
+               strOut += "\n";
+               logout(strOut);
+            }
+
          }
 
          if (fpidx != NULL)
@@ -3559,18 +3499,6 @@ bool CometSearchManager::DoSingleSpectrumSearchMultiResults(const int topN,
 
    if (!InitializeSingleSpectrumSearch())
       return false;
-
-#ifdef PERF_DEBUG
-   // print set search parameters
-   std::map<std::string, CometParam*> mapParams = GetParamsMap();
-   for (std::map<std::string, CometParam*>::iterator it = mapParams.begin(); it != mapParams.end(); ++it)
-   {
-      if (it->first != "[COMET_ENZYME_INFO]")
-      {
-         printf("OK parameter name=\"%s\" value=\"%s\"\n", it->first.c_str(), it->second->GetStringValue().c_str());
-      }
-   }
-#endif
 
    bool bSucceeded = true;
 

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -3092,7 +3092,7 @@ cleanup_results:
          {
             const auto duration = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - tBeginTime);
             double dTimePerSpectra = (double)duration.count() / (double)iTotalSpectraSearched;
-            cout << CometMassSpecUtils::ElapsedTime(tBeginTime) << " (" << std::fixed << std::setprecision(2) << dTimePerSpectra << " ms per spectrum)" << endl;
+            cout << CometMassSpecUtils::ElapsedTime(tBeginTime) << " (" << iTotalSpectraSearched << " spectra searched, " << std::fixed << std::setprecision(2) << dTimePerSpectra << " ms/spectrum, " << 1000.0 / dTimePerSpectra << " Hz)" << endl;
          }
 
          if (bSucceeded)

--- a/CometSearch/CometSearchManager.cpp
+++ b/CometSearch/CometSearchManager.cpp
@@ -73,8 +73,8 @@ AScoreProCpp::AScoreDllInterface* g_AScoreInterface;
 vector<vector<comet_fileoffset_t>> g_pvProteinsList;
 
 // Fragment index globals - INITIALIZED ONCE, READ-ONLY DURING SEARCH
-unsigned int** g_iFragmentIndex;                            // stores fragment index; [BIN(fragmass)][which g_vFragmentPeptides entries]
-unsigned int* g_iCountFragmentIndex;                        // stores counts of fragment index; [BIN(fragmass)]
+unsigned int* g_iFragmentIndex;                             // CSR flat data: concatenated posting lists
+unsigned int* g_iFragmentIndexOffset;                       // CSR offsets [uiMaxFragmentArrayIndex+1]
 bool* g_bIndexPrecursors;                                   // array for BIN(precursors), set to true if precursor present in file
 vector<struct FragmentPeptidesStruct> g_vFragmentPeptides;  // each peptide is represented here iWhichPeptide, which mod if any, calculated mass
 vector<PlainPeptideIndexStruct> g_vRawPeptides;             // list of unmodified peptides and their proteins as file pointers
@@ -3280,15 +3280,8 @@ cleanup_results:
    {
       free(g_bIndexPrecursors);       // allocated in InitializeStaticParams
 
-      for (unsigned int iMass = 0; iMass < g_massRange.uiMaxFragmentArrayIndex; ++iMass)
-      {
-         if (g_iFragmentIndex[iMass] != NULL)
-         {
-            delete[] g_iFragmentIndex[iMass];
-         }
-      }
       delete[] g_iFragmentIndex;
-      delete[] g_iCountFragmentIndex;
+      delete[] g_iFragmentIndexOffset;
    }
 
    if (g_staticParams.iDbType != DbType::FASTA_DB) // for either index search

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DEPS = CometSearch/CometData.h CometSearch/CometDataInternal.h CometSearch/Comet
 LIBPATHS = -L$(MSTOOLKIT) -L$(COMETSEARCH) -L$(ASCOREPRO)
 LIBS = -lcometsearch -lmstoolkit -lmstoolkitextern -lascorepro -lm -lpthread
 ifdef MSYSTEM
-   LIBS += -lws2_32
+   LIBS += -lws2_32 -lpsapi
 endif
 
 LIBCOMETSEARCH = $(COMETSEARCH)/libcometsearch.a

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,20 @@ ifdef MSYSTEM
    LIBS += -lws2_32
 endif
 
-comet.exe: $(OBJS)
-	cd $(MSTOOLKIT) && make all
-	cd $(ASCOREPRO) && make all
-	cd $(COMETSEARCH) && make
+LIBCOMETSEARCH = $(COMETSEARCH)/libcometsearch.a
+
+comet.exe: $(OBJS) $(LIBCOMETSEARCH)
+	cd $(MSTOOLKIT) && $(MAKE) all
+	cd $(ASCOREPRO) && $(MAKE) all
 
 ifeq ($(UNAME_S),Darwin)
 	${CXX} $(OBJS) -headerpad_max_install_names -o ${EXECNAME} $(CXXFLAGS) $(LIBPATHS) $(LIBS)
 else
 	${CXX} $(OBJS) -o ${EXECNAME} $(CXXFLAGS) $(LIBPATHS) $(LIBS)
 endif
+
+$(LIBCOMETSEARCH): $(wildcard $(COMETSEARCH)/*.cpp $(COMETSEARCH)/*.h $(COMETSEARCH)/*.hpp)
+	cd $(COMETSEARCH) && $(MAKE)
 
 Comet.o: Comet.cpp $(DEPS)
 	${CXX} ${CXXFLAGS} Comet.cpp -c

--- a/RealtimeSearch/SearchMS1MS2.cs
+++ b/RealtimeSearch/SearchMS1MS2.cs
@@ -447,14 +447,17 @@
                         line = string.Format("Scans processed: {0}", scansProcessedMS2);
                         rtsWriter.WriteLine(line);
 
-                        line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessedMS2);
+                        double dAvgTimePerScan = scansProcessedMS2 > 0 ? elapsedGlobal.TotalMilliseconds / scansProcessedMS2 : 0;
+                        double dHz = dAvgTimePerScan > 0 ? 1000.0 / dAvgTimePerScan : 0;
+
+                        line = string.Format("Average time per scan: {0:F2} ms", dAvgTimePerScan);
                         rtsWriter.WriteLine(line);
 
                         line = string.Format("\ninitialize search elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);
                         line = string.Format("search elapsed time: {0:F2} s, avg {1:F2} ms/spectrum ({2} spectra), {3:F0} Hz\n",
-                           watchGlobal.Elapsed.TotalSeconds, watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2, scansProcessedMS2, 1000.0 / (watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2));
+                           watchGlobal.Elapsed.TotalSeconds, dAvgTimePerScan, scansProcessedMS2, dHz);
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);
 

--- a/RealtimeSearch/SearchMS1MS2.cs
+++ b/RealtimeSearch/SearchMS1MS2.cs
@@ -145,7 +145,7 @@
                      }
 
                      // MS1 RT parameters
-                     double dMaxMS1RTDiff = 300.0;    // maximum allowed retention time difference between query and reference, in seconds
+                     double dMaxMS1RTDiff = 100.0;    // maximum allowed retention time difference between query and reference, in seconds
                      double dMaxQueryRT = 60.0 * rawFile.RetentionTimeFromScanNumber(iLastScan);
 
                      int iPrintEveryScan = 1;
@@ -453,7 +453,7 @@
                         line = string.Format("\ninitialize search elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);
-                        line = string.Format("search elapsed time: {0:F2} s, avg {1:F2} ms/spectrum ({2} spectra), {3:F1} Hz\n",
+                        line = string.Format("search elapsed time: {0:F2} s, avg {1:F2} ms/spectrum ({2} spectra), {3:F0} Hz\n",
                            watchGlobal.Elapsed.TotalSeconds, watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2, scansProcessedMS2, 1000.0 / (watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2));
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);

--- a/RealtimeSearch/SearchMS1MS2.cs
+++ b/RealtimeSearch/SearchMS1MS2.cs
@@ -159,7 +159,7 @@
                      var scanQueue = new ConcurrentQueue<int>();
                      var results = new ConcurrentBag<ScanResult>();
                      var progressLock = new object();
-                     int scansProcessed = 0;
+                     int scansProcessedMS2 = 0;
                      int totalScans = iLastScan - iFirstScan + 1;
 
                      // Initialize ONCE (before threading)
@@ -193,11 +193,6 @@
 
                               if (scanFilter.MSOrder != MSOrderType.Ms && scanFilter.MSOrder != MSOrderType.Ms2)
                               {
-                                 // Update progress for non-searchable scans
-                                 lock (progressLock)
-                                 {
-                                    scansProcessed++;
-                                 }
                                  continue;
                               }
 
@@ -223,10 +218,6 @@
 
                               if (iNumPeaks < 10)  // don't bother searching sparse spectra
                               {
-                                 lock (progressLock)
-                                 {
-                                    scansProcessed++;
-                                 }
                                  continue;
                               }
 
@@ -279,10 +270,6 @@
 
                                  if (dExpPepMass < dPeptideMassLow || dExpPepMass > dPeptideMassHigh)
                                  {
-                                    lock (progressLock)
-                                    {
-                                       scansProcessed++;
-                                    }
                                     continue;
                                  }
 
@@ -301,6 +288,12 @@
                                  result.Proteins = vProtein;
                                  result.Scores = vScores;
                                  result.ElapsedMs = (int)watch.ElapsedMilliseconds;
+
+
+                                 lock (progressLock)
+                                 {
+                                    scansProcessedMS2++;
+                                 }
                               }
 
                               results.Add(result);
@@ -308,21 +301,16 @@
                               // Update progress
                               lock (progressLock)
                               {
-                                 scansProcessed++;
-                                 if (scansProcessed % 100 == 0)
+                                 if (scansProcessedMS2 % 500 == 0)
                                  {
-                                    double percentComplete = (double)scansProcessed / totalScans * 100.0;
-                                    Console.Write("\r Progress: {0:F1}% ({1}/{2} scans)", percentComplete, scansProcessed, totalScans);
+                                    double percentComplete = (double)scansProcessedMS2 / totalScans * 100.0;
+                                    Console.Write("\r Progress: {0:F1}% ({1}/{2} scans)", percentComplete, scansProcessedMS2, totalScans);
                                  }
                               }
                            }
                            catch (Exception ex)
                            {
                               Console.WriteLine("\n Thread {0}: Error processing scan {1}: {2}", threadId, iScanNumber, ex.Message);
-                              lock (progressLock)
-                              {
-                                 scansProcessed++;
-                              }
                            }
                         }
                      }
@@ -352,7 +340,7 @@
                      var sortedResults = results.OrderBy(r => r.ScanNumber).ToList();
 
                      // Create histograms
-                     int iMaxHistogramTime = 1000;
+                     int iMaxHistogramTime = 200;
                      int[] piTimeSearchMS1 = new int[iMaxHistogramTime];
                      int[] piTimeSearchMS2 = new int[iMaxHistogramTime];
                      var slowestRuns = new List<(int TimeMs, string Peptide, int ScanNumber, double XCorr)>();
@@ -456,16 +444,17 @@
                         line = string.Format("\nTotal elapsed time: {0:F2} minutes", elapsedGlobal.TotalMinutes);
                         rtsWriter.WriteLine(line);
 
-                        line = string.Format("Scans processed: {0}", scansProcessed);
+                        line = string.Format("Scans processed: {0}", scansProcessedMS2);
                         rtsWriter.WriteLine(line);
 
-                        line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessed);
+                        line = string.Format("Average time per scan: {0:F2} ms", elapsedGlobal.TotalMilliseconds / scansProcessedMS2);
                         rtsWriter.WriteLine(line);
 
                         line = string.Format("\ninitialize search elapsed time: {0:F2} s", watchIndexCreate.Elapsed.TotalSeconds);
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);
-                        line = string.Format("search elapsed time: {0:F2} s, avg per spectrum {1:F2} ms\n", watchGlobal.Elapsed.TotalSeconds, watchGlobal.Elapsed.TotalMilliseconds / scansProcessed);
+                        line = string.Format("search elapsed time: {0:F2} s, avg {1:F2} ms/spectrum ({2} spectra), {3:F1} Hz\n",
+                           watchGlobal.Elapsed.TotalSeconds, watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2, scansProcessedMS2, 1000.0 / (watchGlobal.Elapsed.TotalMilliseconds / scansProcessedMS2));
                         rtsWriter.WriteLine(line);
                         Console.WriteLine(line);
 
@@ -742,7 +731,7 @@
                   iTmp = 3;
                   sTmp = iTmp.ToString();
                   SearchMgr.SetParam("fragindex_min_ions_report", sTmp, iTmp);
-                  iTmp = 100;
+                  iTmp = 150;
                   sTmp = iTmp.ToString();
                   SearchMgr.SetParam("fragindex_num_spectrumpeaks", sTmp, iTmp);
                   dTmp = 200.0;


### PR DESCRIPTION
Change the fragment ion index from "unsigned int** gi_FragmentIndex" to "unsigned int* g_iFragmentIndex" (compressed sparse row flat data). 
Shrink memory use a bit of "struct DbIndex" by changing "char szPeptide[MAX_PEPTIDE_LEN]" to "string sPeptide" and "char pcVarModSites[MAX_PEPTIDE_LEN_P2]" to "vector<char> pcVarModSites".
Extend CometMassSpecUtils::DBICompareByPeptide() to also consider cPrevAA and cNextAA in the sort in order to get deterministic output for the reporting flanking residues.
Actually implement the fragindex_num_spectrumpeaks parameter; issue identified by M. Hoopmann.
Remove iWhichQuery-indexed SearchFragmentIndex, XcorrScoreI, and StorePeptideI overloads.
Add cross-platform peak memory use display at end of search.