### PR TITLE
Fused batch path memory/performance fixes and FI_DB batch/RTS correctness fixes

### DIFF
--- a/AScorePro/AScoreCalculator.cpp
+++ b/AScorePro/AScoreCalculator.cpp
@@ -141,18 +141,42 @@ namespace AScoreProCpp
          peptides.push_back(p);
       }
 
-      // Sort by score. Prefer original sequence if tied.
+      // Sort by score, descending. On an exact tie, prefer whichever candidate
+      // matches the original (pre-AScore) site placement Comet passed in, so
+      // an ambiguous site stays stable instead of being silently reassigned,
+      // and the choice is grounded in candidate content rather than in
+      // whatever order the peptide generator happened to enumerate
+      // combinations -- which is not itself guaranteed stable across
+      // otherwise-equivalent call contexts (e.g. batch vs. RTS).
+      //
+      // The previous comparator was not a valid strict-weak-ordering: on a
+      // tie it returned "a.toString() == b.toString() ? 1 : 0", which is true
+      // in both directions when a and b are the same peptide (violating
+      // asymmetry) and false in both directions for two genuinely different,
+      // equal-scoring peptides -- leaving std::sort's actual outcome for that
+      // case entirely dependent on generator enumeration order and
+      // std::sort's internal partitioning, not a deliberate rule. It also
+      // never referenced `original` despite the "prefer original sequence"
+      // comment describing the intent.
       struct PeptideScoreComparer
       {
          const Peptide& original;
          explicit PeptideScoreComparer(const Peptide& orig) : original(orig) {}
          bool operator()(const Peptide& a, const Peptide& b) const
          {
-            if (a.getScore() == b.getScore())
-            {
-               return a.toString() == b.toString() ? 1 : 0;
-            }
-            return a.getScore() > b.getScore();
+            if (a.getScore() != b.getScore())
+               return a.getScore() > b.getScore();
+
+            bool bAIsOriginal = (a.toString() == original.toString());
+            bool bBIsOriginal = (b.toString() == original.toString());
+
+            if (bAIsOriginal != bBIsOriginal)
+               return bAIsOriginal;
+
+            // Neither candidate matches the seed placement: fall back to a
+            // canonical, content-only order so the result no longer depends
+            // on enumeration order at all.
+            return a.toString() < b.toString();
          }
       };
 

--- a/CometSearch/CometAlignment.cpp
+++ b/CometSearch/CometAlignment.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/CometAlignment.h
+++ b/CometSearch/CometAlignment.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/CometMassSpecUtils.cpp
+++ b/CometSearch/CometMassSpecUtils.cpp
@@ -634,6 +634,34 @@ string CometMassSpecUtils::GetPeakMemory()
    return strOut;
 }
 
+// See header comment: current (not peak) resident memory, for before/after deltas.
+size_t CometMassSpecUtils::GetCurrentWorkingSetKB()
+{
+   size_t currentMemoryKB = 0;
+
+#ifdef _WIN32
+   PROCESS_MEMORY_COUNTERS pmc = {};
+   if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+   {
+      currentMemoryKB = pmc.WorkingSetSize / 1024;
+   }
+#elif defined(__APPLE__)
+   struct rusage ru;
+   if (getrusage(RUSAGE_SELF, &ru) == 0)
+   {
+      currentMemoryKB = (size_t)ru.ru_maxrss / 1024;   // macOS returns bytes; ru_maxrss is peak, not current, but there is no portable "current RSS" via getrusage
+   }
+#else
+   struct rusage ru;
+   if (getrusage(RUSAGE_SELF, &ru) == 0)
+   {
+      currentMemoryKB = (size_t)ru.ru_maxrss;          // Linux returns KB; same peak-not-current caveat as above
+   }
+#endif
+
+   return currentMemoryKB;
+}
+
 // Plain free function usable from C++/CLI without pulling in CometDataInternal.h
 string GetPeakMemoryStr()
 {

--- a/CometSearch/CometMassSpecUtils.h
+++ b/CometSearch/CometMassSpecUtils.h
@@ -88,10 +88,17 @@ public:
 
    static string GetPeakMemory();
 
-   // Current (not peak) resident memory in KB, 0 on failure. Unlike GetPeakMemory()
-   // (a monotonic process-lifetime high-water mark), this is a point-in-time snapshot
-   // suitable for before/after deltas -- e.g. measuring the incremental memory cost
-   // of a specific phase (see FusedPreloadThenSearch in CometPreprocess.cpp).
+   // Current resident memory in KB, 0 on failure, intended as a point-in-time
+   // snapshot suitable for before/after deltas -- e.g. measuring the incremental
+   // memory cost of a specific phase (see FusedPreloadThenSearch in
+   // CometPreprocess.cpp). This distinction from GetPeakMemory() (a monotonic
+   // process-lifetime high-water mark) only holds on Windows, which has a true
+   // current-RSS query (GetProcessMemoryInfo's WorkingSetSize). macOS and Linux
+   // have no portable current-RSS query via getrusage(), so their
+   // implementations fall back to ru_maxrss -- peak, not current -- making
+   // deltas computed from two calls to this function unreliable on those
+   // platforms (a delta of two peak readings is not the incremental cost of
+   // the phase between them).
    static size_t GetCurrentWorkingSetKB();
 
 };

--- a/CometSearch/CometMassSpecUtils.h
+++ b/CometSearch/CometMassSpecUtils.h
@@ -88,6 +88,12 @@ public:
 
    static string GetPeakMemory();
 
+   // Current (not peak) resident memory in KB, 0 on failure. Unlike GetPeakMemory()
+   // (a monotonic process-lifetime high-water mark), this is a point-in-time snapshot
+   // suitable for before/after deltas -- e.g. measuring the incremental memory cost
+   // of a specific phase (see FusedPreloadThenSearch in CometPreprocess.cpp).
+   static size_t GetCurrentWorkingSetKB();
+
 };
 
 #endif // _COMETMASSSPECUTILS_H_

--- a/CometSearch/CometPostAnalysis.cpp
+++ b/CometSearch/CometPostAnalysis.cpp
@@ -390,21 +390,43 @@ void CometPostAnalysis::AnalyzeSP(Query* pQuery)
    // Target search
    CalculateSP(pQuery->_pResults, pQuery, iSize);
 
-   std::sort(pQuery->_pResults, pQuery->_pResults + iSize, SortFnSp);
-
-   pQuery->_pResults[0].usiRankSp = 1;
-
-   for (int ii=1; ii<iSize; ++ii)
+   // Rank by SP score via an index permutation rather than physically sorting
+   // _pResults by SP and then sorting it back to Xcorr order. isEqual() is an
+   // epsilon-tolerant, non-transitive relation (a~b and b~c does not imply
+   // a~c), so std::sort's result for an isEqual-tied-but-not-bitwise-identical
+   // group is not actually guaranteed independent of the array's order going
+   // into that sort -- a real hazard when the array has just been reordered
+   // by a *different* comparator (SortFnSp) immediately beforehand. Doing the
+   // rank assignment on a side index array means _pResults is sorted by
+   // SortFnXcorr exactly once for this stage (matching RTS's single-pass
+   // std::partial_sort(SortFnXcorr)), so there is no second Xcorr sort whose
+   // outcome could depend on that intermediate SP-order detour.
+   if (iSize > 0)
    {
-      // Determine score rankings
-      if (isEqual(pQuery->_pResults[ii].fScoreSp, pQuery->_pResults[ii-1].fScoreSp))
-         pQuery->_pResults[ii].usiRankSp = pQuery->_pResults[ii-1].usiRankSp;
-      else
-         pQuery->_pResults[ii].usiRankSp = pQuery->_pResults[ii-1].usiRankSp + 1;
+      std::vector<int> viSpOrder(iSize);
+      for (int ii = 0; ii < iSize; ++ii)
+         viSpOrder[ii] = ii;
+
+      std::sort(viSpOrder.begin(), viSpOrder.end(),
+         [pQuery](int a, int b)
+         {
+            return SortFnSp(pQuery->_pResults[a], pQuery->_pResults[b]);
+         });
+
+      pQuery->_pResults[viSpOrder[0]].usiRankSp = 1;
+
+      for (int ii=1; ii<iSize; ++ii)
+      {
+         // Determine score rankings
+         if (isEqual(pQuery->_pResults[viSpOrder[ii]].fScoreSp, pQuery->_pResults[viSpOrder[ii-1]].fScoreSp))
+            pQuery->_pResults[viSpOrder[ii]].usiRankSp = pQuery->_pResults[viSpOrder[ii-1]].usiRankSp;
+         else
+            pQuery->_pResults[viSpOrder[ii]].usiRankSp = pQuery->_pResults[viSpOrder[ii-1]].usiRankSp + 1;
+      }
    }
 
-   // Then sort each entry in descending order by xcorr
-   std::sort(pQuery->_pResults, pQuery->_pResults + iSize, SortFnXcorr);
+   // _pResults is still in the Xcorr order from the sort above -- no second
+   // SortFnXcorr sort needed here.
 
    // if mod search, now sort peptides with same score but different mod locations
    if (g_staticParams.variableModParameters.bVarModSearch)
@@ -443,20 +465,35 @@ void CometPostAnalysis::AnalyzeSP(Query* pQuery)
 
       CalculateSP(pQuery->_pDecoys, pQuery, iSize);
 
-      std::sort(pQuery->_pDecoys, pQuery->_pDecoys + iSize, SortFnSp);
-      pQuery->_pDecoys[0].usiRankSp = 1;
-
-      for (int ii=1; ii<iSize; ++ii)
+      // See the matching target-branch block above for why this ranks via an
+      // index permutation instead of a destructive sort-by-SP-then-back-to-
+      // Xcorr round trip.
+      if (iSize > 0)
       {
-         // Determine score rankings
-         if (isEqual(pQuery->_pDecoys[ii].fScoreSp, pQuery->_pDecoys[ii-1].fScoreSp))
-            pQuery->_pDecoys[ii].usiRankSp = pQuery->_pDecoys[ii-1].usiRankSp;
-         else
-            pQuery->_pDecoys[ii].usiRankSp = pQuery->_pDecoys[ii-1].usiRankSp + 1;
+         std::vector<int> viSpOrder(iSize);
+         for (int ii = 0; ii < iSize; ++ii)
+            viSpOrder[ii] = ii;
+
+         std::sort(viSpOrder.begin(), viSpOrder.end(),
+            [pQuery](int a, int b)
+            {
+               return SortFnSp(pQuery->_pDecoys[a], pQuery->_pDecoys[b]);
+            });
+
+         pQuery->_pDecoys[viSpOrder[0]].usiRankSp = 1;
+
+         for (int ii=1; ii<iSize; ++ii)
+         {
+            // Determine score rankings
+            if (isEqual(pQuery->_pDecoys[viSpOrder[ii]].fScoreSp, pQuery->_pDecoys[viSpOrder[ii-1]].fScoreSp))
+               pQuery->_pDecoys[viSpOrder[ii]].usiRankSp = pQuery->_pDecoys[viSpOrder[ii-1]].usiRankSp;
+            else
+               pQuery->_pDecoys[viSpOrder[ii]].usiRankSp = pQuery->_pDecoys[viSpOrder[ii-1]].usiRankSp + 1;
+         }
       }
 
-      // Then sort each entry by xcorr
-      std::sort(pQuery->_pDecoys, pQuery->_pDecoys + iSize, SortFnXcorr);
+      // _pDecoys is still in the Xcorr order from the sort above -- no second
+      // SortFnXcorr sort needed here.
 
       // if mod search, now sort peptides with same score but different mod locations
       if (g_staticParams.variableModParameters.bVarModSearch)

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -169,27 +169,6 @@ struct RtsScratch
       iResultsCapacity = iCapacity;
    }
 
-   // Resets the subset of Results fields that PreprocessSingleSpectrumCore's
-   // batch-path (non-pooled) loop also resets -- see the near-duplicate loops
-   // there for the batch-path equivalent. Mirrors that loop's field list exactly.
-   static void ResetOneResult(Results& r)
-   {
-      r.dPepMass = 0.0;
-      r.dExpect = 999;
-      r.fScoreSp = 0.0;
-      r.fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-      r.fAScorePro = 0.0;
-      r.usiLenPeptide = 0;
-      r.usiRankSp = 0;
-      r.usiMatchedIons = 0;
-      r.usiTotalIons = 0;
-      r.szPeptide[0] = '\0';
-      r.sAScoreProSiteScores.clear();
-      r.pWhichProtein.clear();
-      r.sPeffOrigResidues.clear();
-      r.iPeffOrigResiduePosition = -9;
-   }
-
    // Called at the start of each new spectrum so pResults/pDecoys are clean for reuse.
    void ResetResultsForNewSpectrum()
    {
@@ -1190,7 +1169,8 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
                                  float *pfFastXcorrData,
                                  float *pfFastXcorrDataNL,
                                  float *pfSpScoreData,
-                                 FusedSparseArena *pArena)
+                                 FusedSparseArena *pArena,
+                                 FusedPointerArena *pPtrArena)
 {
    int i;
    int x;
@@ -1300,19 +1280,27 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
             || g_staticParams.ionInformation.iIonVal[ION_SERIES_Y]))
    {
 
-      try
+      if (pPtrArena != nullptr)
       {
-         pScoring->ppfSparseFastXcorrDataNL = new float*[pScoring->iFastXcorrDataSize]();
+         pScoring->ppfSparseFastXcorrDataNL = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
+         pScoring->bSparsePointerArraysFromPool = true;
       }
-      catch (std::bad_alloc& ba)
+      else
       {
-         string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrDataNL["
-            + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-            + "parameters to address mitigate memory use.\n";
-         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-         logerr(strErrorMsg);
-         return false;
+         try
+         {
+            pScoring->ppfSparseFastXcorrDataNL = new float*[pScoring->iFastXcorrDataSize]();
+         }
+         catch (std::bad_alloc& ba)
+         {
+            string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrDataNL["
+               + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+               + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+               + "parameters to address mitigate memory use.\n";
+            g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+            logerr(strErrorMsg);
+            return false;
+         }
       }
 
       for (i=1; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
@@ -1354,19 +1342,27 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
    }
 
    //MH: Fill sparse matrix
-   try
+   if (pPtrArena != nullptr)
    {
-      pScoring->ppfSparseFastXcorrData = new float*[pScoring->iFastXcorrDataSize]();
+      pScoring->ppfSparseFastXcorrData = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
+      pScoring->bSparsePointerArraysFromPool = true;
    }
-   catch (std::bad_alloc& ba)
+   else
    {
-      string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrData["
-         + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-         + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-         + "parameters to address mitigate memory use.\n";
-      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-      logerr(strErrorMsg);
-      return false;
+      try
+      {
+         pScoring->ppfSparseFastXcorrData = new float*[pScoring->iFastXcorrDataSize]();
+      }
+      catch (std::bad_alloc& ba)
+      {
+         string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrData["
+            + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+            + "parameters to address mitigate memory use.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
    }
 
    for (i=1; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
@@ -1415,19 +1411,27 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
    // MH: Fill sparse matrix for SpScore
    pScoring->iSpScoreData = pScoring->_spectrumInfoInternal.iArraySize / SPARSE_MATRIX_SIZE + 1;
 
-   try
+   if (pPtrArena != nullptr)
    {
-      pScoring->ppfSparseSpScoreData = new float*[pScoring->iSpScoreData]();
+      pScoring->ppfSparseSpScoreData = pPtrArena->AllocSpan(pScoring->iSpScoreData);
+      pScoring->bSparsePointerArraysFromPool = true;
    }
-   catch (std::bad_alloc& ba)
+   else
    {
-      string strErrorMsg =" Error - new(pScoring->ppfSparseSpScoreData["
-         + std::to_string(pScoring->iSpScoreData) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-         + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-         + "parameters to address mitigate memory use.\n";
-      g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-      logerr(strErrorMsg);
-      return false;
+      try
+      {
+         pScoring->ppfSparseSpScoreData = new float*[pScoring->iSpScoreData]();
+      }
+      catch (std::bad_alloc& ba)
+      {
+         string strErrorMsg =" Error - new(pScoring->ppfSparseSpScoreData["
+            + std::to_string(pScoring->iSpScoreData) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+            + "parameters to address mitigate memory use.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
    }
 
    for (i=0; i<pScoring->_spectrumInfoInternal.iArraySize; ++i)
@@ -2011,20 +2015,7 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
 
       for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
       {
-         pScoring->_pResults[j].dPepMass = 0.0;
-         pScoring->_pResults[j].dExpect = 999;
-         pScoring->_pResults[j].fScoreSp = 0.0;
-         pScoring->_pResults[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-         pScoring->_pResults[j].fAScorePro = 0.0;
-         pScoring->_pResults[j].usiLenPeptide = 0;
-         pScoring->_pResults[j].usiRankSp = 0;
-         pScoring->_pResults[j].usiMatchedIons = 0;
-         pScoring->_pResults[j].usiTotalIons = 0;
-         pScoring->_pResults[j].szPeptide[0] = '\0';
-         pScoring->_pResults[j].sAScoreProSiteScores.clear();
-         pScoring->_pResults[j].pWhichProtein.clear();
-         pScoring->_pResults[j].sPeffOrigResidues.clear();
-         pScoring->_pResults[j].iPeffOrigResiduePosition = -9;
+         ResetOneResult(pScoring->_pResults[j]);
 
          if (g_staticParams.options.iDecoySearch)
             pScoring->_pResults[j].pWhichDecoyProtein.clear();
@@ -2035,22 +2026,7 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
          pScoring->_pDecoys = new Results[g_staticParams.options.iNumStored];
 
          for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
-         {
-            pScoring->_pDecoys[j].dPepMass = 0.0;
-            pScoring->_pDecoys[j].dExpect = 999;
-            pScoring->_pDecoys[j].fScoreSp = 0.0;
-            pScoring->_pDecoys[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-            pScoring->_pDecoys[j].fAScorePro = 0.0;
-            pScoring->_pDecoys[j].usiLenPeptide = 0;
-            pScoring->_pDecoys[j].usiRankSp = 0;
-            pScoring->_pDecoys[j].usiMatchedIons = 0;
-            pScoring->_pDecoys[j].usiTotalIons = 0;
-            pScoring->_pDecoys[j].szPeptide[0] = '\0';
-            pScoring->_pDecoys[j].sAScoreProSiteScores.clear();
-            pScoring->_pDecoys[j].pWhichProtein.clear();
-            pScoring->_pDecoys[j].sPeffOrigResidues.clear();
-            pScoring->_pDecoys[j].iPeffOrigResiduePosition = -9;
-         }
+            ResetOneResult(pScoring->_pDecoys[j]);
       }
    }
 
@@ -3185,7 +3161,9 @@ void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
                                           int iSlot,
                                           std::vector<Query*>& outQueries,
                                           std::atomic<size_t>& outCount,
-                                          FusedSparseArena* pArena)
+                                          FusedSparseArena* pArena,
+                                          FusedResultsArena* pResultsArena,
+                                          FusedPointerArena* pPtrArena)
 {
    int iScanNumber = spec.getScanNumber();
    int iSpectrumCharge = 0;
@@ -3347,76 +3325,66 @@ void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
                continue;
             }
 
-            try
+            if (pResultsArena != nullptr)
             {
-               pScoring->_pResults = new Results[g_staticParams.options.iNumStored];
+               FusedResultsArena::ResultsPair pair = pResultsArena->AllocResultsPair();
+               pScoring->_pResults = pair.pResults;
+               pScoring->_pDecoys  = pair.pDecoys;
+               pScoring->bResultsFromPool = true;
             }
-            catch (std::bad_alloc& ba)
-            {
-               string strErrorMsg = " Error - new(_pResults[]). bad_alloc: " + std::string(ba.what()) + "\n";
-               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-               logerr(strErrorMsg);
-               delete pScoring;
-               return;
-            }
-
-            if (g_staticParams.options.iDecoySearch == 2)
+            else
             {
                try
                {
-                  pScoring->_pDecoys = new Results[g_staticParams.options.iNumStored];
+                  pScoring->_pResults = new Results[g_staticParams.options.iNumStored];
                }
                catch (std::bad_alloc& ba)
                {
-                  string strErrorMsg = " Error - new(_pDecoys[]). bad_alloc: " + std::string(ba.what()) + "\n";
+                  string strErrorMsg = " Error - new(_pResults[]). bad_alloc: " + std::string(ba.what()) + "\n";
                   g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
                   logerr(strErrorMsg);
                   delete pScoring;
                   return;
+               }
+
+               if (g_staticParams.options.iDecoySearch == 2)
+               {
+                  try
+                  {
+                     pScoring->_pDecoys = new Results[g_staticParams.options.iNumStored];
+                  }
+                  catch (std::bad_alloc& ba)
+                  {
+                     string strErrorMsg = " Error - new(_pDecoys[]). bad_alloc: " + std::string(ba.what()) + "\n";
+                     g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                     logerr(strErrorMsg);
+                     delete pScoring;
+                     return;
+                  }
+               }
+
+               // Arena-issued Results (above) are already reset by AllocResultsPair();
+               // freshly new[]'d Results here still need it.
+               for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
+               {
+                  ResetOneResult(pScoring->_pResults[j]);
+                  if (g_staticParams.options.iDecoySearch == 2)
+                     ResetOneResult(pScoring->_pDecoys[j]);
                }
             }
 
             pScoring->iMatchPeptideCount = 0;
             pScoring->iDecoyMatchPeptideCount = 0;
 
+            // ResetOneResult() deliberately never touches pWhichDecoyProtein (see its
+            // comment in core/Types.h) -- clear it here regardless of whether _pResults
+            // came from the arena or a fresh new[], same as before this pool existed.
             for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
             {
-               pScoring->_pResults[j].dPepMass = 0.0;
-               pScoring->_pResults[j].dExpect = 999;
-               pScoring->_pResults[j].fScoreSp = 0.0;
-               pScoring->_pResults[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-               pScoring->_pResults[j].fAScorePro = 0.0;
-               pScoring->_pResults[j].usiLenPeptide = 0;
-               pScoring->_pResults[j].usiRankSp = 0;
-               pScoring->_pResults[j].usiMatchedIons = 0;
-               pScoring->_pResults[j].usiTotalIons = 0;
-               pScoring->_pResults[j].szPeptide[0] = '\0';
-               pScoring->_pResults[j].sAScoreProSiteScores.clear();
-               pScoring->_pResults[j].pWhichProtein.clear();
-               pScoring->_pResults[j].sPeffOrigResidues.clear();
-               pScoring->_pResults[j].iPeffOrigResiduePosition = -9;
                memset(pScoring->iXcorrHistogram, 0, sizeof(pScoring->iXcorrHistogram));
 
                if (g_staticParams.options.iDecoySearch)
                   pScoring->_pResults[j].pWhichDecoyProtein.clear();
-
-               if (g_staticParams.options.iDecoySearch == 2)
-               {
-                  pScoring->_pDecoys[j].dPepMass = 0.0;
-                  pScoring->_pDecoys[j].dExpect = 999;
-                  pScoring->_pDecoys[j].fScoreSp = 0.0;
-                  pScoring->_pDecoys[j].fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-                  pScoring->_pDecoys[j].fAScorePro = 0.0;
-                  pScoring->_pDecoys[j].usiLenPeptide = 0;
-                  pScoring->_pDecoys[j].usiRankSp = 0;
-                  pScoring->_pDecoys[j].usiMatchedIons = 0;
-                  pScoring->_pDecoys[j].usiTotalIons = 0;
-                  pScoring->_pDecoys[j].szPeptide[0] = '\0';
-                  pScoring->_pDecoys[j].sAScoreProSiteScores.clear();
-                  pScoring->_pDecoys[j].pWhichProtein.clear();
-                  pScoring->_pDecoys[j].sPeffOrigResidues.clear();
-                  pScoring->_pDecoys[j].iPeffOrigResiduePosition = -9;
-               }
             }
 
             // Preprocess using thread-local scratch buffers; Preprocess() memsets
@@ -3428,7 +3396,7 @@ void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
                             g_rtsScratch.pfFastXcorrData,
                             g_rtsScratch.pfFastXcorrDataNL,
                             g_rtsScratch.pfSpScoreData,
-                            pArena))
+                            pArena, pPtrArena))
             {
                delete pScoring;
                continue;
@@ -3519,6 +3487,26 @@ bool CometPreprocess::FusedLoadAndSearchSpectra(MSReader& mstReader,
    if (session.sparseArenas.empty())
       session.sparseArenas.resize(iNumSlots);
 
+   // Per-slot pool for the outer sparse pointer arrays: same first-use sizing/
+   // persistence pattern as sparseArenas above -- see
+   // docs/20260723_ExtendFusedBatchPath.md Phase 2a.
+   if (session.pointerArenas.empty())
+      session.pointerArenas.resize(iNumSlots);
+
+   // Per-slot _pResults/_pDecoys pool: same first-use sizing/persistence pattern
+   // as sparseArenas above -- see docs/20260723_ExtendFusedBatchPath.md Phase 2b.
+   // EnsureInitialized() captures iNumStored/decoy-search config once; both are
+   // assumed constant for the SearchSession's lifetime (comet.params is not
+   // re-read mid-run), the same assumption sparseArenas already makes about
+   // iNumThreads.
+   if (session.resultsArenas.empty())
+   {
+      session.resultsArenas.resize(iNumSlots);
+      for (auto& arena : session.resultsArenas)
+         arena.EnsureInitialized(g_staticParams.options.iNumStored,
+                                 g_staticParams.options.iDecoySearch == 2);
+   }
+
    // Running count of accumulated Query* across all workers.  Only read by the
    // producer, and only when iSpectrumBatchSize != 0 (batch-size cap feature).
    std::atomic<size_t> aQueryCount{0};
@@ -3537,7 +3525,8 @@ bool CometPreprocess::FusedLoadAndSearchSpectra(MSReader& mstReader,
          Spectrum spec;
          while (queue.pop(spec))
             FusedSearchSpectrum(std::move(spec), t, vSlotQueries[t].v, aQueryCount,
-                                &session.sparseArenas[t]);
+                                &session.sparseArenas[t], &session.resultsArenas[t],
+                                &session.pointerArenas[t]);
       });
    }
 

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -1189,7 +1189,8 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
                                  double *pdTmpCorrelationData,
                                  float *pfFastXcorrData,
                                  float *pfFastXcorrDataNL,
-                                 float *pfSpScoreData)
+                                 float *pfSpScoreData,
+                                 FusedSparseArena *pArena)
 {
    int i;
    int x;
@@ -1321,22 +1322,30 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
             x=i/SPARSE_MATRIX_SIZE;
             if (pScoring->ppfSparseFastXcorrDataNL[x]==NULL)
             {
-               try
+               if (pArena != nullptr)
                {
-                  pScoring->ppfSparseFastXcorrDataNL[x] = new float[SPARSE_MATRIX_SIZE]();
+                  pScoring->ppfSparseFastXcorrDataNL[x] = pArena->AllocBlock();
+                  pScoring->bSparseFromPool = true;
                }
-               catch (std::bad_alloc& ba)
+               else
                {
-                  string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrDataNL["
-                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-                     + "parameters to address mitigate memory use.\n";
-                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-                  logerr(strErrorMsg);
-                  return false;
+                  try
+                  {
+                     pScoring->ppfSparseFastXcorrDataNL[x] = new float[SPARSE_MATRIX_SIZE]();
+                  }
+                  catch (std::bad_alloc& ba)
+                  {
+                     string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrDataNL["
+                        + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                        + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                        + "parameters to address mitigate memory use.\n";
+                     g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                     logerr(strErrorMsg);
+                     return false;
+                  }
+                  for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
+                     pScoring->ppfSparseFastXcorrDataNL[x][y]=0;
                }
-               for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
-                  pScoring->ppfSparseFastXcorrDataNL[x][y]=0;
             }
             y=i-(x*SPARSE_MATRIX_SIZE);
             pScoring->ppfSparseFastXcorrDataNL[x][y] = pfFastXcorrDataNL[i];
@@ -1367,22 +1376,30 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
          x=i/SPARSE_MATRIX_SIZE;
          if (pScoring->ppfSparseFastXcorrData[x]==NULL)
          {
-            try
+            if (pArena != nullptr)
             {
-               pScoring->ppfSparseFastXcorrData[x] = new float[SPARSE_MATRIX_SIZE]();
+               pScoring->ppfSparseFastXcorrData[x] = pArena->AllocBlock();
+               pScoring->bSparseFromPool = true;
             }
-            catch (std::bad_alloc& ba)
+            else
             {
-               string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrData["
-                  + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-                  + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-                  + "parameters to address mitigate memory use.\n";
-               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-               logerr(strErrorMsg);
-               return false;
+               try
+               {
+                  pScoring->ppfSparseFastXcorrData[x] = new float[SPARSE_MATRIX_SIZE]();
+               }
+               catch (std::bad_alloc& ba)
+               {
+                  string strErrorMsg =" Error - new(pScoring->ppfSparseFastXcorrData["
+                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                     + "parameters to address mitigate memory use.\n";
+                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                  logerr(strErrorMsg);
+                  return false;
+               }
+               for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
+                  pScoring->ppfSparseFastXcorrData[x][y]=0;
             }
-            for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
-               pScoring->ppfSparseFastXcorrData[x][y]=0;
          }
          y=i-(x*SPARSE_MATRIX_SIZE);
          pScoring->ppfSparseFastXcorrData[x][y] = pfFastXcorrData[i];
@@ -1420,22 +1437,30 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
          x=i/SPARSE_MATRIX_SIZE;
          if (pScoring->ppfSparseSpScoreData[x]==NULL)
          {
-            try
+            if (pArena != nullptr)
             {
-               pScoring->ppfSparseSpScoreData[x] = new float[SPARSE_MATRIX_SIZE]();
+               pScoring->ppfSparseSpScoreData[x] = pArena->AllocBlock();
+               pScoring->bSparseFromPool = true;
             }
-            catch (std::bad_alloc& ba)
+            else
             {
-               string strErrorMsg =" Error - new(pScoring->ppfSparseSpScoreData["
-                  + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
-                  + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
-                  + "parameters to address mitigate memory use.\n";
-               g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
-               logerr(strErrorMsg);
-               return false;
+               try
+               {
+                  pScoring->ppfSparseSpScoreData[x] = new float[SPARSE_MATRIX_SIZE]();
+               }
+               catch (std::bad_alloc& ba)
+               {
+                  string strErrorMsg =" Error - new(pScoring->ppfSparseSpScoreData["
+                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                     + "parameters to address mitigate memory use.\n";
+                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                  logerr(strErrorMsg);
+                  return false;
+               }
+               for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
+                  pScoring->ppfSparseSpScoreData[x][y]=0;
             }
-            for (y=0; y<SPARSE_MATRIX_SIZE; ++y)
-               pScoring->ppfSparseSpScoreData[x][y]=0;
          }
          y=i-(x*SPARSE_MATRIX_SIZE);
          pScoring->ppfSparseSpScoreData[x][y] = pfSpScoreData[i];
@@ -3159,7 +3184,8 @@ QueryMS1* CometPreprocess::PreprocessMS1SingleSpectrumThreadLocal(double* pdMass
 void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
                                           int iSlot,
                                           std::vector<Query*>& outQueries,
-                                          std::atomic<size_t>& outCount)
+                                          std::atomic<size_t>& outCount,
+                                          FusedSparseArena* pArena)
 {
    int iScanNumber = spec.getScanNumber();
    int iSpectrumCharge = 0;
@@ -3401,7 +3427,8 @@ void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
                             g_rtsScratch.pdTmpCorrelationData,
                             g_rtsScratch.pfFastXcorrData,
                             g_rtsScratch.pfFastXcorrDataNL,
-                            g_rtsScratch.pfSpScoreData))
+                            g_rtsScratch.pfSpScoreData,
+                            pArena))
             {
                delete pScoring;
                continue;
@@ -3482,6 +3509,16 @@ bool CometPreprocess::FusedLoadAndSearchSpectra(MSReader& mstReader,
    struct alignas(64) SlotVec { std::vector<Query*> v; };
    std::vector<SlotVec> vSlotQueries(iNumSlots);
 
+   // Per-slot sparse-XCorr-matrix arenas: sized once (first call for this session),
+   // then reused/reset across every subsequent flush round -- see
+   // docs/20260723_ExtendFusedBatchPath.md. Not resized on later calls even if
+   // iNumThreads could theoretically change mid-run (it can't -- iNumThreads is
+   // fixed at InitializeStaticParams() time), mirroring how vSlotQueries above is
+   // freshly sized every round but sparseArenas deliberately is not (its whole
+   // point is to persist across rounds).
+   if (session.sparseArenas.empty())
+      session.sparseArenas.resize(iNumSlots);
+
    // Running count of accumulated Query* across all workers.  Only read by the
    // producer, and only when iSpectrumBatchSize != 0 (batch-size cap feature).
    std::atomic<size_t> aQueryCount{0};
@@ -3495,11 +3532,12 @@ bool CometPreprocess::FusedLoadAndSearchSpectra(MSReader& mstReader,
 
    for (int t = 0; t < iNumSlots; ++t)
    {
-      tp->doJob([&queue, t, &vSlotQueries, &aQueryCount]()
+      tp->doJob([&queue, t, &vSlotQueries, &aQueryCount, &session]()
       {
          Spectrum spec;
          while (queue.pop(spec))
-            FusedSearchSpectrum(std::move(spec), t, vSlotQueries[t].v, aQueryCount);
+            FusedSearchSpectrum(std::move(spec), t, vSlotQueries[t].v, aQueryCount,
+                                &session.sparseArenas[t]);
       });
    }
 

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -1295,8 +1295,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
 
       if (pPtrArena != nullptr)
       {
-         pScoring->ppfSparseFastXcorrDataNL = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
-         pScoring->bSparsePointerArraysFromPool = true;
+         try
+         {
+            pScoring->ppfSparseFastXcorrDataNL = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
+            pScoring->bSparsePointerArraysFromPool = true;
+         }
+         catch (std::bad_alloc& ba)
+         {
+            string strErrorMsg =" Error - AllocSpan(pScoring->ppfSparseFastXcorrDataNL["
+               + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+               + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+               + "parameters to address mitigate memory use.\n";
+            g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+            logerr(strErrorMsg);
+            return false;
+         }
       }
       else
       {
@@ -1325,8 +1338,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
             {
                if (pArena != nullptr)
                {
-                  pScoring->ppfSparseFastXcorrDataNL[x] = pArena->AllocBlock();
-                  pScoring->bSparseFromPool = true;
+                  try
+                  {
+                     pScoring->ppfSparseFastXcorrDataNL[x] = pArena->AllocBlock();
+                     pScoring->bSparseFromPool = true;
+                  }
+                  catch (std::bad_alloc& ba)
+                  {
+                     string strErrorMsg =" Error - AllocBlock(pScoring->ppfSparseFastXcorrDataNL["
+                        + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                        + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                        + "parameters to address mitigate memory use.\n";
+                     g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                     logerr(strErrorMsg);
+                     return false;
+                  }
                }
                else
                {
@@ -1357,8 +1383,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
    //MH: Fill sparse matrix
    if (pPtrArena != nullptr)
    {
-      pScoring->ppfSparseFastXcorrData = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
-      pScoring->bSparsePointerArraysFromPool = true;
+      try
+      {
+         pScoring->ppfSparseFastXcorrData = pPtrArena->AllocSpan(pScoring->iFastXcorrDataSize);
+         pScoring->bSparsePointerArraysFromPool = true;
+      }
+      catch (std::bad_alloc& ba)
+      {
+         string strErrorMsg =" Error - AllocSpan(pScoring->ppfSparseFastXcorrData["
+            + std::to_string(pScoring->iFastXcorrDataSize) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+            + "parameters to address mitigate memory use.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
    }
    else
    {
@@ -1387,8 +1426,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
          {
             if (pArena != nullptr)
             {
-               pScoring->ppfSparseFastXcorrData[x] = pArena->AllocBlock();
-               pScoring->bSparseFromPool = true;
+               try
+               {
+                  pScoring->ppfSparseFastXcorrData[x] = pArena->AllocBlock();
+                  pScoring->bSparseFromPool = true;
+               }
+               catch (std::bad_alloc& ba)
+               {
+                  string strErrorMsg =" Error - AllocBlock(pScoring->ppfSparseFastXcorrData["
+                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                     + "parameters to address mitigate memory use.\n";
+                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                  logerr(strErrorMsg);
+                  return false;
+               }
             }
             else
             {
@@ -1426,8 +1478,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
 
    if (pPtrArena != nullptr)
    {
-      pScoring->ppfSparseSpScoreData = pPtrArena->AllocSpan(pScoring->iSpScoreData);
-      pScoring->bSparsePointerArraysFromPool = true;
+      try
+      {
+         pScoring->ppfSparseSpScoreData = pPtrArena->AllocSpan(pScoring->iSpScoreData);
+         pScoring->bSparsePointerArraysFromPool = true;
+      }
+      catch (std::bad_alloc& ba)
+      {
+         string strErrorMsg =" Error - AllocSpan(pScoring->ppfSparseSpScoreData["
+            + std::to_string(pScoring->iSpScoreData) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+            + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+            + "parameters to address mitigate memory use.\n";
+         g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+         logerr(strErrorMsg);
+         return false;
+      }
    }
    else
    {
@@ -1456,8 +1521,21 @@ bool CometPreprocess::Preprocess(struct Query *pScoring,
          {
             if (pArena != nullptr)
             {
-               pScoring->ppfSparseSpScoreData[x] = pArena->AllocBlock();
-               pScoring->bSparseFromPool = true;
+               try
+               {
+                  pScoring->ppfSparseSpScoreData[x] = pArena->AllocBlock();
+                  pScoring->bSparseFromPool = true;
+               }
+               catch (std::bad_alloc& ba)
+               {
+                  string strErrorMsg =" Error - AllocBlock(pScoring->ppfSparseSpScoreData["
+                     + std::to_string(x) + "][" + std::to_string(SPARSE_MATRIX_SIZE) + "]). bad_alloc: " + std::string(ba.what()) + ".\n"
+                     + "Comet ran out of memory. Look into \"spectrum_batch_size\"\n"
+                     + "parameters to address mitigate memory use.\n";
+                  g_cometStatus.SetStatus(CometResult_Failed, strErrorMsg);
+                  logerr(strErrorMsg);
+                  return false;
+               }
             }
             else
             {
@@ -3422,14 +3500,14 @@ void CometPreprocess::FusedSearchSpectrum(Spectrum spec,
             pScoring->iMatchPeptideCount = 0;
             pScoring->iDecoyMatchPeptideCount = 0;
 
+            memset(pScoring->iXcorrHistogram, 0, sizeof(pScoring->iXcorrHistogram));
+
             // ResetOneResult() deliberately never touches pWhichDecoyProtein (see its
             // comment in core/Types.h) -- clear it here regardless of whether _pResults
             // came from the arena or a fresh new[], same as before this pool existed.
-            for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
+            if (g_staticParams.options.iDecoySearch)
             {
-               memset(pScoring->iXcorrHistogram, 0, sizeof(pScoring->iXcorrHistogram));
-
-               if (g_staticParams.options.iDecoySearch)
+               for (int j = 0; j < g_staticParams.options.iNumStored; ++j)
                   pScoring->_pResults[j].pWhichDecoyProtein.clear();
             }
 

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -249,11 +249,12 @@ struct BoundedSpectrumQueue
 
 
 // Mutates mstSpectrum in place (clearMzRange zeroes cleared-range intensities)
-// and moves it into queue if it survives all three filters.  Returns true iff
-// the spectrum was enqueued.  This is the ONLY copy of this filter sequence;
-// both the synchronous and readahead loops in FusedLoadAndSearchSpectra call
-// it so they cannot drift apart on a future filter change.
-bool CometPreprocess::FilterAndEnqueueSpectrum(Spectrum& mstSpectrum, BoundedSpectrumQueue& queue)
+// and returns true iff it survives the iMinPeaks/activation-method filters.
+// This is the ONLY copy of this filter sequence; FilterAndEnqueueSpectrum below
+// (both the synchronous and readahead loops in FusedLoadAndSearchSpectra) and
+// the diagnostic FusedPreloadThenSearch's own read loop all call it so they
+// cannot drift apart on a future filter change.
+bool CometPreprocess::ApplySpectrumFilters(Spectrum& mstSpectrum)
 {
    int iNumClearedPeaks = 0;
 
@@ -279,6 +280,16 @@ bool CometPreprocess::FilterAndEnqueueSpectrum(Spectrum& mstSpectrum, BoundedSpe
       return false;
 
    if (!CometPreprocess::CheckActivationMethodFilter(mstSpectrum.getActivationMethod()))
+      return false;
+
+   return true;
+}
+
+// Moves mstSpectrum into queue if it survives ApplySpectrumFilters().  Returns
+// true iff the spectrum was enqueued.
+bool CometPreprocess::FilterAndEnqueueSpectrum(Spectrum& mstSpectrum, BoundedSpectrumQueue& queue)
+{
+   if (!ApplySpectrumFilters(mstSpectrum))
       return false;
 
    queue.push(std::move(mstSpectrum));
@@ -3734,6 +3745,224 @@ bool CometPreprocess::FusedLoadAndSearchSpectra(MSReader& mstReader,
    // mutated.  Concatenate into session.queries (ownership of the raw Query* moves
    // by value; they are freed later in Pipeline cleanupBatch).  Push order is
    // irrelevant: Pipeline.cpp sorts by scan number before writing.
+   size_t iTotalQueries = 0;
+   for (auto& slot : vSlotQueries)
+      iTotalQueries += slot.v.size();
+
+   session.queries.reserve(session.queries.size() + iTotalQueries);
+   for (auto& slot : vSlotQueries)
+   {
+      session.queries.insert(session.queries.end(), slot.v.begin(), slot.v.end());
+      slot.v.clear();
+   }
+
+   return !g_cometStatus.IsError() && !g_cometStatus.IsCancel();
+}
+
+
+// DIAGNOSTIC / BENCHMARK ONLY -- not part of the normal search pipeline.
+// Opt-in via the COMET_PRELOAD_BENCHMARK environment variable (see
+// FiStrategy::executeBatch / PiStrategy::executeBatch). Reads every matching
+// spectrum for the current input file into memory FIRST (single-threaded, same
+// filters as the normal fused path), then dispatches the whole in-memory set
+// across the thread pool for search -- separately timed and memory-snapshotted
+// at each phase boundary. This exists to answer one specific question: how much
+// of the normal fused path's measured Hz is raw-file read/parse time vs. actual
+// search, by reproducing RTS's own preload-then-search-only-timed methodology
+// (RealtimeSearch/SearchMS1MS2.cs) inside the batch path for a fair comparison.
+// See docs/20260724_PreloadBenchmark.md.
+//
+// Unlike FusedLoadAndSearchSpectra, this always consumes the ENTIRE remaining
+// scan range in one call (no FUSED_FLUSH_MIN_BATCH_SIZE flush cap) -- the whole
+// point is to measure one uninterrupted preload phase and one uninterrupted
+// search phase, not to bound peak memory the way normal batch search does.
+bool CometPreprocess::FusedPreloadThenSearch(MSReader& mstReader,
+                                             int iFirstScan,
+                                             int iLastScan,
+                                             int iAnalysisType,
+                                             ThreadPool* tp,
+                                             SearchSession& session)
+{
+   int iFileLastScan = -1;
+   int iScanNumber = 0;
+   int iTotalScans = 0;
+   int iTmpCount = 0;
+   Spectrum mstSpectrum;
+
+   g_massRange.usiMaxFragmentCharge = 0;
+   g_staticParams.precalcMasses.iMinus17 = BIN(g_staticParams.massUtility.dH2O);
+   g_staticParams.precalcMasses.iMinus18 = BIN(g_staticParams.massUtility.dNH3);
+
+   Threading::InitMutex(&_maxChargeMutex);
+
+   const int iNumSlots = g_staticParams.options.iNumThreads;
+
+   struct alignas(64) SlotVec { std::vector<Query*> v; };
+   std::vector<SlotVec> vSlotQueries(iNumSlots);
+
+   if (session.sparseArenas.empty())
+      session.sparseArenas.resize(iNumSlots);
+   if (session.pointerArenas.empty())
+      session.pointerArenas.resize(iNumSlots);
+   if (session.resultsArenas.empty())
+   {
+      session.resultsArenas.resize(iNumSlots);
+      for (auto& arena : session.resultsArenas)
+         arena.EnsureInitialized(g_staticParams.options.iNumStored,
+                                 g_staticParams.options.iDecoySearch == 2);
+   }
+
+   std::atomic<size_t> aQueryCount{0};   // unused for flow control here (no flush cap); FusedSearchSpectrum's signature still requires it
+
+   // ---- Phase 1: preload every matching spectrum into memory ----
+   const size_t memBeforePreloadKB = CometMassSpecUtils::GetCurrentWorkingSetKB();
+   const auto tPreloadStart = chrono::steady_clock::now();
+
+   std::vector<Spectrum> vAllSpectra;
+   vAllSpectra.reserve(200000);   // generous upfront guess to avoid most reallocation churn; grows if needed
+
+   while (true)
+   {
+      if (_bFirstScan)
+      {
+         PreloadIons(mstReader, mstSpectrum, false, 0);
+         _bFirstScan = false;
+      }
+      else
+      {
+         PreloadIons(mstReader, mstSpectrum, true);
+      }
+
+      if (iFileLastScan == -1)
+         iFileLastScan = mstReader.getLastScan();
+
+      if ((iFileLastScan != -1) && (iFileLastScan < iFirstScan))
+      {
+         _bDoneProcessingAllSpectra = true;
+         break;
+      }
+
+      iScanNumber = mstSpectrum.getScanNumber();
+
+      if (g_staticParams.bSkipToStartScan && iScanNumber < iFirstScan)
+      {
+         g_staticParams.bSkipToStartScan = false;
+
+         PreloadIons(mstReader, mstSpectrum, false, iFirstScan);
+         iScanNumber = mstSpectrum.getScanNumber();
+
+         while (iScanNumber == 0 && iFirstScan < iLastScan)
+         {
+            iFirstScan++;
+            PreloadIons(mstReader, mstSpectrum, false, iFirstScan);
+            iScanNumber = mstSpectrum.getScanNumber();
+         }
+      }
+
+      if (iScanNumber != 0)
+      {
+         iTmpCount = iScanNumber;
+
+         if (iLastScan != 0 && iScanNumber > iLastScan)
+         {
+            _bDoneProcessingAllSpectra = true;
+            break;
+         }
+         if (iFirstScan != 0 && iLastScan != 0 && !(iFirstScan <= iScanNumber && iScanNumber <= iLastScan))
+            continue;
+         if (iFirstScan != 0 && iLastScan == 0 && iScanNumber < iFirstScan)
+            continue;
+
+         if (ApplySpectrumFilters(mstSpectrum))
+            vAllSpectra.push_back(std::move(mstSpectrum));
+
+         iTotalScans++;
+      }
+      else if (IsValidInputType(g_staticParams.inputFile.iInputType))
+      {
+         _bDoneProcessingAllSpectra = true;
+         break;
+      }
+      else
+      {
+         iTmpCount++;
+         if (iTmpCount > iFileLastScan)
+         {
+            _bDoneProcessingAllSpectra = true;
+            break;
+         }
+      }
+
+      // bIgnoreSpectrumBatchSize=true: read the ENTIRE remaining range in this
+      // one preload phase, deliberately ignoring both the legacy spectrum_batch_size
+      // concept and the fused path's FUSED_FLUSH_MIN_BATCH_SIZE flush cap.
+      if (CheckExit(iAnalysisType, iScanNumber, iTotalScans, iLastScan,
+                    mstReader.getLastScan(), 0, true))
+      {
+         _bDoneProcessingAllSpectra = true;
+         break;
+      }
+   }
+
+   const double dPreloadSeconds = chrono::duration<double>(chrono::steady_clock::now() - tPreloadStart).count();
+   const size_t memAfterPreloadKB = CometMassSpecUtils::GetCurrentWorkingSetKB();
+
+   if (!g_staticParams.options.bOutputSqtStream)
+   {
+      // Signed double delta -- GetCurrentWorkingSetKB() is a point-in-time snapshot,
+      // not a monotonic counter, so it CAN legitimately decrease. This was not just
+      // theoretical: a large-file run (326,696 spectra) showed working set drop from
+      // 37.42GB to 4.31GB across the search phase, consistent with the OS trimming
+      // this process's working set under real memory pressure -- see
+      // docs/20260724_PreloadBenchmark.md's "Follow-up" section. An unsigned (size_t)
+      // subtraction here would silently underflow to a huge bogus value instead of
+      // showing that negative delta (this bug was hit and fixed during that run).
+      printf(" [PRELOAD] %zu spectra in %.3fs (%.1f Hz) -- memory %.2fGB -> %.2fGB (%+.2fGB)\n",
+             vAllSpectra.size(), dPreloadSeconds,
+             (dPreloadSeconds > 0.0) ? (vAllSpectra.size() / dPreloadSeconds) : 0.0,
+             memBeforePreloadKB / (1024.0 * 1024.0), memAfterPreloadKB / (1024.0 * 1024.0),
+             ((double)memAfterPreloadKB - (double)memBeforePreloadKB) / (1024.0 * 1024.0));
+      fflush(stdout);
+   }
+
+   // ---- Phase 2: search every preloaded spectrum across the thread pool ----
+   const auto tSearchStart = chrono::steady_clock::now();
+
+   std::atomic<size_t> iNextIndex{0};
+   const size_t iTotalSpectra = vAllSpectra.size();
+
+   for (int t = 0; t < iNumSlots; ++t)
+   {
+      tp->doJob([&vAllSpectra, &iNextIndex, iTotalSpectra, t, &vSlotQueries, &aQueryCount, &session]()
+      {
+         size_t i;
+         while ((i = iNextIndex.fetch_add(1, std::memory_order_relaxed)) < iTotalSpectra)
+         {
+            FusedSearchSpectrum(std::move(vAllSpectra[i]), t, vSlotQueries[t].v, aQueryCount,
+                                &session.sparseArenas[t], &session.resultsArenas[t],
+                                &session.pointerArenas[t]);
+         }
+      });
+   }
+
+   tp->wait_on_threads();
+
+   const double dSearchSeconds = chrono::duration<double>(chrono::steady_clock::now() - tSearchStart).count();
+   const size_t memAfterSearchKB = CometMassSpecUtils::GetCurrentWorkingSetKB();
+
+   if (!g_staticParams.options.bOutputSqtStream)
+   {
+      // See the [PRELOAD] print above for why this must be a signed double delta.
+      printf(" [SEARCH] %zu spectra in %.3fs (%.1f Hz) -- memory %.2fGB -> %.2fGB (%+.2fGB)\n",
+             iTotalSpectra, dSearchSeconds,
+             (dSearchSeconds > 0.0) ? (iTotalSpectra / dSearchSeconds) : 0.0,
+             memAfterPreloadKB / (1024.0 * 1024.0), memAfterSearchKB / (1024.0 * 1024.0),
+             ((double)memAfterSearchKB - (double)memAfterPreloadKB) / (1024.0 * 1024.0));
+      fflush(stdout);
+   }
+
+   Threading::DestroyMutex(_maxChargeMutex);
+
    size_t iTotalQueries = 0;
    for (auto& slot : vSlotQueries)
       iTotalQueries += slot.v.size();

--- a/CometSearch/CometPreprocess.cpp
+++ b/CometSearch/CometPreprocess.cpp
@@ -21,6 +21,7 @@
 #include "CometSearch.h"
 #include "CometPostAnalysis.h"
 #include <string.h>
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
@@ -28,6 +29,7 @@
 #include <atomic>
 #include <thread>
 #include <memory>
+#include <vector>
 
 Mutex CometPreprocess::_maxChargeMutex;
 bool CometPreprocess::_bDoneProcessingAllSpectra;
@@ -1627,7 +1629,45 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
          dIntensityCutoff = dPctCutoff;
    }
 
-   int iNumFragmentPeaks = 0;
+   // Select the top iFragIndexNumSpectrumPeaks peaks BY INTENSITY for
+   // vfRawFragmentPeakMass, matching LoadIons()'s explicit mstSpectrum.sortIntensity()
+   // call before its equivalent reverse-iteration loop below. Without this, taking
+   // the last iFragIndexNumSpectrumPeaks entries of pdMass[]/pdInten[] in their raw
+   // input order (native mass-ascending order for a centroided peak list) silently
+   // selects the iFragIndexNumSpectrumPeaks HIGHEST-MASS peaks instead of the
+   // highest-INTENSITY ones whenever a spectrum has more peaks than that cap -- a
+   // scientifically wrong peak selection for FI_DB fragment-ion-index matching (mass
+   // has no bearing on how informative a peak is), and a real source of candidate-
+   // coverage divergence between this path (RTS single-spectrum search) and
+   // LoadIons() (batch search), confirmed by comparing the two paths' raw peak lists
+   // for the same spectrum: RTS's list excluded every peak below ~240 Da while
+   // batch's included several low-mass, high-intensity peaks (e.g. immonium ions).
+   if (g_staticParams.iDbType == DbType::FI_DB)
+   {
+      std::vector<int> viIntensityOrder;
+      viIntensityOrder.reserve(iNumPeaks);
+      for (int i = 0; i < iNumPeaks; ++i)
+      {
+         if (pdInten[i] >= dIntensityCutoff && pdInten[i] > 0.0)
+            viIntensityOrder.push_back(i);
+      }
+
+      std::sort(viIntensityOrder.begin(), viIntensityOrder.end(),
+         [pdMass, pdInten](int a, int b)
+         {
+            if (pdInten[a] != pdInten[b])
+               return pdInten[a] > pdInten[b];
+            return pdMass[a] < pdMass[b];   // deterministic tie-break on an intensity tie
+         });
+
+      size_t iCap = (size_t)g_staticParams.options.iFragIndexNumSpectrumPeaks;
+      if (viIntensityOrder.size() < iCap)
+         iCap = viIntensityOrder.size();
+
+      pScoring->vfRawFragmentPeakMass.reserve(iCap);
+      for (size_t k = 0; k < iCap; ++k)
+         pScoring->vfRawFragmentPeakMass.push_back((float)pdMass[viIntensityOrder[k]]);
+   }
 
    // Pre-compute per-spectrum constant values used inside the peak loop.
    // For iRemovePrecursor modes 1/3/4 these m/z values are identical for every
@@ -1667,11 +1707,6 @@ Query* CometPreprocess::PreprocessSingleSpectrumCore(int iPrecursorCharge,
 
       if (dIntensity >= dIntensityCutoff && dIntensity > 0.0)
       {
-         if (g_staticParams.iDbType == DbType::FI_DB && iNumFragmentPeaks < g_staticParams.options.iFragIndexNumSpectrumPeaks)
-         {
-            pScoring->vfRawFragmentPeakMass.push_back((float)dIon);
-            iNumFragmentPeaks++;
-         }
          if (g_staticParams.options.iPrintAScoreProScore)
          {
             pScoring->vRawFragmentPeakMassIntensity.emplace_back(dIon, dIntensity);

--- a/CometSearch/CometPreprocess.h
+++ b/CometSearch/CometPreprocess.h
@@ -120,12 +120,16 @@ public:
    // spectrum in a single pass using thread-local scratch buffers.  iSlot is this
    // worker's pre-assigned _ppbDuplFragmentArr index.  outQueries is this worker's
    // own result vector (no lock needed); outCount is a shared running total bumped
-   // with relaxed ordering for the CheckExit batch-size-cap read.  The actual index
-   // search (FI_DB vs. PI_DB) is dispatched by CometSearch::RunSearch(Query*, int).
+   // with relaxed ordering for the CheckExit batch-size-cap read.  pArena is this
+   // worker's per-slot sparse-XCorr-matrix bump arena (session.sparseArenas[iSlot]),
+   // used instead of a per-spectrum heap allocation for each Query's sparse child
+   // blocks -- see docs/20260723_ExtendFusedBatchPath.md.  The actual index search
+   // (FI_DB vs. PI_DB) is dispatched by CometSearch::RunSearch(Query*, int).
    static void FusedSearchSpectrum(Spectrum spec,
                                    int iSlot,
                                    std::vector<Query*>& outQueries,
-                                   std::atomic<size_t>& outCount);
+                                   std::atomic<size_t>& outCount,
+                                   FusedSparseArena* pArena);
 
    // Fused FI_DB/PI_DB batch path: stream spectra through a bounded producer/
    // consumer queue into FusedSearchSpectrum workers.  Replaces
@@ -181,6 +185,12 @@ private:
    // if it survives all three filters.  Returns true iff enqueued.
    static bool FilterAndEnqueueSpectrum(Spectrum& mstSpectrum,
                                         BoundedSpectrumQueue& queue);
+   // pArena: when non-null, each sparse-matrix child block ([SPARSE_MATRIX_SIZE]
+   // leaf array) is taken from this bump arena instead of individually heap-
+   // allocated, and pScoring->bSparseFromPool is set so the Query destructor skips
+   // delete[]-ing them (see docs/20260723_ExtendFusedBatchPath.md). Currently only
+   // the fused batch path (FusedSearchSpectrum) passes non-null; nullptr preserves
+   // the prior per-spectrum-heap-allocation behavior for any other caller.
    static bool Preprocess(struct Query *pScoring,
                           Spectrum mstSpectrum,
                           double *pdTmpRawData,
@@ -188,7 +198,8 @@ private:
                           double *pdTmpCorrelationData,
                           float *pfFastXcorrData,
                           float *pfFastXcorrDataNL,
-                          float *pfSpScoreData);
+                          float *pfSpScoreData,
+                          FusedSparseArena *pArena = nullptr);
    static bool LoadIons(struct Query *pScoring,
                         double *pdTmpRawData,
                         Spectrum mstSpectrum,

--- a/CometSearch/CometPreprocess.h
+++ b/CometSearch/CometPreprocess.h
@@ -123,13 +123,18 @@ public:
    // with relaxed ordering for the CheckExit batch-size-cap read.  pArena is this
    // worker's per-slot sparse-XCorr-matrix bump arena (session.sparseArenas[iSlot]),
    // used instead of a per-spectrum heap allocation for each Query's sparse child
-   // blocks -- see docs/20260723_ExtendFusedBatchPath.md.  The actual index search
-   // (FI_DB vs. PI_DB) is dispatched by CometSearch::RunSearch(Query*, int).
+   // blocks.  pResultsArena is this worker's per-slot _pResults/_pDecoys pool
+   // (session.resultsArenas[iSlot]).  pPtrArena is this worker's per-slot pool for
+   // the outer sparse pointer arrays (session.pointerArenas[iSlot]) -- see
+   // docs/20260723_ExtendFusedBatchPath.md.  The actual index search (FI_DB vs.
+   // PI_DB) is dispatched by CometSearch::RunSearch(Query*, int).
    static void FusedSearchSpectrum(Spectrum spec,
                                    int iSlot,
                                    std::vector<Query*>& outQueries,
                                    std::atomic<size_t>& outCount,
-                                   FusedSparseArena* pArena);
+                                   FusedSparseArena* pArena,
+                                   FusedResultsArena* pResultsArena,
+                                   FusedPointerArena* pPtrArena);
 
    // Fused FI_DB/PI_DB batch path: stream spectra through a bounded producer/
    // consumer queue into FusedSearchSpectrum workers.  Replaces
@@ -188,9 +193,13 @@ private:
    // pArena: when non-null, each sparse-matrix child block ([SPARSE_MATRIX_SIZE]
    // leaf array) is taken from this bump arena instead of individually heap-
    // allocated, and pScoring->bSparseFromPool is set so the Query destructor skips
-   // delete[]-ing them (see docs/20260723_ExtendFusedBatchPath.md). Currently only
-   // the fused batch path (FusedSearchSpectrum) passes non-null; nullptr preserves
-   // the prior per-spectrum-heap-allocation behavior for any other caller.
+   // delete[]-ing them. pPtrArena: when non-null, the three outer
+   // ppfSparse*[...] pointer arrays themselves are taken from this arena instead
+   // of individually heap-allocated, and pScoring->bSparsePointerArraysFromPool
+   // is set so the Query destructor skips delete[]-ing them (see
+   // docs/20260723_ExtendFusedBatchPath.md). Currently only the fused batch path
+   // (FusedSearchSpectrum) passes non-null for either; nullptr preserves the
+   // prior per-spectrum-heap-allocation behavior for any other caller.
    static bool Preprocess(struct Query *pScoring,
                           Spectrum mstSpectrum,
                           double *pdTmpRawData,
@@ -199,7 +208,8 @@ private:
                           float *pfFastXcorrData,
                           float *pfFastXcorrDataNL,
                           float *pfSpScoreData,
-                          FusedSparseArena *pArena = nullptr);
+                          FusedSparseArena *pArena = nullptr,
+                          FusedPointerArena *pPtrArena = nullptr);
    static bool LoadIons(struct Query *pScoring,
                         double *pdTmpRawData,
                         Spectrum mstSpectrum,

--- a/CometSearch/CometPreprocess.h
+++ b/CometSearch/CometPreprocess.h
@@ -148,6 +148,15 @@ public:
                                           ThreadPool* tp,
                                           SearchSession& session);
 
+   // DIAGNOSTIC / BENCHMARK ONLY -- see the .cpp definition's comment and
+   // docs/20260724_PreloadBenchmark.md. Opt-in via COMET_PRELOAD_BENCHMARK.
+   static bool FusedPreloadThenSearch(MSReader& mstReader,
+                                      int iFirstScan,
+                                      int iLastScan,
+                                      int iAnalysisType,
+                                      ThreadPool* tp,
+                                      SearchSession& session);
+
    // Returns the thread-local raw-data buffer used by PreprocessSingleSpectrumThreadLocal.
    // The buffer is sized to g_staticParams.iArraySizeGlobal and its content after a
    // PreprocessSingleSpectrumThreadLocal call holds the binned sqrt-intensity spectrum
@@ -182,12 +191,16 @@ private:
    static bool AdjustMassTol(struct Query *pScoring);
    static bool CheckActivationMethodFilter(MSActivation act);
 
-   // Shared by both the synchronous and readahead producer loops in
-   // FusedLoadAndSearchSpectra so a future filter change (clearMzRange,
-   // iMinPeaks, activation method) cannot land in only one of the two call
-   // sites and silently diverge between them.  Mutates mstSpectrum in place
-   // (clearMzRange zeroes cleared-range intensities) and moves it into queue
-   // if it survives all three filters.  Returns true iff enqueued.
+   // Shared by the synchronous and readahead producer loops in
+   // FusedLoadAndSearchSpectra, and by FusedPreloadThenSearch's own read loop,
+   // so a future filter change (clearMzRange, iMinPeaks, activation method)
+   // cannot land in only one call site and silently diverge from the others.
+   // Mutates mstSpectrum in place (clearMzRange zeroes cleared-range
+   // intensities). Returns true iff it survives all three filters.
+   static bool ApplySpectrumFilters(Spectrum& mstSpectrum);
+
+   // Moves mstSpectrum into queue if it survives ApplySpectrumFilters().
+   // Returns true iff enqueued.
    static bool FilterAndEnqueueSpectrum(Spectrum& mstSpectrum,
                                         BoundedSpectrumQueue& queue);
    // pArena: when non-null, each sparse-matrix child block ([SPARSE_MATRIX_SIZE]

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -8135,19 +8135,70 @@ void CometSearch::StorePeptideI(Query* pQuery,
 
    if (g_staticParams.options.iDecoySearch == 2 && bDecoyPep)
    {
-      short siLowestDecoyXcorrScoreIndex = pQuery->siLowestDecoyXcorrScoreIndex;
+      short siLowestDecoyXcorrScoreIndex = 0;
+
+      // Fresh, exhaustive recompute every call -- mirrors StorePeptide()'s top-of-function
+      // scan (commit 7c04814d) rather than trusting pQuery->siLowestDecoyXcorrScoreIndex,
+      // which is only maintained by the simple score-only loop at the bottom of this
+      // function (kept cheap on purpose: it exists solely to feed the approximate
+      // pre-filter gate in XcorrScoreI(), "dXcorr >= pQuery->dLowestXcorrScore", not to
+      // decide which slot gets evicted). Relying on that stale, score-only cached index
+      // here meant the "which slot is worst" answer could still be wrong on an exact-score
+      // tie between two already-filled slots, even after the eviction-preference check
+      // below was added -- the eviction check only validates the comparison against
+      // whichever slot this index happens to point at; it can't fix a wrong index. That
+      // made which of 3+ exactly-tied candidates survived depend on arrival order among
+      // worker threads (batch FI_DB/PI_DB) vs. RTS's fixed single-threaded scan order --
+      // the confirmed root cause of FI_DB batch vs. RTS PSM divergence on tied spectra.
+      // usiLenPeptide==0 identifies a still-empty slot, which must be preferred as "lowest"
+      // over any already-filled slot regardless of score, so empty slots get filled before
+      // any eviction happens.
+      for (short siA = 1; siA < g_staticParams.options.iNumStored; ++siA)
+      {
+         if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].usiLenPeptide != 0
+            && pQuery->_pDecoys[siA].usiLenPeptide == 0)
+         {
+            siLowestDecoyXcorrScoreIndex = siA;
+         }
+         else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].usiLenPeptide == 0)
+         {
+            // current lowest is already an empty slot; only another empty slot could
+            // tie it and it doesn't matter which empty slot we keep pointing at
+         }
+         else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr > pQuery->_pDecoys[siA].fXcorr)
+         {
+            siLowestDecoyXcorrScoreIndex = siA;
+         }
+         else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].fXcorr == pQuery->_pDecoys[siA].fXcorr)
+         {
+            int iCmp = strcmp(pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].szPeptide, pQuery->_pDecoys[siA].szPeptide);
+
+            if (iCmp < 0)
+            {
+               siLowestDecoyXcorrScoreIndex = siA;
+            }
+            else if (iCmp == 0 && g_staticParams.variableModParameters.bVarModSearch)
+            {
+               for (int x = 0; x < pQuery->_pDecoys[siA].usiLenPeptide + 2; ++x)
+               {
+                  if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].piVarModSites[x] < pQuery->_pDecoys[siA].piVarModSites[x])
+                  {
+                     siLowestDecoyXcorrScoreIndex = siA;
+                     break;
+                  }
+                  else if (pQuery->_pDecoys[siLowestDecoyXcorrScoreIndex].piVarModSites[x] > pQuery->_pDecoys[siA].piVarModSites[x])
+                  {
+                     break;
+                  }
+               }
+            }
+         }
+      }
 
       // Mirrors the fix in StorePeptide() (commit 7c04814d, "Fix non-deterministic FASTA_DB
       // search results under concurrent scoring ties"): only replace the identified worst
       // slot if the incoming candidate is actually preferred under the same (score, then
-      // sequence, then mod state) rule used to pick that slot. Without this, a candidate
-      // that merely ties the current worst score unconditionally evicted it regardless of
-      // tie-break preference, so the survivor of a multi-way tie depended on arrival order
-      // among callers of this function. RTS's single-threaded-per-query scan makes arrival
-      // order fixed for RTS (confirmed empirically -- see docs/20260714_EvalueJitter.md
-      // Phase 1), but XcorrScoreI()/StorePeptideI() are also reachable from batch FI_DB/PI_DB
-      // search paths that scan the database across multiple threads per query (evidenced by
-      // Query::accessMutex existing at all), where this fix is a real correctness issue.
+      // sequence, then mod state) rule used to pick that slot.
       //
       // Compare at float precision (matching what actually gets stored, fXcorr) rather than
       // double: comparing the full-precision double dXcorr against a float widened back to
@@ -8311,7 +8362,54 @@ void CometSearch::StorePeptideI(Query* pQuery,
    }
    else
    {
-      short siLowestXcorrScoreIndex = pQuery->siLowestXcorrScoreIndex;
+      short siLowestXcorrScoreIndex = 0;
+
+      // Fresh, exhaustive recompute every call -- see the matching block in the decoy
+      // branch above for full rationale. pQuery->siLowestXcorrScoreIndex is only ever
+      // maintained by the simple score-only loop at the bottom of this function, which
+      // exists to feed the approximate pre-filter gate in XcorrScoreI(), not to decide
+      // which slot to evict.
+      for (int i = 1; i < g_staticParams.options.iNumStored; ++i)
+      {
+         if (pQuery->_pResults[siLowestXcorrScoreIndex].usiLenPeptide != 0
+            && pQuery->_pResults[i].usiLenPeptide == 0)
+         {
+            siLowestXcorrScoreIndex = i;
+         }
+         else if (pQuery->_pResults[siLowestXcorrScoreIndex].usiLenPeptide == 0)
+         {
+            // current lowest is already an empty slot; only another empty slot could
+            // tie it and it doesn't matter which empty slot we keep pointing at
+         }
+         else if (pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr > pQuery->_pResults[i].fXcorr)
+         {
+            siLowestXcorrScoreIndex = i;
+         }
+         else if (pQuery->_pResults[siLowestXcorrScoreIndex].fXcorr == pQuery->_pResults[i].fXcorr)
+         {
+            int iCmp = strcmp(pQuery->_pResults[siLowestXcorrScoreIndex].szPeptide, pQuery->_pResults[i].szPeptide);
+
+            if (iCmp < 0)
+            {
+               siLowestXcorrScoreIndex = i;
+            }
+            else if (iCmp == 0 && g_staticParams.variableModParameters.bVarModSearch)
+            {
+               for (int x = 0; x < pQuery->_pResults[i].usiLenPeptide + 2; ++x)
+               {
+                  if (pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites[x] < pQuery->_pResults[i].piVarModSites[x])
+                  {
+                     siLowestXcorrScoreIndex = i;
+                     break;
+                  }
+                  else if (pQuery->_pResults[siLowestXcorrScoreIndex].piVarModSites[x] > pQuery->_pResults[i].piVarModSites[x])
+                  {
+                     break;
+                  }
+               }
+            }
+         }
+      }
 
       // See the matching check in the decoy branch above for rationale.
       {

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -7980,7 +7980,21 @@ void CometSearch::XcorrScoreI(char* szProteinSeq,
    // PI_DB: gate on xcorr and minimum xcorr threshold (all mass-matched candidates scored)
    if (g_staticParams.iDbType == DbType::FI_DB)
    {
-      if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport && dXcorr >= pQuery->dLowestXcorrScore)
+      // "+ 0.00005" mirrors the fudge factor already used in the PI_DB and FASTA_DB
+      // gates below/StorePeptide's caller: dXcorr here is a full-precision double,
+      // but pQuery->dLowestXcorrScore was assigned from a stored fXcorr (float) and
+      // widened back to double, so it carries a float-rounding error on the order of
+      // 1e-7 to 1e-6 relative to the true value. Without the margin, a second
+      // candidate that ties the first at the 3-decimal xcorr precision Comet actually
+      // stores (dXcorr is already rounded to 3 decimals above) fails this ">="
+      // check roughly half the time, purely depending on which way the float
+      // rounding happened to go -- silently dropping a legitimate tied candidate
+      // before it ever reaches StorePeptideI/CheckDuplicateI, regardless of any
+      // tie-break logic downstream. Confirmed empirically: for a large sample of
+      // 3-decimal-rounded xcorr values, "dXcorr >= (double)(float)dXcorr" is false
+      // ~50% of the time.
+      if (iNumMatchedFragmentIons >= g_staticParams.options.iFragIndexMinIonsReport
+         && dXcorr + 0.00005 >= pQuery->dLowestXcorrScore)
       {
          if (!CheckDuplicateI(pQuery, iStartPos, iEndPos, bDecoyPep, szProteinSeq, piVarModSites, dbe))
          {

--- a/CometSearch/core/Constants.h
+++ b/CometSearch/core/Constants.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/core/Constants.h
+++ b/CometSearch/core/Constants.h
@@ -46,7 +46,7 @@
 // is what needs to stay above the amortization floor, not the round's total
 // size.
 #define FUSED_FLUSH_PER_THREAD      50
-#define FUSED_FLUSH_MIN_BATCH_SIZE  5000
+#define FUSED_FLUSH_MIN_BATCH_SIZE  1000
 #define FRAGINDEX_MAX_NUMPEAKS      150      // number of spectrum peaks used to query fragment index
 #define FRAGINDEX_MAX_NUMSCORED     100      // for each fragment index spectrum query, score up to this many peptides
 #define FRAGINDEX_MAX_COMBINATIONS  10000    // raised from 2000; see docs/20260714_modifications.md

--- a/CometSearch/core/FusedResultsArena.h
+++ b/CometSearch/core/FusedResultsArena.h
@@ -1,0 +1,147 @@
+// Copyright 2026 Jimmy Eng
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-slot checkout-and-reset-in-place pool for the fused FI_DB/PI_DB batch
+// path's _pResults/_pDecoys (Results[iNumStored] arrays). See
+// docs/20260723_ExtendFusedBatchPath.md, Phase 2b for the full design
+// rationale.
+//
+// Unlike FusedSparseArena (a pure bump-and-forget arena, safe because its
+// blocks are plain float[SPARSE_MATRIX_SIZE]), Results has non-trivial
+// members (std::string, std::vector<ProteinEntryStruct>) that would leak
+// their own backing heap allocations if a chunk's memory were ever reused
+// without running their destructors. So this arena's chunks, once allocated,
+// are NEVER destroyed and their Results objects are NEVER re-constructed --
+// only reset in place via ResetOneResult() (core/Types.h), the same
+// technique RtsScratch already uses for the RTS single-spectrum pool. This
+// also means a slot reused across many rounds sees its pWhichProtein/
+// site-score-string capacities stabilize over time instead of starting at
+// zero every spectrum, since .clear() does not release capacity.
+//
+// One instance per worker slot, owned by SearchSession::resultsArenas (see
+// that struct for why NOT thread_local). AllocResultsPair() is called only
+// by the single worker task-closure that owns this slot for the current
+// flush round -- exactly one writer at a time, no lock needed. ResetRound()
+// is called once per round, from Pipeline.cpp's cleanupBatch lambda, only
+// after tp->wait_on_threads() has returned -- i.e. only when no
+// AllocResultsPair() call can possibly be in flight.
+
+#ifndef _COMETFUSEDRESULTSARENA_H_
+#define _COMETFUSEDRESULTSARENA_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <vector>
+#include "core/Types.h"   // Results, ResetOneResult
+
+struct FusedResultsArena
+{
+   // Target bytes per chunk. Unlike FusedSparseArena's fixed-size blocks,
+   // a Results[iNumStored] "block" scales with the run's iNumStored (1 to
+   // 100+ depending on comet.params' num_output_lines), so spectra-per-chunk
+   // is derived from this byte budget at first use rather than fixed --
+   // see docs/20260723_ExtendFusedBatchPath.md Phase 2 "Risks".
+   static constexpr size_t kChunkByteBudget = 32u * 1024u * 1024u;   // ~32 MB/chunk
+
+   struct ResultsPair
+   {
+      Results* pResults;
+      Results* pDecoys;   // nullptr when decoys are not requested
+   };
+
+   struct Chunk
+   {
+      std::unique_ptr<Results[]> results;   // iSpectraPerChunk * iNumStored entries
+      std::unique_ptr<Results[]> decoys;    // same shape; null if !bWantDecoys
+   };
+
+   std::vector<Chunk> vChunks;      // append-only; existing entries never move/free
+   size_t iSpectraPerChunk = 0;     // 0 = not yet initialised
+   int    iNumStored       = 0;
+   bool   bWantDecoys      = false;
+
+   size_t iCurChunk     = 0;   // chunk currently being filled
+   size_t iCurChunkUsed = 0;   // spectra (not Results elements) used in that chunk this round
+
+   // Called once on first use for this arena. iNumStored/bWantDecoysIn are
+   // assumed constant for the SearchSession's lifetime (comet.params is not
+   // re-read mid-run), mirroring FusedLoadAndSearchSpectra's similar
+   // assumption that iNumThreads does not change mid-run.
+   void EnsureInitialized(int iNumStoredIn, bool bWantDecoysIn)
+   {
+      if (iSpectraPerChunk != 0)
+         return;
+
+      iNumStored  = iNumStoredIn;
+      bWantDecoys = bWantDecoysIn;
+
+      const size_t bytesPerSpectrum =
+         sizeof(Results) * (size_t)iNumStored * (bWantDecoys ? 2 : 1);
+      iSpectraPerChunk = std::max<size_t>(1, kChunkByteBudget / std::max<size_t>(bytesPerSpectrum, 1));
+   }
+
+   // Returns one spectrum's worth of freshly-reset Results storage. Must not
+   // be called before EnsureInitialized().
+   ResultsPair AllocResultsPair()
+   {
+      if (vChunks.empty() || iCurChunkUsed >= iSpectraPerChunk)
+      {
+         if (iCurChunk + 1 < vChunks.size())        // reuse a chunk grown in an earlier round
+         {
+            ++iCurChunk;
+         }
+         else
+         {
+            Chunk c;
+            c.results.reset(new Results[iSpectraPerChunk * (size_t)iNumStored]);
+            if (bWantDecoys)
+               c.decoys.reset(new Results[iSpectraPerChunk * (size_t)iNumStored]);
+            vChunks.push_back(std::move(c));
+            iCurChunk = vChunks.size() - 1;
+         }
+         iCurChunkUsed = 0;
+      }
+
+      Results* pResults = vChunks[iCurChunk].results.get() + iCurChunkUsed * (size_t)iNumStored;
+      Results* pDecoys  = bWantDecoys
+         ? vChunks[iCurChunk].decoys.get() + iCurChunkUsed * (size_t)iNumStored
+         : nullptr;
+      ++iCurChunkUsed;
+
+      for (int j = 0; j < iNumStored; ++j)
+         ResetOneResult(pResults[j]);
+      if (pDecoys != nullptr)
+      {
+         for (int j = 0; j < iNumStored; ++j)
+            ResetOneResult(pDecoys[j]);
+      }
+
+      return ResultsPair{ pResults, pDecoys };
+   }
+
+   // Rewinds to the start of chunk 0 for the next round. All chunks (and the
+   // Results objects within them) stay allocated and constructed -- steady-
+   // state reuse across rounds -- so after the first several rounds this
+   // does zero further heap traffic. Must only be called when no
+   // AllocResultsPair() call for this slot can be in flight (see file header
+   // comment).
+   void ResetRound()
+   {
+      iCurChunk     = 0;
+      iCurChunkUsed = 0;
+   }
+};
+
+#endif // _COMETFUSEDRESULTSARENA_H_

--- a/CometSearch/core/FusedResultsArena.h
+++ b/CometSearch/core/FusedResultsArena.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/core/FusedSparseArena.h
+++ b/CometSearch/core/FusedSparseArena.h
@@ -1,0 +1,91 @@
+// Copyright 2026 Jimmy Eng
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-slot bump arena for the fused FI_DB/PI_DB batch path's sparse XCorr matrix
+// child blocks (Query::ppfSparseSpScoreData / ppfSparseFastXcorrData /
+// ppfSparseFastXcorrDataNL leaf blocks). See docs/20260723_ExtendFusedBatchPath.md
+// for the full design rationale.
+//
+// One instance per worker slot, owned by SearchSession::sparseArenas (NOT
+// thread_local -- see the design doc's "why the existing pool can't be reused
+// unchanged" section for why keying by slot index instead of OS thread identity
+// is required here). AllocBlock() is called only by the single worker task-closure
+// that owns this slot for the current flush round -- exactly one writer at a time,
+// no lock needed. ResetRound() is called once per round, from Pipeline.cpp's
+// cleanupBatch lambda, only after tp->wait_on_threads() has returned -- i.e. only
+// when no AllocBlock() call can possibly be in flight.
+
+#ifndef _COMETFUSEDSPARSEARENA_H_
+#define _COMETFUSEDSPARSEARENA_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <vector>
+#include "CometData.h"   // SPARSE_MATRIX_SIZE
+
+struct FusedSparseArena
+{
+   // ~25 MB/chunk at SPARSE_MATRIX_SIZE=100 floats/block. Not measurement-tuned yet
+   // (see docs/20260723_ExtendFusedBatchPath.md "Risks / open questions").
+   static constexpr size_t kChunkBlocks = 65536;
+
+   // Append-only: existing entries are never moved, resized, or freed once
+   // allocated, so pointers handed out by AllocBlock() stay valid for the life of
+   // the arena (i.e. across ResetRound() calls too -- ResetRound() only rewinds
+   // the fill cursor, it does not release chunks).
+   std::vector<std::unique_ptr<float[]>> vChunks;
+
+   size_t iCurChunk     = 0;   // chunk currently being filled
+   size_t iCurChunkUsed = 0;   // blocks used in that chunk so far this round
+
+   // Returns a zeroed float[SPARSE_MATRIX_SIZE] block. Zero-on-issue preserves the
+   // same pre-zeroed guarantee RtsScratch::AllocSparseChild() provides for the RTS
+   // single-spectrum pool (CometPreprocess.cpp) -- several downstream sparse-matrix
+   // consumers (e.g. CometPostAnalysis.cpp) implicitly rely on never-written bins
+   // reading as zero.
+   float* AllocBlock()
+   {
+      if (vChunks.empty() || iCurChunkUsed >= kChunkBlocks)
+      {
+         if (iCurChunk + 1 < vChunks.size())        // reuse a chunk grown in an earlier round
+         {
+            ++iCurChunk;
+         }
+         else
+         {
+            vChunks.push_back(std::make_unique<float[]>(kChunkBlocks * SPARSE_MATRIX_SIZE));
+            iCurChunk = vChunks.size() - 1;
+         }
+         iCurChunkUsed = 0;
+      }
+
+      float* p = vChunks[iCurChunk].get() + iCurChunkUsed * SPARSE_MATRIX_SIZE;
+      std::fill(p, p + SPARSE_MATRIX_SIZE, 0.0f);
+      ++iCurChunkUsed;
+      return p;
+   }
+
+   // Rewinds to the start of chunk 0 for the next round. All chunks stay allocated
+   // (steady-state reuse across rounds) -- after the first several rounds this does
+   // zero further heap traffic for sparse child blocks. Must only be called when no
+   // AllocBlock() call for this slot can be in flight (see file header comment).
+   void ResetRound()
+   {
+      iCurChunk     = 0;
+      iCurChunkUsed = 0;
+   }
+};
+
+#endif // _COMETFUSEDSPARSEARENA_H_

--- a/CometSearch/core/FusedSparseArena.h
+++ b/CometSearch/core/FusedSparseArena.h
@@ -12,19 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Per-slot bump arena for the fused FI_DB/PI_DB batch path's sparse XCorr matrix
-// child blocks (Query::ppfSparseSpScoreData / ppfSparseFastXcorrData /
-// ppfSparseFastXcorrDataNL leaf blocks). See docs/20260723_ExtendFusedBatchPath.md
-// for the full design rationale.
+// Per-slot bump arena for the fused FI_DB/PI_DB batch path's per-spectrum
+// heap allocations that are pure POD data (safe to bump-allocate and forget,
+// unlike Results -- see core/FusedResultsArena.h for that case). See
+// docs/20260723_ExtendFusedBatchPath.md (Phase 1 and Phase 2a) for the full
+// design rationale.
 //
-// One instance per worker slot, owned by SearchSession::sparseArenas (NOT
-// thread_local -- see the design doc's "why the existing pool can't be reused
-// unchanged" section for why keying by slot index instead of OS thread identity
-// is required here). AllocBlock() is called only by the single worker task-closure
-// that owns this slot for the current flush round -- exactly one writer at a time,
-// no lock needed. ResetRound() is called once per round, from Pipeline.cpp's
-// cleanupBatch lambda, only after tp->wait_on_threads() has returned -- i.e. only
-// when no AllocBlock() call can possibly be in flight.
+// FusedBumpArena<T, kChunkBytes> is a template so the same append-only,
+// never-move chunk-growth logic serves two purposes without a second,
+// hand-duplicated copy of the same tricky invariants:
+//   - FusedSparseArena (Phase 1): fixed-size float[SPARSE_MATRIX_SIZE] child
+//     blocks for Query::ppfSparseSpScoreData/ppfSparseFastXcorrData/
+//     ppfSparseFastXcorrDataNL, via AllocBlock().
+//   - FusedPointerArena (Phase 2a): variable-length float* spans for the
+//     outer ppfSparse*[...] pointer arrays themselves (length varies per
+//     spectrum with the mass-dependent bin count), via AllocSpan(n).
+//
+// One instance per worker slot, owned by SearchSession::sparseArenas /
+// pointerArenas (NOT thread_local -- see the design doc's "why the existing
+// pool can't be reused unchanged" section for why keying by slot index
+// instead of OS thread identity is required here). AllocBlock()/AllocSpan()
+// are called only by the single worker task-closure that owns this slot for
+// the current flush round -- exactly one writer at a time, no lock needed.
+// ResetRound() is called once per round, from Pipeline.cpp's cleanupBatch
+// lambda, only after tp->wait_on_threads() has returned -- i.e. only when no
+// AllocBlock()/AllocSpan() call can possibly be in flight.
 
 #ifndef _COMETFUSEDSPARSEARENA_H_
 #define _COMETFUSEDSPARSEARENA_H_
@@ -35,57 +47,85 @@
 #include <vector>
 #include "CometData.h"   // SPARSE_MATRIX_SIZE
 
-struct FusedSparseArena
+template<typename T, size_t kChunkBytes>
+struct FusedBumpArena
 {
-   // ~25 MB/chunk at SPARSE_MATRIX_SIZE=100 floats/block. Not measurement-tuned yet
-   // (see docs/20260723_ExtendFusedBatchPath.md "Risks / open questions").
-   static constexpr size_t kChunkBlocks = 65536;
+   // Target element count per chunk, derived from a target byte budget so the
+   // same template reads naturally for both float (Phase 1, 4 bytes/element)
+   // and float* (Phase 2a, 8 bytes/element on x64) instantiations. Not
+   // measurement-tuned -- see docs/20260723_ExtendFusedBatchPath.md "Risks".
+   static constexpr size_t kChunkElements =
+      (kChunkBytes / sizeof(T)) > 0 ? (kChunkBytes / sizeof(T)) : 1;
+
+   struct ChunkSlot
+   {
+      std::unique_ptr<T[]> data;
+      size_t               capacity;   // usually kChunkElements; larger only for an
+                                        // oversized single request (see AllocSpan).
+   };
 
    // Append-only: existing entries are never moved, resized, or freed once
-   // allocated, so pointers handed out by AllocBlock() stay valid for the life of
-   // the arena (i.e. across ResetRound() calls too -- ResetRound() only rewinds
-   // the fill cursor, it does not release chunks).
-   std::vector<std::unique_ptr<float[]>> vChunks;
+   // allocated, so pointers/spans handed out by AllocSpan()/AllocBlock() stay
+   // valid for the life of the arena (i.e. across ResetRound() calls too --
+   // ResetRound() only rewinds the fill cursor, it does not release chunks).
+   std::vector<ChunkSlot> vChunks;
 
    size_t iCurChunk     = 0;   // chunk currently being filled
-   size_t iCurChunkUsed = 0;   // blocks used in that chunk so far this round
+   size_t iCurChunkUsed = 0;   // elements used in that chunk so far this round
 
-   // Returns a zeroed float[SPARSE_MATRIX_SIZE] block. Zero-on-issue preserves the
-   // same pre-zeroed guarantee RtsScratch::AllocSparseChild() provides for the RTS
-   // single-spectrum pool (CometPreprocess.cpp) -- several downstream sparse-matrix
-   // consumers (e.g. CometPostAnalysis.cpp) implicitly rely on never-written bins
-   // reading as zero.
-   float* AllocBlock()
+   // Returns a zeroed (or null-initialised, for T=float*), contiguous span of
+   // n elements. If a single request exceeds the normal per-chunk element
+   // count, a one-off, exactly-sized chunk is allocated for it instead of
+   // risking any possibility of overflowing a fixed-size chunk -- this
+   // guarantees correctness regardless of how large iArraySizeGlobal-derived
+   // sizes turn out to be for a given comet.params, rather than relying on a
+   // compile-time upper bound.
+   T* AllocSpan(size_t n)
    {
-      if (vChunks.empty() || iCurChunkUsed >= kChunkBlocks)
+      if (vChunks.empty() || iCurChunkUsed + n > vChunks[iCurChunk].capacity)
       {
-         if (iCurChunk + 1 < vChunks.size())        // reuse a chunk grown in an earlier round
+         if (iCurChunk + 1 < vChunks.size() && n <= vChunks[iCurChunk + 1].capacity)
          {
-            ++iCurChunk;
+            ++iCurChunk;                              // reuse a chunk grown in an earlier round
          }
          else
          {
-            vChunks.push_back(std::make_unique<float[]>(kChunkBlocks * SPARSE_MATRIX_SIZE));
+            const size_t cap = std::max(kChunkElements, n);
+            ChunkSlot slot{ std::unique_ptr<T[]>(new T[cap]), cap };
+            vChunks.push_back(std::move(slot));
             iCurChunk = vChunks.size() - 1;
          }
          iCurChunkUsed = 0;
       }
 
-      float* p = vChunks[iCurChunk].get() + iCurChunkUsed * SPARSE_MATRIX_SIZE;
-      std::fill(p, p + SPARSE_MATRIX_SIZE, 0.0f);
-      ++iCurChunkUsed;
+      T* p = vChunks[iCurChunk].data.get() + iCurChunkUsed;
+      std::fill(p, p + n, T());
+      iCurChunkUsed += n;
       return p;
    }
 
-   // Rewinds to the start of chunk 0 for the next round. All chunks stay allocated
-   // (steady-state reuse across rounds) -- after the first several rounds this does
-   // zero further heap traffic for sparse child blocks. Must only be called when no
-   // AllocBlock() call for this slot can be in flight (see file header comment).
+   // Fixed-size convenience wrapper -- Phase 1's original usage.
+   T* AllocBlock() { return AllocSpan(SPARSE_MATRIX_SIZE); }
+
+   // Rewinds to the start of chunk 0 for the next round. All chunks stay
+   // allocated (steady-state reuse across rounds) -- after the first several
+   // rounds this does zero further heap traffic. Must only be called when no
+   // AllocSpan()/AllocBlock() call for this slot can be in flight (see file
+   // header comment).
    void ResetRound()
    {
       iCurChunk     = 0;
       iCurChunkUsed = 0;
    }
 };
+
+// Phase 1: float[SPARSE_MATRIX_SIZE] sparse-matrix child blocks. 65536 blocks/
+// chunk * 100 floats/block * 4 bytes/float = ~25 MB/chunk, matching the
+// original (pre-generalization) FusedSparseArena sizing exactly.
+using FusedSparseArena = FusedBumpArena<float, 65536u * SPARSE_MATRIX_SIZE * sizeof(float)>;
+
+// Phase 2a: variable-length float* spans for the outer sparse pointer arrays.
+// ~2 MB/chunk (256K pointers on x64) -- not measurement-tuned.
+using FusedPointerArena = FusedBumpArena<float*, 2u * 1024u * 1024u>;
 
 #endif // _COMETFUSEDSPARSEARENA_H_

--- a/CometSearch/core/FusedSparseArena.h
+++ b/CometSearch/core/FusedSparseArena.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/core/FusedSparseArena.h
+++ b/CometSearch/core/FusedSparseArena.h
@@ -90,7 +90,11 @@ struct FusedBumpArena
          }
          else
          {
-            const size_t cap = std::max(kChunkElements, n);
+            // Parenthesized to block macro expansion if a translation unit pulls in
+            // <windows.h> without NOMINMAX (its own `max` macro would otherwise
+            // swallow this call and turn it into a syntax error) -- CometSearch.vcxproj
+            // itself defines NOMINMAX, but tests/unit/CometUnitTests.vcxproj does not.
+            const size_t cap = (std::max)(kChunkElements, n);
             ChunkSlot slot{ std::unique_ptr<T[]>(new T[cap]), cap };
             vChunks.push_back(std::move(slot));
             iCurChunk = vChunks.size() - 1;

--- a/CometSearch/core/Params.h
+++ b/CometSearch/core/Params.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/core/Types.h
+++ b/CometSearch/core/Types.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/core/Types.h
+++ b/CometSearch/core/Types.h
@@ -73,6 +73,31 @@ struct Results
    vector<struct ProteinEntryStruct> pWhichDecoyProtein;  // keep separate decoy list (used for separate decoy matches and combined results)
 };
 
+// Resets one Results slot to its pre-search sentinel state so it is safe to reuse
+// for a new spectrum, whether the underlying memory came from a fresh new[],
+// RtsScratch's thread-local RTS pool, or the fused batch path's FusedResultsArena.
+// Deliberately does not touch pWhichDecoyProtein -- callers reset that themselves
+// only when iDecoySearch actually applies, matching the pre-existing call sites
+// this consolidates (see docs/20260723_ExtendFusedBatchPath.md, Phase 2 prerequisite
+// refactor).
+inline void ResetOneResult(Results& r)
+{
+   r.dPepMass = 0.0;
+   r.dExpect = 999;
+   r.fScoreSp = 0.0;
+   r.fXcorr = (float)g_staticParams.options.dMinimumXcorr;
+   r.fAScorePro = 0.0;
+   r.usiLenPeptide = 0;
+   r.usiRankSp = 0;
+   r.usiMatchedIons = 0;
+   r.usiTotalIons = 0;
+   r.szPeptide[0] = '\0';
+   r.sAScoreProSiteScores.clear();
+   r.pWhichProtein.clear();
+   r.sPeffOrigResidues.clear();
+   r.iPeffOrigResiduePosition = -9;
+}
+
 struct SpecLibResults // MS2 spec lib
 {
    unsigned int iWhichSpecLib;                // the matched spectral library entry
@@ -708,16 +733,30 @@ struct Query
    unsigned long int  _uliNumMatchedPeptides;  // # of peptides that get scored
    unsigned long int  _uliNumMatchedDecoyPeptides;
 
-   // When true, sparse child arrays (float[SPARSE_MATRIX_SIZE]) belong to the
-   // thread-local RtsScratch pool and must NOT be delete[]'d by the destructor.
-   // Set only by PreprocessSingleSpectrumThreadLocal via PreprocessSingleSpectrumCore.
+   // When true, sparse child arrays (float[SPARSE_MATRIX_SIZE]) belong to a pool
+   // and must NOT be delete[]'d by the destructor -- either the thread-local
+   // RtsScratch pool (set by PreprocessSingleSpectrumThreadLocal via
+   // PreprocessSingleSpectrumCore, RTS path) or a per-slot FusedSparseArena (set
+   // by Preprocess(), fused batch path). See
+   // docs/20260723_ExtendFusedBatchPath.md for the batch-path pool.
    bool bSparseFromPool;
 
-   // When true, _pResults/_pDecoys belong to the thread-local RtsScratch pool
-   // (RtsScratch::pResults/pDecoys) and must NOT be delete[]'d by the destructor --
-   // the pool owns that memory for the lifetime of the thread and reuses it for the
-   // next spectrum. Set only by PreprocessSingleSpectrumThreadLocal via
-   // PreprocessSingleSpectrumCore. See docs/20260714_rtspostprocessing.md finding 1.
+   // Same idea as bSparseFromPool, but for the outer ppfSparseSpScoreData/
+   // ppfSparseFastXcorrData/ppfSparseFastXcorrDataNL pointer arrays themselves
+   // (not their child blocks). Unlike bSparseFromPool, RTS's pool has never
+   // pooled these -- only set by Preprocess() when given a non-null
+   // FusedPointerArena (fused batch path). Deliberately a separate flag rather
+   // than folding into bSparseFromPool: reusing that flag's meaning would
+   // silently change RTS's destructor behavior for memory RTS's pool was never
+   // designed to own. See docs/20260723_ExtendFusedBatchPath.md Phase 2a.
+   bool bSparsePointerArraysFromPool;
+
+   // When true, _pResults/_pDecoys belong to a pool and must NOT be delete[]'d
+   // by the destructor -- either the thread-local RtsScratch pool (RTS path) or
+   // a per-slot FusedResultsArena (fused batch path, see
+   // docs/20260723_ExtendFusedBatchPath.md Phase 2b). Set by
+   // PreprocessSingleSpectrumCore (RTS) or FusedSearchSpectrum (batch). See also
+   // docs/20260714_rtspostprocessing.md finding 1 for the original RTS pool.
    bool bResultsFromPool;
 
    // Sparse matrix representation of data
@@ -775,6 +814,7 @@ struct Query
       _uliNumMatchedDecoyPeptides = 0;
 
       bSparseFromPool = false;
+      bSparsePointerArraysFromPool = false;
       bResultsFromPool = false;
 
       // Set by CometPreprocess::Preprocess (or its long/MS1-path siblings)
@@ -823,7 +863,8 @@ struct Query
                delete[] ppfSparseSpScoreData[i];
          }
       }
-      delete[] ppfSparseSpScoreData;
+      if (!bSparsePointerArraysFromPool)
+         delete[] ppfSparseSpScoreData;
       ppfSparseSpScoreData = NULL;
 
       if (g_staticParams.ionInformation.bUseWaterAmmoniaLoss
@@ -841,7 +882,8 @@ struct Query
                   delete[] ppfSparseFastXcorrDataNL[i];
             }
          }
-         delete[] ppfSparseFastXcorrDataNL;
+         if (!bSparsePointerArraysFromPool)
+            delete[] ppfSparseFastXcorrDataNL;
          ppfSparseFastXcorrDataNL = NULL;
       }
       else
@@ -855,7 +897,8 @@ struct Query
             }
          }
       }
-      delete[] ppfSparseFastXcorrData;
+      if (!bSparsePointerArraysFromPool)
+         delete[] ppfSparseFastXcorrData;
       ppfSparseFastXcorrData = NULL;
 
       if (bResultsFromPool)

--- a/CometSearch/core/Types.h
+++ b/CometSearch/core/Types.h
@@ -73,31 +73,6 @@ struct Results
    vector<struct ProteinEntryStruct> pWhichDecoyProtein;  // keep separate decoy list (used for separate decoy matches and combined results)
 };
 
-// Resets one Results slot to its pre-search sentinel state so it is safe to reuse
-// for a new spectrum, whether the underlying memory came from a fresh new[],
-// RtsScratch's thread-local RTS pool, or the fused batch path's FusedResultsArena.
-// Deliberately does not touch pWhichDecoyProtein -- callers reset that themselves
-// only when iDecoySearch actually applies, matching the pre-existing call sites
-// this consolidates (see docs/20260723_ExtendFusedBatchPath.md, Phase 2 prerequisite
-// refactor).
-inline void ResetOneResult(Results& r)
-{
-   r.dPepMass = 0.0;
-   r.dExpect = 999;
-   r.fScoreSp = 0.0;
-   r.fXcorr = (float)g_staticParams.options.dMinimumXcorr;
-   r.fAScorePro = 0.0;
-   r.usiLenPeptide = 0;
-   r.usiRankSp = 0;
-   r.usiMatchedIons = 0;
-   r.usiTotalIons = 0;
-   r.szPeptide[0] = '\0';
-   r.sAScoreProSiteScores.clear();
-   r.pWhichProtein.clear();
-   r.sPeffOrigResidues.clear();
-   r.iPeffOrigResiduePosition = -9;
-}
-
 struct SpecLibResults // MS2 spec lib
 {
    unsigned int iWhichSpecLib;                // the matched spectral library entry
@@ -169,6 +144,39 @@ struct ProteinEntryStruct
       return (lWhichProtein < a.lWhichProtein);
    }
 };
+
+// Resets one Results slot to its pre-search sentinel state so it is safe to reuse
+// for a new spectrum, whether the underlying memory came from a fresh new[],
+// RtsScratch's thread-local RTS pool, or the fused batch path's FusedResultsArena.
+// Deliberately does not touch pWhichDecoyProtein -- callers reset that themselves
+// only when iDecoySearch actually applies, matching the pre-existing call sites
+// this consolidates (see docs/20260723_ExtendFusedBatchPath.md, Phase 2 prerequisite
+// refactor).
+//
+// Defined here (after ProteinEntryStruct's full definition) rather than
+// immediately after struct Results: pWhichProtein.clear() requires
+// ProteinEntryStruct to be a complete type, which it is not yet at that earlier
+// point in the file (only forward-declared via the elaborated-type-specifier in
+// Results' member declarations). MSVC's STL and libstdc++ tolerate instantiating
+// vector<T>::clear() against an incomplete T in this situation, but libc++
+// (macOS) does not and fails to compile.
+inline void ResetOneResult(Results& r)
+{
+   r.dPepMass = 0.0;
+   r.dExpect = 999;
+   r.fScoreSp = 0.0;
+   r.fXcorr = (float)g_staticParams.options.dMinimumXcorr;
+   r.fAScorePro = 0.0;
+   r.usiLenPeptide = 0;
+   r.usiRankSp = 0;
+   r.usiMatchedIons = 0;
+   r.usiTotalIons = 0;
+   r.szPeptide[0] = '\0';
+   r.sAScoreProSiteScores.clear();
+   r.pWhichProtein.clear();
+   r.sPeffOrigResidues.clear();
+   r.iPeffOrigResiduePosition = -9;
+}
 
 struct PeffModStruct       // stores info read from PEFF header
 {

--- a/CometSearch/output/IResultWriter.h
+++ b/CometSearch/output/IResultWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/output/MzIdentMlWriter.h
+++ b/CometSearch/output/MzIdentMlWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/output/PepXmlWriter.h
+++ b/CometSearch/output/PepXmlWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/output/PercolatorWriter.h
+++ b/CometSearch/output/PercolatorWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/output/SqtWriter.h
+++ b/CometSearch/output/SqtWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/output/TxtWriter.h
+++ b/CometSearch/output/TxtWriter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/FastaStrategy.cpp
+++ b/CometSearch/search/FastaStrategy.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/FastaStrategy.h
+++ b/CometSearch/search/FastaStrategy.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/FiStrategy.cpp
+++ b/CometSearch/search/FiStrategy.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/FiStrategy.cpp
+++ b/CometSearch/search/FiStrategy.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include "Common.h"
 #include "FiStrategy.h"
 #include "SearchUtils.h"
@@ -134,8 +135,17 @@ bool FiStrategy::executeBatch(MSToolkit::MSReader& mstReader,
    {
       session.statusRef.SetStatusMsg(string("Running fused FI_DB search..."));
 
-      bool bSucceeded = CometPreprocess::FusedLoadAndSearchSpectra(
-            mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session);
+      // DIAGNOSTIC / BENCHMARK ONLY: COMET_PRELOAD_BENCHMARK opts into
+      // FusedPreloadThenSearch (read the whole file into memory first, then
+      // search, separately timed) instead of the normal streaming fused path.
+      // See CometPreprocess.cpp's FusedPreloadThenSearch comment and
+      // docs/20260724_PreloadBenchmark.md. Default behavior (env var unset) is
+      // completely unchanged.
+      bool bSucceeded = getenv("COMET_PRELOAD_BENCHMARK") != nullptr
+            ? CometPreprocess::FusedPreloadThenSearch(
+                  mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session)
+            : CometPreprocess::FusedLoadAndSearchSpectra(
+                  mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session);
 
       iPercentStart = iPercentEnd;
       iPercentEnd   = mstReader.getPercent();

--- a/CometSearch/search/FiStrategy.h
+++ b/CometSearch/search/FiStrategy.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/ISearchStrategy.h
+++ b/CometSearch/search/ISearchStrategy.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/PiStrategy.cpp
+++ b/CometSearch/search/PiStrategy.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/PiStrategy.cpp
+++ b/CometSearch/search/PiStrategy.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include "Common.h"
 #include "PiStrategy.h"
 #include "SearchUtils.h"
@@ -90,8 +91,12 @@ bool PiStrategy::executeBatch(MSToolkit::MSReader& mstReader,
    {
       session.statusRef.SetStatusMsg(string("Running fused PI_DB search..."));
 
-      bool bSucceeded = CometPreprocess::FusedLoadAndSearchSpectra(
-            mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session);
+      // DIAGNOSTIC / BENCHMARK ONLY -- see FiStrategy::executeBatch's identical gate.
+      bool bSucceeded = getenv("COMET_PRELOAD_BENCHMARK") != nullptr
+            ? CometPreprocess::FusedPreloadThenSearch(
+                  mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session)
+            : CometPreprocess::FusedLoadAndSearchSpectra(
+                  mstReader, iFirstScan, iLastScan, iAnalysisType, tp, session);
 
       iPercentStart = iPercentEnd;
       iPercentEnd   = mstReader.getPercent();

--- a/CometSearch/search/PiStrategy.h
+++ b/CometSearch/search/PiStrategy.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/Pipeline.cpp
+++ b/CometSearch/search/Pipeline.cpp
@@ -158,6 +158,13 @@ bool Pipeline::run(SearchSession&                     session,
          session.queries.clear();
          for (auto* q : session.ms1Queries) delete q;
          session.ms1Queries.clear();
+
+         // Rewind (not free) the fused batch path's per-slot sparse-matrix arenas,
+         // if any were used this run -- safe here because this only runs after
+         // executeBatch()'s underlying FusedLoadAndSearchSpectra() has already
+         // returned, i.e. after tp->wait_on_threads() confirmed every worker for
+         // this round is idle. See docs/20260723_ExtendFusedBatchPath.md.
+         for (auto& arena : session.sparseArenas) arena.ResetRound();
       };
 
       while (!CometPreprocess::DoneProcessingAllSpectra())

--- a/CometSearch/search/Pipeline.cpp
+++ b/CometSearch/search/Pipeline.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/Pipeline.cpp
+++ b/CometSearch/search/Pipeline.cpp
@@ -159,12 +159,13 @@ bool Pipeline::run(SearchSession&                     session,
          for (auto* q : session.ms1Queries) delete q;
          session.ms1Queries.clear();
 
-         // Rewind (not free) the fused batch path's per-slot sparse-matrix arenas,
-         // if any were used this run -- safe here because this only runs after
-         // executeBatch()'s underlying FusedLoadAndSearchSpectra() has already
-         // returned, i.e. after tp->wait_on_threads() confirmed every worker for
-         // this round is idle. See docs/20260723_ExtendFusedBatchPath.md.
+         // Rewind (not free) the fused batch path's per-slot sparse-matrix and
+         // results arenas, if any were used this run -- safe here because this
+         // only runs after executeBatch()'s underlying FusedLoadAndSearchSpectra()
+         // has already returned, i.e. after tp->wait_on_threads() confirmed every
+         // worker for this round is idle. See docs/20260723_ExtendFusedBatchPath.md.
          for (auto& arena : session.sparseArenas) arena.ResetRound();
+         for (auto& arena : session.resultsArenas) arena.ResetRound();
       };
 
       while (!CometPreprocess::DoneProcessingAllSpectra())

--- a/CometSearch/search/Pipeline.cpp
+++ b/CometSearch/search/Pipeline.cpp
@@ -159,13 +159,15 @@ bool Pipeline::run(SearchSession&                     session,
          for (auto* q : session.ms1Queries) delete q;
          session.ms1Queries.clear();
 
-         // Rewind (not free) the fused batch path's per-slot sparse-matrix and
-         // results arenas, if any were used this run -- safe here because this
-         // only runs after executeBatch()'s underlying FusedLoadAndSearchSpectra()
-         // has already returned, i.e. after tp->wait_on_threads() confirmed every
-         // worker for this round is idle. See docs/20260723_ExtendFusedBatchPath.md.
+         // Rewind (not free) the fused batch path's per-slot sparse-matrix,
+         // results, and pointer arenas, if any were used this run -- safe here
+         // because this only runs after executeBatch()'s underlying
+         // FusedLoadAndSearchSpectra() has already returned, i.e. after
+         // tp->wait_on_threads() confirmed every worker for this round is idle.
+         // See docs/20260723_ExtendFusedBatchPath.md.
          for (auto& arena : session.sparseArenas) arena.ResetRound();
          for (auto& arena : session.resultsArenas) arena.ResetRound();
+         for (auto& arena : session.pointerArenas) arena.ResetRound();
       };
 
       while (!CometPreprocess::DoneProcessingAllSpectra())

--- a/CometSearch/search/Pipeline.h
+++ b/CometSearch/search/Pipeline.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/SearchSession.h
+++ b/CometSearch/search/SearchSession.h
@@ -42,6 +42,7 @@
 
 #include "core/Params.h"
 #include "core/Types.h"
+#include "core/FusedSparseArena.h"
 #include "CometStatus.h"
 #include <mutex>
 #include <vector>
@@ -55,6 +56,13 @@ struct SearchSession
    // batch paths (LoadAndPreprocessSpectra, PreprocessSingleSpectrum, etc.) still
    // guard direct pushes to this vector with queriesMutex.
    std::vector<Query*>    queries;
+
+   // Per-slot sparse-XCorr-matrix bump arenas for the fused FI_DB/PI_DB batch path
+   // (FusedLoadAndSearchSpectra). Sized to iNumSlots on first use there; indexed by
+   // the same iSlot each worker task-closure already owns for a round. Reset (not
+   // freed) once per round by Pipeline.cpp's cleanupBatch, alongside the `queries`
+   // free above. See docs/20260723_ExtendFusedBatchPath.md.
+   std::vector<FusedSparseArena> sparseArenas;
 
    // Per-batch MS1 result accumulator (batch path only).
    std::vector<QueryMS1*> ms1Queries;

--- a/CometSearch/search/SearchSession.h
+++ b/CometSearch/search/SearchSession.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/SearchSession.h
+++ b/CometSearch/search/SearchSession.h
@@ -43,6 +43,7 @@
 #include "core/Params.h"
 #include "core/Types.h"
 #include "core/FusedSparseArena.h"
+#include "core/FusedResultsArena.h"
 #include "CometStatus.h"
 #include <mutex>
 #include <vector>
@@ -63,6 +64,18 @@ struct SearchSession
    // freed) once per round by Pipeline.cpp's cleanupBatch, alongside the `queries`
    // free above. See docs/20260723_ExtendFusedBatchPath.md.
    std::vector<FusedSparseArena> sparseArenas;
+
+   // Per-slot pool for the outer sparse-matrix pointer arrays (Query::
+   // ppfSparseSpScoreData/ppfSparseFastXcorrData/ppfSparseFastXcorrDataNL
+   // themselves, not their child blocks -- those are sparseArenas above). Same
+   // sizing/indexing/reset lifecycle. See docs/20260723_ExtendFusedBatchPath.md
+   // Phase 2a.
+   std::vector<FusedPointerArena> pointerArenas;
+
+   // Per-slot _pResults/_pDecoys pool for the fused FI_DB/PI_DB batch path. Same
+   // sizing/indexing/reset lifecycle as sparseArenas above; see
+   // docs/20260723_ExtendFusedBatchPath.md Phase 2b.
+   std::vector<FusedResultsArena> resultsArenas;
 
    // Per-batch MS1 result accumulator (batch path only).
    std::vector<QueryMS1*> ms1Queries;

--- a/CometSearch/search/SearchUtils.cpp
+++ b/CometSearch/search/SearchUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/search/SearchUtils.h
+++ b/CometSearch/search/SearchUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/threading/SearchMemoryPool.cpp
+++ b/CometSearch/threading/SearchMemoryPool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CometSearch/threading/SearchMemoryPool.h
+++ b/CometSearch/threading/SearchMemoryPool.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/20260723_ExtendFusedBatchPath.md
+++ b/docs/20260723_ExtendFusedBatchPath.md
@@ -380,3 +380,315 @@ the answer is now "much less penalty, but not zero." A phase 2 covering the oute
 curve. The original 82,000 / 165,000 / ~400,000 ("all spectra") configurations were not re-tested
 in this pass; given memory is now higher rather than lower at each tested size, those larger configs
 should be approached with the same OOM caution as the original investigation, not less.
+
+## Phase 2 plan: pool the outer sparse pointer arrays and `_pResults`/`_pDecoys`
+
+Status: IMPLEMENTED and validated -- see "Phase 2 results" near the end for measured before/after
+numbers, including a chunk-size tuning finding not anticipated by this plan. Line numbers below are
+as they were when this plan was written (commit `4c5567b9`, phase 1); see the Phase 2 results
+section for what actually landed.
+
+### Recap: what's left after phase 1
+
+Phase 1 pooled only the sparse matrix *child* blocks (the `float[SPARSE_MATRIX_SIZE]` leaves).
+Two other per-spectrum heap allocations in the fused batch path remain untouched, and per the
+Results section above, their residual cost is now the visible bottleneck:
+
+1. The three outer sparse-matrix **pointer arrays** (`ppfSparseFastXcorrDataNL`,
+   `ppfSparseFastXcorrData`, `ppfSparseSpScoreData`) -- `CometPreprocess.cpp:1305`, `:1359`, `:1420`.
+2. **`_pResults`/`_pDecoys`** (the `Results[iNumStored]` arrays) -- allocated in `FusedSearchSpectrum`
+   (around `CometPreprocess.cpp:3450-3489`, the `new Results[...]` calls and their per-field reset
+   loop).
+
+These need two different designs, because one is safely bump-allocatable (pure `float*` data) and
+the other is not (has non-trivial C++ members).
+
+### 2a. Outer sparse-matrix pointer arrays
+
+**A finding that changes the framing versus phase 1:** these outer arrays are *not* pooled even by
+the existing RTS single-spectrum pool. The `Query` destructor's unconditional
+`delete[] ppfSparseFastXcorrDataNL` / `delete[] ppfSparseFastXcorrData` / `delete[] ppfSparseSpScoreData`
+calls (`core/Types.h:826-827`, `:844-845`, `:858-859`) run regardless of `bSparseFromPool` -- only the
+inner per-bucket child-block loops are gated by that flag (`:818`, `:834`, `:849`). So unlike phase 1
+(which extended an existing RTS mechanism to the batch path), phase 2a would be pooling something
+RTS itself has never pooled either. That is fine -- it does not need to touch the RTS path at all --
+but it means there is no existing pattern to mirror here beyond phase 1's own arena design.
+
+**Design.** These arrays vary in length per spectrum (`iFastXcorrDataSize`/`iSpScoreData` scale with
+the spectrum's precursor mass), unlike phase 1's fixed-size `SPARSE_MATRIX_SIZE` blocks. Generalize
+`FusedSparseArena` (`core/FusedSparseArena.h`) into a small template, `FusedBumpArena<T>`, with two
+allocation modes built on the same append-only, never-move chunk list:
+
+- `AllocBlock()` -- fixed-size convenience wrapper (phase 1's existing usage), equivalent to
+  `AllocSpan(SPARSE_MATRIX_SIZE)`.
+- `AllocSpan(size_t n)` -- new for 2a: returns a zeroed, contiguous span of `n` elements. If the
+  remaining space in the current chunk is less than `n`, the remainder is wasted (never split a span
+  across chunks -- ownership stays a single contiguous pointer, matching how the code indexes these
+  arrays) and a new chunk begins. Chunk size must be >= the largest possible single request
+  (`g_staticParams.iArraySizeGlobal / SPARSE_MATRIX_SIZE + 1`) so a request can never fail to fit in
+  a freshly started chunk.
+
+Two type aliases cover both uses: `using FusedSparseChildArena = FusedBumpArena<float>;` (phase 1,
+unchanged behavior) and `using FusedPointerArena = FusedBumpArena<float*>;` (new).
+
+*Judgment call:* genericizing touches phase 1's already-shipped, validated code purely to avoid a
+second, hand-duplicated copy of the same chunk-growth logic (a real risk -- see phase 1's own
+"Correctness invariants" section for how easy it would be to get the never-move/zero-on-issue rules
+subtly wrong a second time). A hand-written, standalone `FusedPointerArena` struct is an equally
+valid, lower-risk-to-phase-1 alternative if keeping shipped code untouched is preferred; either way
+requires re-running phase 1's full validation (T1-T20 + byte-identical diff), since either changes
+the concrete type `sparseArenas` holds.
+
+**Wiring.**
+- `SearchSession` (`search/SearchSession.h`): add `std::vector<FusedPointerArena> pointerArenas;`,
+  sized alongside `sparseArenas` in `FusedLoadAndSearchSpectra` (same first-use lazy init, same
+  `iNumSlots` sizing).
+- `Preprocess()` (`CometPreprocess.cpp:1185`+): add a second optional parameter,
+  `FusedPointerArena* pPtrArena = nullptr`, threaded the same way `pArena` is today (from
+  `FusedSearchSpectrum` -> `Preprocess()`).
+- At each of the three allocation sites (`:1305`, `:1359`, `:1420`), when `pPtrArena != nullptr`:
+  replace `new float*[N]()` with `pPtrArena->AllocSpan(N)`, and set a **new** flag
+  `pScoring->bSparsePointerArraysFromPool = true`.
+
+**New `Query` flag: `bSparsePointerArraysFromPool`** (`core/Types.h`, alongside `bSparseFromPool`/
+`bResultsFromPool` at `:711-721`). Cannot reuse `bSparseFromPool` -- as established above, that flag
+never gated these outer-array deletes for *either* path, so repurposing it would silently change
+RTS's behavior (leaking these arrays, since RTS's pool was never designed to own them), not just add
+a capability to the batch path. Destructor changes needed: wrap the three unconditional
+`delete[] ppfSparse*` calls (`:826`, `:844-845`, `:858-859`) in
+`if (!bSparsePointerArraysFromPool)`.
+
+**Reset.** `FusedPointerArena::ResetRound()` rewinds the cursor only (O(1)), called from
+`Pipeline.cpp`'s `cleanupBatch` alongside the existing `sparseArenas` reset loop.
+
+### 2b. `_pResults`/`_pDecoys`
+
+**Why this needs a different mechanism than 2a/phase 1.** `Results` (`core/Types.h:44-74`) has two
+`std::string` and two `std::vector<ProteinEntryStruct>` members. A pure bump arena that hands out
+raw memory and "forgets" it at `ResetRound()` -- phase 1/2a's approach -- would leak whatever heap
+memory those strings/vectors had allocated the moment a chunk gets reused, since nothing would ever
+run their destructors. That rules out a memory-bump-and-forget design here.
+
+**Design: checkout-and-reset-in-place, not bump-and-forget.** Still an append-only, never-move chunk
+list (same pointer-stability requirement as phase 1, since issued `Results*` pointers must stay valid
+until the round's flush writes them out), but each chunk stores real, default-constructed
+`Results[]` objects (via `new Results[...]`, which default-constructs their string/vector members
+once, when a chunk grows) rather than raw bytes. Reuse across rounds relies on the exact reset-in-place
+technique `RtsScratch` already uses for the RTS path -- `EnsureResultsInitialized()` /
+`ResetOneResult()` / `ResetResultsForNewSpectrum()` (`CometPreprocess.cpp:155-208`) -- not
+placement-new/explicit-destructor bookkeeping. This is deliberately the simpler, safer of the two
+ways to handle non-POD members; see "Correctness invariants" below for why the alternative was
+rejected.
+
+A side benefit beyond eliminating `new[]`/`delete[]`: `ResetOneResult()`'s `.clear()` calls do not
+release a `std::vector`'s/`std::string`'s capacity, so a `Results` slot reused across *many* rounds
+will have its `pWhichProtein`/site-score-string capacity grow to fit its typical usage once, then
+stop reallocating -- something today's fresh-every-spectrum design can never benefit from, since
+every spectrum currently starts every vector at capacity 0. This is a genuinely new win, not just
+phase 1's technique reapplied.
+
+**Prerequisite refactor.** The field-reset list already exists in two near-duplicate places --
+`RtsScratch::ResetOneResult()` (`:175-191`) and an inline loop in `FusedSearchSpectrum`
+(`CometPreprocess.cpp`, the `new Results[...]` block and its following `for` loop). The code already
+flags this exact risk in a comment (`:172-174`: "Resets the subset of Results fields that
+PreprocessSingleSpectrumCore's batch-path (non-pooled) loop also resets ... Mirrors that loop's
+field list exactly"). Adding a third copy inside the new pool without consolidating first would make
+an already-acknowledged risk worse. Factor the field list into one shared function (e.g.
+`CometMassSpecUtils::ResetOneResult(Results&)`), called from all three places (RTS pool, the batch
+path's existing non-pooled fallback, and the new pool below). This refactor alone should be built and
+validated (T1-T20, byte-identical output) as its own step before adding the pool, since it changes
+nothing observable if done correctly.
+
+**`FusedResultsArena` (sketch).** `AllocResultsPair(iNumStored, bWantDecoys)` returns
+`{Results* pResults; Results* pDecoys /* nullptr if !bWantDecoys */;}`, running the shared
+`ResetOneResult()` loop on issue -- matching phase 1's `AllocBlock()` zero-on-issue convention,
+keeping `ResetRound()` O(1), and putting the reset cost exactly where the original code already paid
+it (no double cost). Unlike 2a, no variable-length span handling is needed: a `Results[iNumStored]`
+block's size depends only on `g_staticParams.options.iNumStored`, a single run-wide constant, not on
+anything spectrum-specific -- so this is a fixed-size-block arena, structurally simpler than 2a's.
+
+**Wiring.** `SearchSession` gets `std::vector<FusedResultsArena> resultsArenas;` (sized alongside the
+others). This only threads through `FusedSearchSpectrum`'s signature, not `Preprocess()`'s -- Results
+allocation happens directly in `FusedSearchSpectrum`, not inside `Preprocess()`.
+
+**Query flag: reuse `bResultsFromPool` as-is.** Unlike 2a, no new flag is needed: the destructor's
+existing `bResultsFromPool` branch (`:861-868`) already unconditionally covers both `_pResults` and
+`_pDecoys` with exactly the semantics 2b needs ("pool owns this, don't touch it") -- it was simply
+never set `true` by the batch path before. No destructor change required for 2b, mirroring phase 1's
+finding that `Query`'s destructor needed no changes.
+
+**Reset.** `FusedResultsArena::ResetRound()` rewinds the issuance cursor only (O(1)) -- the field-reset
+work happens at `AllocResultsPair()` time (issue), not here.
+
+### Correctness invariants (both sub-phases)
+
+- The same three invariants from phase 1 apply identically here, for the same structural reasons:
+  exactly one writer per slot's arena per round (the single `doJob` closure owning that slot for the
+  round); no arena access during `ResetRound()` (only called from `cleanupBatch`, after
+  `tp->wait_on_threads()` has returned); no pointer invalidation on chunk growth (append-only, never
+  move or resize an existing chunk).
+- **2b-specific.** Placement-new/manual-destructor-call arenas were considered and rejected in favor
+  of reset-in-place specifically to avoid a new invariant class phase 1/2a do not have: "every
+  constructed C++ object in a chunk must have its destructor run before that chunk's memory is next
+  treated as raw bytes." Reset-in-place sidesteps this entirely -- the `Results` objects in a chunk
+  stay constructed (never destroyed) for the arena's whole lifetime; only their dynamic (string/
+  vector) contents get cleared and refilled, exactly mirroring what `RtsScratch` already does safely
+  for RTS.
+
+### Implementation steps (suggested order -- each independently buildable/testable)
+
+1. Prerequisite refactor: consolidate the `Results` field-reset list into one shared function, used
+   by `RtsScratch::ResetOneResult()`, the batch path's existing inline loop, and (once added)
+   `FusedResultsArena`. Build + run T1-T20 to confirm this pure refactor changes nothing (byte-
+   identical output expected -- same field list, just called from a shared location).
+2. **Phase 2b first** (`_pResults`/`_pDecoys`): structurally simpler and lower-risk than 2a (no
+   variable-length spans, reuses `bResultsFromPool` as-is, no destructor change needed).
+3. **Phase 2a second** (outer pointer arrays): generalize `FusedSparseArena` into `FusedBumpArena<T>`
+   (or write a standalone `FusedPointerArena`, per the judgment call above), wire through
+   `Preprocess()`, add `bSparsePointerArraysFromPool` and the three destructor guard changes.
+4. Re-run the full phase 1 validation plan (T1-T20, byte-identical-output diff, the four-point
+   `FUSED_FLUSH_MIN_BATCH_SIZE` sweep) after **each** of steps 2 and 3 independently, not just once at
+   the end -- this isolates which sub-phase contributes how much (matching this investigation's
+   repeated measure-before/after-each-change discipline) and avoids one sub-phase's bug being masked
+   by the other's fix.
+
+### Expected outcome / what would falsify this plan
+
+Phase 1's own results attributed the residual Hz-degradation-with-batch-size and the higher-than-
+original-baseline memory at each size to these two remaining allocations. If 2b and/or 2a genuinely
+close that gap, the four-point sweep should show Hz *flattening out* (not just improving further) as
+batch size grows, and peak memory should stop exceeding phase 1's own pre-fix numbers at each size.
+If Hz still degrades meaningfully with batch size after both sub-phases, that would mean a third,
+still-unidentified cost is responsible, and would call for fresh instrumentation-driven investigation
+(e.g. adding `RTS_TIMING`-style per-step timing to the batch path, which does not currently exist --
+see `docs/20260714_rtspostprocessing.md`'s methodology for the RTS path as a template) rather than
+further guessing.
+
+### Risks / open questions
+
+- **`FusedResultsArena` chunk sizing is workload-sensitive in a new way.** Memory per chunk scales
+  with `iNumStored` (a run-wide constant that could be 1 or 100 depending on `comet.params`), unlike
+  phase 1/2a's blocks, which are a fixed size regardless of params. A chunk-spectra-count default
+  tuned for `iNumStored=2` (this investigation's benchmark config) could be a poor default for
+  `iNumStored=100` runs (100x more memory per chunk). Should size by a chunk *byte* budget, not a
+  fixed chunk-spectra-count -- i.e. compute `kChunkSpectra = kChunkByteBudget / (iNumStored *
+  sizeof(Results))` once `iNumStored` is known at first use, rather than a compile-time constant.
+- **Generalizing `FusedSparseArena` into `FusedBumpArena<T>` changes phase 1's already-shipped,
+  validated code.** Needs the same correctness validation phase 1 got (T1-T20 + byte-identical diff)
+  even though phase 1's own logic is meant to be behaviorally unchanged, purely because the concrete
+  class changes underneath it.
+- **Neither sub-phase touches the RTS single-spectrum path.** Both are additive, fused-batch-path-only
+  changes, consistent with phase 1's scoping and this repo's general pattern of keeping RTS and batch
+  memory-ownership logic deliberately separate (see `CometPreprocess.h`'s own comment on
+  `bUseThreadLocalPool`, and phase 1's "why the existing pool can't be reused unchanged" section
+  above).
+
+## Phase 2 results (2026-07-24, implemented and measured)
+
+Implemented in the order this plan suggested: (1) the prerequisite `Results` field-reset
+consolidation (`ResetOneResult` moved to a free function in `core/Types.h`, replacing three
+near-duplicate inline copies), (2) Phase 2b (`FusedResultsArena`, `core/FusedResultsArena.h`, new),
+(3) Phase 2a (`FusedSparseArena.h` generalized into a `FusedBumpArena<T, kChunkBytes>` template;
+`FusedSparseArena`/`FusedPointerArena` are now `using` aliases of two instantiations). `Query` got
+one new flag, `bSparsePointerArraysFromPool`, exactly as planned -- `bResultsFromPool` was reused
+as-is for 2b with no destructor change, also as planned.
+
+**Correctness**, validated independently after each of the three steps above (not just once at the
+end, per the plan's suggested order):
+- Full Linux `tests/unit/run_tests.py` suite: 19/19 passed after the refactor, after 2b, and after
+  2a (T1-T7, T11-T16, T19, T20).
+- Byte-identical output diff (same methodology as phase 1: `20250903_Hela_Ast_Neo_02.raw`, scan
+  range 1-40000, 37,453 spectra spanning multiple flush rounds) run three times, each comparing the
+  new state against the last validated one -- refactor vs. phase-1 baseline, 2b vs. refactor, and
+  (2a+2b combined) vs. phase-1 baseline. All three: byte-identical PSM data, only the output file's
+  embedded `-N` basename text differed.
+
+**An unplanned finding: `FusedPointerArena`'s chunk size mattered a lot.** The first Phase 2a
+measurement, using the same ~32 MB chunk-byte-budget guess phase 1 used for `FusedSparseArena`
+(never separately tuned, exactly the risk this plan's own "Risks" section flagged), was a poor
+trade: 0.3-4.4% faster than 2b alone but consistently ~3-3.5GB heavier at every batch size --
+including at `FUSED_FLUSH_MIN_BATCH_SIZE=1000`, where there is little pointer-array data to pool in
+the first place. Shrinking `kChunkBytes` from 32 MB to 2 MB (`core/FusedSparseArena.h`) left peak
+memory *unchanged* (ruling out chunk-size waste as the memory driver -- the cost is inherent to
+holding pointer-array data un-flushed longer, the same tradeoff 2b already makes for `Results`) but
+took Phase 2a from a marginal win to a clear one, described below. `2 MB` is itself still an
+untuned guess, just a better one than 32 MB for this workload -- see "Risks" below.
+
+**Performance (full file, 326,696 MS2 spectra), final state (refactor + 2b + tuned 2a) against both
+the phase 1 baseline and the very first (pre-phase-1) baseline from the original investigation:**
+
+| FUSED_FLUSH_MIN_BATCH_SIZE | Original (pre-phase-1) | Phase 1 only | Phase 2 (final) | Hz, phase 2 vs. original |
+|---|---|---|---|---|
+| 100 (effective 400) | not tested | not tested | 3009 Hz / 34.8GB | -- |
+| 250 (effective 400) | not tested | not tested | 2941 Hz / 34.8GB | -- |
+| 500 | not tested | not tested | 3012 Hz / 34.8GB | -- |
+| 1,000 | 1888 Hz / 30.3GB | 3234 Hz / 31.3GB | 3515 Hz / 35.8GB | +86% |
+| 5,000 ("default" when this table was measured -- see below) | 1332 Hz / 31.8GB | 2966 Hz / 33.6GB | 3496 Hz / 37.3GB | +162% |
+| 10,000 | 1019 Hz / 34.5GB | 2588 Hz / 35.5GB | 3497 Hz / 39.6GB | +243% |
+| 20,000 | 665 Hz / 40.0GB | 2088 Hz / 41.1GB | 3179 Hz / 44.8GB | +378% |
+
+**Default changed, 2026-07-24: `FUSED_FLUSH_MIN_BATCH_SIZE` is now `1,000` (was `5,000`).** Based on
+this table's "Phase 2 (final)" column, `1,000` gives both the best throughput (3515 Hz, versus
+3496/3497/3179 Hz at 5,000/10,000/20,000) and the lowest memory (35.8GB, versus 37.3-44.8GB) of every
+non-floored value tested -- there is no longer a reason to default to a larger value now that phase 2
+has removed most of the throughput penalty larger values used to carry, and smaller peak memory is a
+strict win with no measured downside at this workload's scale. The `5,000` label above is left as
+"default at the time" for an accurate historical record of what this specific table measured, not
+current behavior -- see `git log core/Constants.h` for the change itself.
+
+`FUSED_FLUSH_PER_THREAD` (`core/Constants.h:48`) imposes a floor: the actual per-round flush
+threshold is `max(FUSED_FLUSH_MIN_BATCH_SIZE, iNumThreads * FUSED_FLUSH_PER_THREAD)`, which is
+`max(N, 8 * 50) = max(N, 400)` for this benchmark's 8 threads. So `100` and `250` both actually ran
+at an effective threshold of `400`, not their nominal values -- their near-identical Hz (3009 vs.
+2941, within run-to-run noise) and identical memory (34.8GB both) confirm this rather than
+representing two genuinely different configurations. `500` is only slightly above that same floor,
+which is why it also lands in the same narrow band. None of the three moved memory measurably below
+the 1,000 row's 35.8GB -- consistent with the fixed ~19.8GB FI-index baseline (see the original
+2026-07-23 investigation) dominating at these small batch sizes, with the pooled-arena contribution
+too small yet to show much variation.
+
+**Interpretation.** The original pathology -- Hz collapsing as batch size grew (1888 -> 665 Hz, -65%
+from 1,000 to 20,000) -- is essentially gone: Hz is now flat from 1,000 through 10,000
+(3515/3496/3497 Hz) and only softens at 20,000 (3179 Hz, still 51% above phase 1 alone at that size
+and 4.8x the original baseline). Memory still grows with batch size, as expected for "hold more
+results before flushing," but far more gently in relative terms than the original problem: +25%
+from 1,000 to 20,000 (35.8GB -> 44.8GB) versus the original's +32% (30.3GB -> 40.0GB) *combined with*
+a throughput collapse the current numbers no longer show.
+
+**Against the validation plan's stated success criterion** ("Hz should stay roughly flat... peak
+memory growth... should shrink substantially versus baseline, stop exceeding phase 1's own pre-fix
+numbers"): the Hz-flattening half is essentially achieved. The memory half is not -- final peak
+memory is still higher than phase 1 alone at every size (e.g. 44.8GB vs. 41.1GB at 20,000), by
+roughly a constant 4-5GB across all four sizes, attributable to the two new pools (`FusedResultsArena`
++ tuned `FusedPointerArena`) holding their own data un-flushed for the same duration `FusedSparseArena`
+already does. This is the expected, accepted cost of pooling rather than a defect -- pooling trades
+allocator churn for a larger steady-state working set -- and per the interpretation above, is a much
+better trade than the original per-spectrum-allocation regime it replaced.
+
+**Conclusion:** the original question from the 2026-07-23 investigation -- can
+`FUSED_FLUSH_MIN_BATCH_SIZE` be raised to reduce flush-wait pauses without a severe throughput
+penalty -- now has a much more favorable answer than after phase 1 alone. Throughput no longer
+collapses with batch size; it stays close to its best value across the whole tested range. Memory
+still grows somewhat with batch size, which is inherent to holding more results in memory longer
+(the entire point of raising this constant) rather than a bug to fix further. The 82,000 / 165,000 /
+~400,000-"all" configurations skipped in the original investigation were not re-tested here; given
+memory still grows with batch size (now from a higher floor, ~35-45GB across the tested range versus
+the original ~30-40GB), those larger configs should still be approached with real OOM caution on a
+machine like the one used throughout this investigation (63.5GB total RAM).
+
+### Risks / open questions (Phase 2, post-implementation)
+
+- **`kChunkBytes = 2 MB` for `FusedPointerArena` is a better guess, not a tuned optimum.** Only two
+  values (32 MB, 2 MB) were compared, at one batch size (20,000) before adopting 2 MB across the
+  board. A proper sweep of chunk sizes (and confirming the optimum doesn't shift at the larger,
+  untested batch sizes) was not performed.
+- **The ~4-5GB memory premium of Phase 2 over Phase 1 alone was not decomposed** between
+  `FusedResultsArena` and the tuned `FusedPointerArena` -- both were implemented and measured
+  together as "final state." Isolating each pool's individual memory contribution (e.g. via the same
+  before/after methodology used for 2b alone earlier in this document) would clarify whether one pool
+  dominates the premium, which would be the natural next place to look for further memory reduction.
+- **All Phase 2 measurements reuse the same machine, raw file, and params as phase 1 and the original
+  investigation** (this repo's benchmarking convention throughout this document) -- results have not
+  been checked against a different `iNumStored`/decoy-search configuration, which `FusedResultsArena`'s
+  own sizing (chunk-byte-budget divided by `iNumStored`) is specifically designed to adapt to but
+  which was never exercised here (`iNumStored=2` throughout, from `num_output_lines=1`).

--- a/docs/20260723_ExtendFusedBatchPath.md
+++ b/docs/20260723_ExtendFusedBatchPath.md
@@ -1,0 +1,382 @@
+# Extend the RTS thread-local sparse-matrix pool to the fused batch path
+
+Status: IMPLEMENTED and validated -- see "Results" section near the end for measured
+before/after numbers.
+
+## Background
+
+A 2026-07-23 investigation into `FUSED_FLUSH_MIN_BATCH_SIZE` (`CometSearch/core/Constants.h:49`)
+benchmarked FI_DB batch search (`20250903_Hela_Ast_Neo_02.raw`, 326,696 MS2 spectra, 8 threads,
+human canonical target-decoy FASTA/index, phospho search params) across four values of that
+constant:
+
+| FUSED_FLUSH_MIN_BATCH_SIZE | Search time | ms/spec | Hz | Peak memory | Total time |
+|---|---|---|---|---|---|
+| 1,000 | 2m:53s | 0.53 | 1888 | 30.3GB | 4m:00s |
+| 5,000 (repo default) | 4m:05s | 0.75 | 1332 | 31.8GB | 5m:13s |
+| 10,000 | 5m:20s | 0.98 | 1019 | 34.5GB | 6m:27s |
+| 20,000 | 8m:11s | 1.50 | 665 | 40.0GB | 9m:18s |
+
+Raising the batch size made both memory and throughput monotonically *worse*, the opposite of
+the "avoid flush-wait pauses" hypothesis that motivated the investigation. The sweep was stopped
+after 20,000 (82,000 / 165,000 / ~400,000 were not run) once the mechanism was understood, to
+avoid an OOM/paging run on a 63.5GB-RAM machine already at 40GB peak.
+
+**Root cause**, traced to `CometPreprocess.cpp`: the fused batch path
+(`FiStrategy`/`PiStrategy::executeBatch` -> `FusedLoadAndSearchSpectra` -> `FusedSearchSpectrum`
+-> `Preprocess()`) heap-allocates a fresh sparse XCorr matrix (`ppfSparseSpScoreData`,
+`ppfSparseFastXcorrData`, `ppfSparseFastXcorrDataNL`) for **every spectrum**, via individual
+`new float*[...]` (the outer pointer array) and `new float[SPARSE_MATRIX_SIZE]` calls (the per-
+bucket child blocks), at `CometPreprocess.cpp:1304`, `:1350`, `:1403`. `FUSED_FLUSH_MIN_BATCH_SIZE`
+does not control how much gets "preloaded" -- raw spectrum reads are already bounded to
+`iNumThreads * 4` in flight (`BoundedSpectrumQueue`, `CometPreprocess.cpp:3494`), independent of
+this constant. What it actually controls is how many of these individually-`new`'d `Query`
+objects -- each carrying its own sparse matrix -- stay alive on the heap simultaneously, across
+8 threads sharing one CRT heap, before `Pipeline::run()`'s per-round flush frees them all. A
+bigger batch size means more concurrently-live, separately-allocated sparse matrices, which
+directly explains both the memory growth and (via heap allocator contention/fragmentation under
+concurrent multi-threaded alloc/free pressure) the throughput drop.
+
+There is already a pooled/reused version of this exact allocation in the codebase --
+`Query::bSparseFromPool` (`core/Types.h:711-721`), backed by the `thread_local RtsScratch` pool
+(`CometPreprocess.cpp:55-211`) -- but per its own comment it is wired up **only** for
+`PreprocessSingleSpectrumThreadLocal`, the true single-spectrum real-time-search (RTS) entry
+point. The fused batch path never takes that branch. This document plans extending that pooling
+to the fused batch path.
+
+## Goal
+
+Eliminate per-spectrum heap allocation/deallocation of each `Query`'s sparse XCorr matrix child
+blocks in the fused batch path, so that `FUSED_FLUSH_MIN_BATCH_SIZE` can be raised (reducing how
+often the batch pauses to flush results and relaunch the worker pool) without the memory-growth
+and allocator-contention penalty measured above.
+
+## Current architecture (baseline)
+
+`RtsScratch` (`CometPreprocess.cpp:55-211`) is a `thread_local` struct owning, per OS thread:
+
+- Six transient scratch buffers (`pdTmpRawData`, `pdTmpFastXcorrData`, `pdTmpCorrelationData`,
+  `pfFastXcorrData`, `pfFastXcorrDataNL`, `pfSpScoreData`) used only *during* one `Preprocess()`
+  call and safe to reuse immediately afterward. **The fused batch path already reuses these** --
+  `FusedSearchSpectrum` passes `g_rtsScratch.pdTmpRawData` etc. straight into `Preprocess()`
+  (`CometPreprocess.cpp:3398-3404`) -- this part of the pool is not the problem.
+- `pSparseChildPool`: a flat, pre-zeroed slab of `float[SPARSE_MATRIX_SIZE]` blocks
+  (`SPARSE_MATRIX_SIZE` = 100, `CometData.h:35`), handed out sequentially by `AllocSparseChild()`
+  (`:147-152`) and bulk-reset via `ResetForNewSpectrum()` (`:134-142`) at the start of the next
+  spectrum on that thread. Sized for exactly one in-flight spectrum's worth of blocks
+  (`iSparsePoolCapacity = 6 * (iSize / SPARSE_MATRIX_SIZE + 2)`, `:125`).
+- `pResults`/`pDecoys`: a single `Results[iNumStored]` array, reused in place and reset field-by-
+  field via `ResetResultsForNewSpectrum()` (`:194-208`) at the start of the next spectrum.
+
+`Query::bSparseFromPool` / `Query::bResultsFromPool` (`core/Types.h:711-721`) mark whether the
+`Query` destructor should skip `delete[]`-ing these because the pool owns them. Both are set only
+by `PreprocessSingleSpectrumCore(bUseThreadLocalPool=true)` (`CometPreprocess.cpp:1458`+), called
+only from `PreprocessSingleSpectrumThreadLocal` -- the RTS path. The comment at
+`CometPreprocess.h:207-208` states the reason explicitly: "the batch path must use false because
+pooled Queries are destroyed before the pool is reset."
+
+The key invariant this design relies on -- documented in the concurrency-nondeterminism section of
+`docs/20260714_rtspostprocessing.md` -- is that **exactly one spectrum's pool data is alive per
+thread at a time**: `ResetForNewSpectrum()` fully re-zeros exactly what the immediately preceding
+spectrum on that thread wrote, before the next spectrum starts. That invariant is what a fused-
+batch-path pool must NOT rely on, since the whole point of batching is to keep many `Query`
+objects alive at once.
+
+## Why the existing pool can't be reused unchanged
+
+1. **Lifetime mismatch.** RTS destroys/returns each `Query` before the next spectrum on that
+   thread starts. The fused batch path deliberately keeps up to roughly
+   `FUSED_FLUSH_MIN_BATCH_SIZE / iNumSlots` `Query` objects alive concurrently per worker slot --
+   that is the entire point of the batch-and-flush design (`search/Pipeline.cpp:155-214`) -- so a
+   "one buffer, reset before the next spectrum" pool would corrupt every earlier `Query`'s still-
+   referenced sparse data the moment the next spectrum on that slot ran.
+2. **Ownership crosses threads at flush.** Each slot's `Query` objects are produced by that
+   slot's worker task, concatenated into `session.queries` after `tp->wait_on_threads()` returns
+   (`CometPreprocess.cpp:3706-3714`), then freed later by `Pipeline::run()`'s `cleanupBatch` lambda
+   (`Pipeline.cpp:155-161`) on the calling (main) thread -- not the worker thread that created
+   them. A `thread_local` free-list-style pool needs the free to happen on the same thread as the
+   alloc, which does not hold here.
+3. **Slot index is not a stable OS-thread identity across rounds.** `FusedLoadAndSearchSpectra`
+   submits `iNumSlots` fresh closures per round via `tp->doJob()` (`:3496-3504`) into a
+   `BS::thread_pool` (`ThreadPool.h:89`); nothing pins "slot t" to the same underlying OS worker
+   thread from one call to `FusedLoadAndSearchSpectra` to the next, so a `thread_local`-keyed pool
+   does not consistently correspond to "slot t" across rounds, even though it is stable within one
+   round (each slot's closure runs its own `while (queue.pop(spec))` loop single-threaded for the
+   whole round, `:3498-3503`).
+
+## Proposed design
+
+### Core choice: per-slot bump arena, reset at the flush boundary -- not a free list
+
+All `Query` objects created during one flush round share the exact same destruction point:
+`cleanupBatch()` deletes the whole `session.queries` vector at once, every round
+(`Pipeline.cpp:157-158`). This is a natural match for a bump/arena allocator that hands out memory
+sequentially during the round and resets in bulk (O(1), not per-object) at the same point
+`cleanupBatch` already runs -- no per-block free-list bookkeeping, and no return-to-owner-thread
+problem, because nothing is ever individually freed mid-round; the whole arena is simply rewound
+once, on whichever thread runs `cleanupBatch` (safe, because that only happens after
+`tp->wait_on_threads()` has returned, i.e. after every worker for that round is already idle -- no
+concurrent arena access is possible at that point).
+
+### Ownership: `SearchSession`, keyed by slot index
+
+Add to `SearchSession` (`search/SearchSession.h:49-77`):
+
+```cpp
+std::vector<FusedSparseArena> sparseArenas;   // sized to iNumSlots on first use, indexed by iSlot
+```
+
+`session` already outlives every round for one input file (constructed once in `Pipeline::run()`,
+passed by reference through `executeBatch` / `FusedLoadAndSearchSpectra` / `FusedSearchSpectrum`,
+and already the exact place `cleanupBatch` reaches into via `session.queries`), so it is the
+natural, already-threaded-through owner. Sizing/lazy-init happens once, at the top of
+`FusedLoadAndSearchSpectra`, the first time `session.sparseArenas.empty()` (mirrors how
+`vSlotQueries` is sized there today, `:3483`).
+
+Explicitly **not** `thread_local`, and **not** keyed by OS thread identity -- keyed by the same
+`iSlot` index `FusedSearchSpectrum` already receives as a parameter (`:125-128`), sidestepping the
+slot-to-OS-thread instability noted above entirely.
+
+### Data structure: append-only chunk list (never reallocate/move existing storage)
+
+A single growable `std::vector<float>` (realloc-on-grow) is unsafe here: any `resize()` /
+`reserve()` that reallocates would invalidate every pointer already handed out to a `Query`
+created earlier in the same round -- and those pointers are read later (output writing, post-
+analysis) after the round's allocation phase has moved on to later spectra that may trigger
+growth. So each chunk, once allocated, is never moved or freed for the life of the run:
+
+```cpp
+struct FusedSparseArena
+{
+   static constexpr size_t kChunkBlocks = 65536;   // ~25 MB/chunk at SPARSE_MATRIX_SIZE=100 floats
+
+   std::vector<std::unique_ptr<float[]>> vChunks;  // append-only; existing entries never move/free
+   size_t iCurChunk     = 0;   // chunk currently being filled
+   size_t iCurChunkUsed = 0;   // blocks used in that chunk so far this round
+
+   // Called only from the single worker task-closure that owns this slot for the current
+   // round (FusedSearchSpectrum) -- no lock needed, exactly one writer at a time (see
+   // "Correctness invariants" below).
+   float* AllocBlock()
+   {
+      if (vChunks.empty() || iCurChunkUsed >= kChunkBlocks)
+      {
+         if (iCurChunk + 1 < vChunks.size())        // reuse a chunk grown in an earlier round
+            ++iCurChunk;
+         else
+         {
+            vChunks.push_back(std::make_unique<float[]>(kChunkBlocks * SPARSE_MATRIX_SIZE));
+            iCurChunk = vChunks.size() - 1;
+         }
+         iCurChunkUsed = 0;
+      }
+      float* p = vChunks[iCurChunk].get() + iCurChunkUsed * SPARSE_MATRIX_SIZE;
+      std::fill(p, p + SPARSE_MATRIX_SIZE, 0.0f);   // zero-on-issue -- preserves AllocSparseChild's
+                                                      // existing pre-zeroed guarantee, at per-block
+                                                      // cost instead of a bulk per-round memset
+      ++iCurChunkUsed;
+      return p;
+   }
+
+   // Called once per round, only after tp->wait_on_threads() has returned AND cleanupBatch has
+   // finished freeing session.queries for that round -- i.e. no concurrent AllocBlock() call can
+   // be in flight. Rewinds to the start of chunk 0; all chunks stay allocated (steady-state
+   // reuse), so after the first several rounds this design does zero further heap traffic for
+   // sparse child blocks.
+   void ResetRound() { iCurChunk = 0; iCurChunkUsed = 0; }
+};
+```
+
+No upfront capacity prediction is needed -- the arena grows on demand during the first several
+rounds and then plateaus once it has enough chunks for the workload's actual peak per-slot usage,
+since chunks are never freed. This is simpler and more robust than trying to precompute
+`iFlushBatchSize / iNumSlots * blocks-per-spectrum` up front, the way the existing single-spectrum
+pool's `6 * (iSize / SPARSE_MATRIX_SIZE + 2)` formula does -- that formula assumes exactly one
+spectrum in flight, not a whole round's worth.
+
+### Wiring into `Preprocess()` / `Query::bSparseFromPool`
+
+`Preprocess()` (`CometPreprocess.cpp:1185-1457`) currently does, at each of three sites:
+
+```cpp
+pScoring->ppfSparseFastXcorrDataNL = new float*[pScoring->iFastXcorrDataSize]();   // :1304
+...
+pScoring->ppfSparseFastXcorrData   = new float*[pScoring->iFastXcorrDataSize]();   // :1350
+...
+pScoring->ppfSparseSpScoreData     = new float*[pScoring->iSpScoreData]();          // :1403
+```
+
+followed by, per in-use bin, `new float[SPARSE_MATRIX_SIZE]`. Add a `FusedSparseArena* pArena`
+parameter to `Preprocess()` (nullptr for any caller that does not want pooling -- currently only
+`FusedSearchSpectrum` calls this function, but keeping it nullable avoids forcing every call site
+to supply one). Thread it from `FusedSearchSpectrum(spec, iSlot, outQueries, outCount)` as
+`&session.sparseArenas[iSlot]`; note `FusedSearchSpectrum` does not currently receive `session` at
+all (`CometPreprocess.h:125-128`, `CometPreprocess.cpp:3159-3162` -- it is called today with only
+`vSlotQueries[t].v` and `aQueryCount`, `:3502`), so this is a small signature/call-site change up
+the chain (`FusedLoadAndSearchSpectra` -> the `doJob` lambda -> `FusedSearchSpectrum`).
+
+When `pArena != nullptr`: each per-bucket `new float[SPARSE_MATRIX_SIZE]` becomes
+`pArena->AllocBlock()`, and `pScoring->bSparseFromPool = true` is set -- reusing the existing flag
+and the existing destructor logic at `core/Types.h:834-857` verbatim; no destructor change is
+needed, since it already skips the child-block `delete[]` whenever this flag is true.
+
+### Explicitly out of scope for this plan (phase 1)
+
+- **The outer `ppfSparseFastXcorrData` / `ppfSparseFastXcorrDataNL` / `ppfSparseSpScoreData`
+  pointer arrays themselves** (the `new float*[N]()` calls at `:1304` / `:1350` / `:1403`) are not
+  pooled by this plan -- only their child blocks are. Each `Query` still does up to 3 small
+  `new[]` calls for these pointer arrays. This is a much cheaper allocation pattern than today's
+  (N children eliminated per `Query`, 3 small pointer-arrays remain), and pooling the pointer
+  arrays too would require either a fixed global upper bound on `iFastXcorrDataSize` /
+  `iSpScoreData` (so every `Query`'s pointer array is the same size and can come from a similarly-
+  shaped pool) or a second, differently-shaped arena -- deferred as a phase 2, measurement-driven
+  follow-on, per the "measure before optimizing further" lesson `docs/20260714_rtspostprocessing.md`
+  draws from its own findings 1 and 6.
+- **`_pResults` / `_pDecoys`** are not pooled by this plan. Unlike the sparse child blocks,
+  `Results` (`core/Types.h:44-74`) has non-trivial members (`std::string`,
+  `vector<ProteinEntryStruct>`) that cannot be safely bump-allocated/reset without explicit
+  placement-new and destructor bookkeeping per slot -- a real but separate design problem.
+  `docs/20260714_rtspostprocessing.md` finding 1 pooled this exact struct for the RTS single-
+  spectrum path (reset-in-place, not arena-based, since RTS only ever needs one live copy at a
+  time) and measured only a ~1.4%-of-total-time isolated win there; given `num_output_lines=1` in
+  this session's benchmark params (`iNumStored=2`), `Results` is a comparatively small contributor
+  next to the sparse matrices, which scale with the mass-range-dependent bin count, not a small
+  fixed constant. Worth a follow-up measurement once phase 1 is validated, not a blocker for it.
+
+## Implementation steps
+
+1. Add `FusedSparseArena` as a new small struct -- likely its own header (e.g.
+   `CometSearch/core/FusedSparseArena.h`) so both `SearchSession.h` and `CometPreprocess.cpp` can
+   include it without pulling in unrelated dependencies.
+2. Add `std::vector<FusedSparseArena> sparseArenas;` to `SearchSession`
+   (`search/SearchSession.h`).
+3. In `FusedLoadAndSearchSpectra` (`CometPreprocess.cpp:3455`+), resize `session.sparseArenas` to
+   `iNumSlots` on first use (mirrors `vSlotQueries` sizing at `:3483`).
+4. Thread an arena reference through `FusedSearchSpectrum`'s signature
+   (`CometPreprocess.h:125-128`, `CometPreprocess.cpp:3159-3162`) and its call site inside the
+   `doJob` lambda (`:3498-3503`).
+5. In `Preprocess()` (`CometPreprocess.cpp:1185-1457`), add the `FusedSparseArena*` parameter,
+   branch the three child-block allocation sites (`:1304`, `:1350`, `:1403` and their per-bucket
+   loops) on whether it is non-null, and set `pScoring->bSparseFromPool = true` when pooled.
+6. In `Pipeline.cpp`'s `cleanupBatch` lambda (`:155-161`), add
+   `for (auto& arena : session.sparseArenas) arena.ResetRound();` alongside the existing
+   `delete q` loop -- same point in the same function, so the "no concurrent access" invariant is
+   trivially true by construction (nothing schedules new work into a slot's arena until the next
+   `executeBatch()` call, which happens after `cleanupBatch()` returns).
+7. No change needed to `Query`'s destructor (`core/Types.h:820-886`) -- it already branches on
+   `bSparseFromPool` correctly for this exact "don't delete[], pool owns it" case.
+
+## Correctness invariants to preserve (and verify)
+
+- **Exactly one writer per slot's arena per round.** True by construction: each slot's
+  `FusedSearchSpectrum` calls all run inside the single `while (queue.pop(spec))` loop of that
+  slot's one `doJob` closure (`:3498-3503`) -- never two closures touching the same `iSlot`
+  concurrently.
+- **No arena access during `ResetRound()`.** True by construction: `cleanupBatch()` runs only
+  after `executeBatch()` -> `FusedLoadAndSearchSpectra()` has returned, which itself only returns
+  after `tp->wait_on_threads()` (`:3698`) -- every worker for that round is already idle.
+- **No pointer invalidation on growth.** The chunk-list design never moves or frees an already-
+  allocated chunk; `AllocBlock()` only ever appends a new chunk, or reuses an existing later chunk
+  from an earlier, larger round -- and that reuse only happens after `ResetRound()`, i.e. after
+  every prior pointer into it is already dead. No existing chunk is ever resized.
+- **Zero-on-issue.** `AllocBlock()` must zero exactly the block it returns before returning it,
+  preserving the guarantee `pSparseChildPool`'s bulk pre-zero + `ResetForNewSpectrum()` provide
+  today (`CometPreprocess.cpp:126`, `:138-141`) -- several downstream sparse-matrix consumers
+  (e.g. `CometPostAnalysis.cpp:1290-1301`) implicitly rely on unallocated/never-written bins
+  reading as zero.
+
+## Validation plan
+
+1. **Correctness, batch path.** Unlike the RTS path documented in
+   `docs/20260714_rtspostprocessing.md` (unreachable from the Linux suite), the fused batch path
+   IS exercised by `tests/unit/run_tests.py`. Full suite (T1-T18) must pass unchanged.
+2. **Byte-identical output.** Run the same FI_DB search (this session's phosho params +
+   `20250903_Hela_Ast_Neo_02.raw`, or a smaller/faster fixture for iteration) before and after,
+   diff the full `.txt` output -- must be byte-identical, since this change only alters memory
+   *ownership*, not any scoring/search logic. (Unlike `docs/20260714_rtspostprocessing.md`'s RTS
+   `rts.out` diffs, an exact match is expected here -- the batch path does not have that doc's
+   documented near-tied-score nondeterminism sources.)
+3. **Re-run this session's exact benchmark sweep** (`FUSED_FLUSH_MIN_BATCH_SIZE` =
+   1000/5000/10000/20000, same raw file, same params, same machine) and compare against the
+   2026-07-23 baseline table reproduced at the top of this document. Success criterion: Hz should
+   stay roughly flat (not degrade) as batch size increases, and peak-memory growth above the fixed
+   ~19.8GB FI-index baseline should shrink substantially versus baseline, since concurrently-live
+   sparse child blocks are now pooled/arena blocks reused across rounds instead of N fresh heap
+   allocations per round.
+4. **Only after 1-3 pass**, extend the sweep to the three configs skipped this session (82,000 /
+   165,000 / ~400,000-"all") to check whether the original goal -- raising
+   `FUSED_FLUSH_MIN_BATCH_SIZE` to reduce flush-wait pauses without a memory/throughput penalty --
+   is actually achievable now. This is the real test of whether phase 1 alone resolves the
+   original question, or whether the remaining un-pooled costs (outer pointer arrays,
+   `_pResults`/`_pDecoys`) become the new bottleneck at that scale.
+
+## Risks / open questions
+
+- **Steady-state chunk count is workload-dependent and per-slot.** If per-thread spectrum load is
+  uneven (e.g. some spectra need far more sparse blocks than others, and happen to cluster onto
+  one slot), one slot's arena could grow much larger than others'. Not a correctness risk (each
+  arena is independent), but worth watching in the phase-1 memory measurement -- if it happens,
+  total memory could still track close to today's worst case for that one slot, just without the
+  allocator churn.
+- **`kChunkBlocks` is a guess (65536, ~25 MB/chunk)** -- no measurement backs this number yet. Too
+  small wastes time on repeated `vChunks.push_back()` calls (still cheap, but not free); too large
+  wastes memory on partially-used trailing chunks, times `iNumSlots`. Should be tuned against a
+  real run's actual usage distribution during implementation, not fixed a priori.
+- **This plan does not address the two costs explicitly deferred above** (outer pointer arrays,
+  `_pResults`/`_pDecoys`). If step 4 of the validation plan shows those now dominate at very large
+  batch sizes, a phase 2 covering them would be a natural follow-up, written as its own dated doc
+  once phase 1's measurements are in hand (matching this repo's existing pattern of one dated doc
+  per investigation/change, e.g. `docs/20260714_rtspostprocessing.md`,
+  `docs/20260714_EvalueJitter.md`).
+
+## Results (2026-07-23, phase 1 implemented and measured)
+
+Implemented exactly as designed above: `CometSearch/core/FusedSparseArena.h` (new), plus edits to
+`search/SearchSession.h`, `CometPreprocess.h`/`.cpp` (three allocation sites in `Preprocess()`,
+`FusedSearchSpectrum()`/`FusedLoadAndSearchSpectra()` signatures), and `search/Pipeline.cpp`'s
+`cleanupBatch` lambda. No changes needed to `Query`'s destructor, as predicted.
+
+**Correctness:**
+- Full Linux `tests/unit/run_tests.py` suite: 19/19 passed (T1-T7, T11-T16, T19, T20), including
+  T19/T20 which exercise the FI_DB/PI_DB fused batch path directly.
+- Byte-identical output diff: same FI_DB search (this doc's params + `20250903_Hela_Ast_Neo_02.raw`,
+  scan range 1-40000, 37,453 spectra spanning 7+ flush rounds at the default
+  `FUSED_FLUSH_MIN_BATCH_SIZE=5000`) run with the pre-change code (via `git stash`) and the
+  post-change code. Every PSM data row was byte-identical; the only diff line was the output
+  file's embedded `-N` basename text itself.
+
+**Performance (full file, 326,696 MS2 spectra, otherwise identical to the original 2026-07-23
+sweep):**
+
+| FUSED_FLUSH_MIN_BATCH_SIZE | Before (search time / Hz / peak mem) | After (search time / Hz / peak mem) | Hz change |
+|---|---|---|---|
+| 1,000 | 2m:53s / 1888 Hz / 30.3GB | 1m:41s / 3234 Hz / 31.3GB | +71% |
+| 5,000 (default) | 4m:05s / 1332 Hz / 31.8GB | 1m:50s / 2966 Hz / 33.6GB | +123% |
+| 10,000 | 5m:20s / 1019 Hz / 34.5GB | 2m:6s / 2588 Hz / 35.5GB | +154% |
+| 20,000 | 8m:11s / 665 Hz / 40.0GB | 2m:36s / 2088 Hz / 41.1GB | +214% |
+
+**Interpretation.** A large, real, consistent throughput win at every batch size tested (71-214%
+faster), most pronounced at the larger sizes -- exactly where the original allocator-contention
+problem was worst. This confirms the root-cause diagnosis and the arena design.
+
+**However, the success criterion in the validation plan above was only partially met.** The plan
+predicted Hz should "stay roughly flat" as batch size increases and memory growth should "shrink
+substantially" -- neither happened completely. With the fix, Hz still degrades as batch size grows
+(3234 -> 2966 -> 2588 -> 2088), just far less steeply than before (1888 -> 1332 -> 1019 -> 665), and
+peak memory is now slightly *higher* than the pre-fix baseline at every size (e.g. 41.1GB vs 40.0GB
+at 20,000), still growing with batch size. This is consistent with the plan's own "explicitly out
+of scope" section: the outer `ppfSparseFastXcorrData`/`ppfSparseFastXcorrDataNL`/
+`ppfSparseSpScoreData` pointer arrays (3 small `new[]` calls per spectrum) and `_pResults`/
+`_pDecoys` (1-2 `new[]` calls per spectrum) are still individually heap-allocated per spectrum and
+still accumulate un-pooled for as long as a `Query` stays alive before flush -- phase 1 removed the
+*largest* per-spectrum allocation (the sparse child blocks, which scale with mass-range bin count)
+but not these smaller, fixed-size ones. Their residual cost is exactly what's now visible in the
+remaining Hz-degradation and memory-growth trend.
+
+**Conclusion:** phase 1 is a real, validated win and should be kept, but does not fully resolve the
+original question ("can `FUSED_FLUSH_MIN_BATCH_SIZE` be raised arbitrarily without penalty?") --
+the answer is now "much less penalty, but not zero." A phase 2 covering the outer pointer arrays and
+`_pResults`/`_pDecoys`, per the deferred-scope section above, would be needed to fully flatten the
+curve. The original 82,000 / 165,000 / ~400,000 ("all spectra") configurations were not re-tested
+in this pass; given memory is now higher rather than lower at each tested size, those larger configs
+should be approached with the same OOM caution as the original investigation, not less.

--- a/docs/20260724_PreloadBenchmark.md
+++ b/docs/20260724_PreloadBenchmark.md
@@ -1,0 +1,223 @@
+# Batch vs. RTS FI_DB throughput: isolating read time from search time
+
+Status: IMPLEMENTED and measured.
+
+## Background
+
+`docs/20260723_ExtendFusedBatchPath.md` closed most of the gap between the fused batch path's
+throughput at different `FUSED_FLUSH_MIN_BATCH_SIZE` values, but that investigation's own batch
+numbers (up to ~3500-5500 Hz) were dwarfed by a separate RTS benchmark
+(`20260420-human-phosho/run2.out/results/index.html`) showing FI_DB real-time search reaching
+12,681 Hz at 20 threads on `20240924_Hela_01.raw` (63,488 MS2 spectra). This document investigates
+that gap directly.
+
+## First pass: same file, same index, batch's own reported Hz
+
+Running the current batch code (`Comet.exe -D<idx> <raw>`) against the exact file/index/thread
+counts RTS was tested at:
+
+| Threads | RTS FI_DB (Hz) | Batch FI_DB (Hz) | Batch / RTS |
+|---|---|---|---|
+| 1 | 1,356 | 1,154 | 85% |
+| 2 | 2,651 | 2,241 | 85% |
+| 4 | 5,209 | 3,944 | 76% |
+| 8 | 8,991 | 5,474 | 61% |
+| 20 | 12,681 | 4,303 | 34% |
+
+Batch not only falls further behind as thread count rises, it gets *slower* in absolute terms past
+8 threads.
+
+## Second pass: quantifying read time directly
+
+Temporary instrumentation (since reverted) timed every `PreloadIons()` call in the fused batch
+path's single-threaded producer loop:
+
+| Threads | Total wall time | Cumulative raw-read time | Read % of wall time |
+|---|---|---|---|
+| 1 | 54s | 8.2s | 15% |
+| 8 | 11s | 8.55s | 78% |
+| 20 | 13s | 11.59s | 89% |
+
+At 8+ threads, raw-file read/parse -- a single-threaded operation in the fused batch path (see
+`docs/20260723_ExtendFusedBatchPath.md`'s producer/consumer design) -- is nearly the entire
+measured wall time, and that read time itself grows with thread count (8.55s -> 11.59s, +35% from
+8 to 20 threads) due to `BoundedSpectrumQueue` mutex contention from more idle/blocking consumers.
+RTS's own reported Hz explicitly excludes an equivalent preload phase
+(`SearchMS1MS2.cs` reads all spectra into memory first; only the subsequent search loop is timed --
+see the `preload_s`/`search_s` columns in `run2.out/results/index.html`), so the two Hz numbers were
+never measuring the same thing.
+
+## Third pass: a real preload-then-search-only implementation
+
+To get a number genuinely comparable to RTS's methodology (not just an estimate from subtracting
+read time, which is unreliable here since the producer and consumers run concurrently and most
+search work happens *during* the read window, not after it), implemented a real preload-then-search
+path for the fused batch pipeline.
+
+### Design
+
+- **`CometMassSpecUtils::GetCurrentWorkingSetKB()`** (`CometMassSpecUtils.h`/`.cpp`, new) -- current
+  (not peak) resident memory, for before/after deltas. `GetPeakMemory()` (used elsewhere in this
+  codebase) is a monotonic process-lifetime high-water mark and can't isolate one phase's cost.
+- **`CometPreprocess::ApplySpectrumFilters()`** (`CometPreprocess.h`/`.cpp`) -- the `clearMzRange`/
+  `iMinPeaks`/activation-method filter logic, factored out of `FilterAndEnqueueSpectrum` (which now
+  calls it) into its own method so the new preload path's read loop can reuse it without a second,
+  hand-duplicated copy -- same rationale as every other shared-logic extraction in this
+  investigation series.
+- **`CometPreprocess::FusedPreloadThenSearch()`** (`CometPreprocess.cpp`, new) -- diagnostic-only,
+  same signature as `FusedLoadAndSearchSpectra`. Two phases, each separately timed and
+  memory-snapshotted:
+  1. **Preload**: the same single-threaded read loop as the normal fused path (same
+     `PreloadIons`/`ApplySpectrumFilters` calls, same scan-range logic), but appending into a
+     `std::vector<Spectrum>` instead of pushing into `BoundedSpectrumQueue` -- and with no
+     `FUSED_FLUSH_MIN_BATCH_SIZE` flush cap, since the whole point is one uninterrupted preload of
+     the entire remaining range.
+  2. **Search**: the preloaded vector is dispatched across `iNumThreads` workers via a plain
+     `std::atomic<size_t>` work-stealing index (`fetch_add`) instead of the queue -- each worker
+     calls the same `FusedSearchSpectrum()` used by the normal path, with the same per-slot arenas
+     (`sparseArenas`/`resultsArenas`/`pointerArenas`).
+- **Opt-in via `COMET_PRELOAD_BENCHMARK` environment variable**, checked in
+  `FiStrategy::executeBatch` / `PiStrategy::executeBatch`: unset (default) runs the normal path,
+  completely unchanged; set, runs `FusedPreloadThenSearch` instead and prints
+  `[PRELOAD]`/`[SEARCH]` lines with per-phase spectra/time/Hz/memory. (From WSL, invoking the
+  Windows binary needs `WSLENV=COMET_PRELOAD_BENCHMARK` alongside setting the variable itself, or
+  it won't cross the interop boundary into the Windows process.)
+
+### Correctness validation
+
+- Full Linux unit suite (T1-T20, 19/19) passes with the default (non-preload) path, confirming the
+  `ApplySpectrumFilters` refactor didn't change default behavior.
+- Byte-identical output diff: same FI_DB search (scan range 1-20000 on `20240924_Hela_01.raw`) run
+  with `COMET_PRELOAD_BENCHMARK` unset and set. Every PSM data row identical; only the output
+  file's embedded `-N` basename text differed.
+
+## Results
+
+Full file (63,488 MS2 spectra), `FUSED_FLUSH_MIN_BATCH_SIZE` at its shipped default (1,000; note
+this path ignores it anyway since it never flushes mid-run):
+
+| Threads | RTS search-only (Hz) | Batch preload search-only (Hz) | Batch / RTS | Preload time | Preload memory | Search memory | Total peak |
+|---|---|---|---|---|---|---|---|
+| 1 | 1,356 | 1,141 | 84% | 6.29s (10,112 Hz) | +1.34GB | +16.26GB | 36.5GB |
+| 2 | 2,651 | 2,188 | 83% | 6.01s (10,577 Hz) | +1.34GB | +16.30GB | 36.5GB |
+| 4 | 5,209 | 4,214 | 81% | 6.00s (10,594 Hz) | +1.34GB | +16.36GB | 36.6GB |
+| 8 | 8,991 | 5,652 | 63% | 5.87s (10,824 Hz) | +1.34GB | +16.48GB | 36.7GB |
+| 20 | 12,681 | 6,387 | 50% | 5.89s (10,796 Hz) | +1.35GB | +16.89GB | 37.3GB |
+
+**The hypothesis is confirmed at low-to-moderate thread counts.** Excluding read time closes most
+of the gap at 1-4 threads (81-84% of RTS's throughput, up from 76-85% -- comparable, since at those
+thread counts read was never the dominant cost in the first place per the second-pass table above)
+and dramatically improves the picture at 8-20 threads versus the original raw-Hz comparison (63%/50%
+of RTS here, vs. 61%/34% before) -- and unlike the original numbers, search-only Hz no longer
+*declines* from 8 to 20 threads. Preload itself is fast and cheap: ~6s and ~1.3-1.4GB regardless of
+thread count, for the entire file's spectra.
+
+**But a real gap remains at 8-20 threads even with read fully excluded.** Batch's search-only
+throughput barely improves from 8 to 20 threads (5,652 -> 6,387 Hz, +13%) while RTS keeps climbing
+strongly over the same range (8,991 -> 12,681 Hz, +41%). Both now use a comparable low-overhead
+work-distribution mechanism (batch: atomic work-stealing index; RTS: lock-free
+`ConcurrentQueue<int>`), so simple dispatch overhead is an unlikely explanation. The RTS benchmark's
+own writeup flags a candidate mechanism for exactly this kind of scaling-past-8-threads pattern:
+the fragment-ion index scan reads a large (3.7-billion-entry), shared, read-only structure with
+almost no compute per match, making it inherently more exposed to memory-bandwidth contention across
+this CPU's P-cores/E-cores than a more compute-heavy workload would be -- consistent with both RTS
+and batch sharing the same underlying `SearchFragmentIndex()` call and hitting a similar
+architecture-level ceiling once thread count is high enough, independent of which harness is driving
+it. This was not directly measured here and would need its own investigation (e.g. hardware
+performance counters for memory bandwidth/cache-miss rate) to confirm rather than infer.
+
+**Memory, first look: preloading every spectrum for the file costs relatively little** (~1.3-1.4GB
+for 63,563 spectra) -- `Spectrum` objects are lightweight (centroided peaks + metadata). Holding
+*every search result* in memory simultaneously (no flush cap, by design of this benchmark) costs far
+more: +16.3-16.9GB, ~12x the preload cost, consistent with Phase 1/2's own finding that per-spectrum
+`Query` result objects (not the raw spectra) are the dominant per-spectrum memory cost. Total peak
+(36.5-37.3GB) is correspondingly far above the normal streaming path's ~20-22GB for the same file,
+and grows only modestly with thread count (+2% from 1 to 20 threads) -- unlike the original
+`FUSED_FLUSH_MIN_BATCH_SIZE` investigation's batch-size-dependent growth, here every configuration
+holds the same total result set, just distributed across a different number of worker threads.
+
+**This first look was confounded by file size -- see the Follow-up section below for the corrected,
+apples-to-apples number.** The 63,488-spectrum file used throughout this document is a different,
+much smaller file than the 326,696-spectrum file `docs/20260723_ExtendFusedBatchPath.md`'s 35.8GB
+streaming number came from. Comparing the two directly (36.7GB vs. 35.8GB, "not much different") was
+a mistake made in a follow-up conversation about this document and is corrected next.
+
+## Follow-up: same-file comparison and a real memory-pressure finding
+
+A natural follow-up question: `docs/20260723_ExtendFusedBatchPath.md` reports 35.8GB as Comet's own
+peak memory for the streaming path (`FUSED_FLUSH_MIN_BATCH_SIZE=1,000`) on
+`20250903_Hela_Ast_Neo_02.raw` (326,696 spectra) -- not far from this document's 36.7GB for
+preload-everything at 8 threads. Does that mean holding tens of thousands of extra spectra and
+results costs very little?
+
+**No -- that comparison is invalid.** The 36.7GB figure above is from a *different, much smaller*
+file (`20240924_Hela_01.raw`, 63,488 spectra -- 5.1x fewer than the 326,696-spectrum file the 35.8GB
+figure came from). Re-running `FusedPreloadThenSearch` against the *same* 326,696-spectrum file,
+same 8 threads, same params as the 35.8GB streaming baseline gives the real, apples-to-apples
+answer:
+
+```
+[PRELOAD] 326696 spectra in 95.450s (3422.7 Hz) -- memory 18.93GB -> 37.42GB (+18.50GB)
+[SEARCH]  326696 spectra in 246.262s (1326.6 Hz) -- memory 37.42GB -> 4.31GB (-33.11GB)
+- done. (7m:54s, 48.0GB)
+```
+
+**Comet's own reported peak: 48.0GB vs. streaming's 35.8GB -- a real +12.2GB, 34% increase**, not
+"not much different." Preloading everything does *not* come cheap at realistic file sizes; the
+earlier-looking similarity was purely an artifact of testing on a 5x-smaller file.
+
+**A second finding, caught by this run: the `[SEARCH]` line's memory reads as a large *decrease*
+(37.42GB -> 4.31GB), which is not something `FusedPreloadThenSearch`'s own logic can produce** (it
+only ever accumulates `Query` objects during the search phase; nothing frees memory until the
+function returns). The only explanation is that the OS trimmed this process's working set under real
+memory pressure at some point during the search phase -- unsurprising, since Comet's own peak (48.0GB)
+was competing against everything else running on a 63.5GB-RAM machine. `GetCurrentWorkingSetKB()` is
+a point-in-time snapshot, not a monotonic counter, so a decrease across two snapshots is a real,
+legitimate possibility, not a bug in the measurement approach itself -- but the original `printf`
+computed the delta as an unsigned (`size_t`) subtraction, which silently underflowed on this negative
+delta into a nonsensical `+17592186044382.88GB`. Fixed by switching both `[PRELOAD]` and `[SEARCH]`
+delta calculations to a signed `double` subtraction (`CometPreprocess.cpp`).
+
+Two practical consequences:
+1. **The large-file search-only Hz (1,326.6) should not be trusted as a clean measurement** -- it was
+   very likely degraded by the paging/working-set-trim event, not a pure reflection of search
+   throughput. The 63,488-spectrum results table above, which showed no such signature, is the more
+   reliable read on search-only scaling.
+2. **This is itself a finding, not just a measurement artifact to route around**: preload-everything
+   on a realistically large file pushed this specific machine into genuine memory pressure. That is
+   exactly the kind of risk `docs/20260723_ExtendFusedBatchPath.md` flagged as a reason to treat large
+   `FUSED_FLUSH_MIN_BATCH_SIZE` values with OOM caution -- preload-everything is the extreme end of
+   that same spectrum, and this run shows the caution was warranted.
+
+## What this does and doesn't settle
+
+- **Settled**: batch's Hz looking so much lower than RTS's was substantially a measurement artifact
+  at low-to-moderate thread counts -- RTS's number excludes preload time, batch's didn't. The
+  underlying search implementation is not the primary story there.
+- **Settled**: a second, independent problem exists in the fused batch path specifically at 8+
+  threads -- read time itself grows with thread count due to `BoundedSpectrumQueue` contention
+  (second-pass table above), which the preload-then-search design sidesteps entirely by not using
+  that queue at all.
+- **Not settled**: why search-only throughput itself (read fully excluded) still scales much worse
+  for batch than RTS past 8 threads. The memory-bandwidth-contention hypothesis is plausible and
+  consistent with what RTS's own writeup already flags, but unconfirmed here.
+- **Settled (Follow-up section)**: preloading every spectrum is cheap; holding every search result
+  until the end is not. On the same 326,696-spectrum file used for the streaming baseline,
+  preload-everything's real peak memory is 48.0GB vs. streaming's 35.8GB (+34%), and the run showed
+  direct evidence of OS-level memory pressure (a working-set trim event) on a 63.5GB-RAM machine.
+  `FUSED_FLUSH_MIN_BATCH_SIZE`'s streaming design stays flat regardless of file size (35.8GB whether
+  the file has 63K or 326K spectra); preload-everything's memory cost scales with file size instead,
+  with no throughput benefit large enough to justify that trade-off in production.
+
+## Status of `FusedPreloadThenSearch`
+
+Implemented as an opt-in diagnostic (`COMET_PRELOAD_BENCHMARK`), not the default search path, and
+not proposed as a replacement for the normal fused streaming path -- it deliberately has no flush
+cap and therefore no bound on peak memory for a large file, which is the opposite trade-off from
+everything else in this investigation series, and the Follow-up section above shows that trade-off is
+a real one, not just theoretical. Kept in the codebase as a reusable tool for future "is this a
+read-path problem or a search problem" questions, following the same precedent as `RTS_TIMING` (see
+`docs/20260714_rtspostprocessing.md`) -- a documented, code-reviewed, opt-in-only instrumentation
+flag rather than a one-off deleted after use, not a recommendation to run it against production-scale
+files without the same OOM caution `docs/20260723_ExtendFusedBatchPath.md` already recommends for
+large `FUSED_FLUSH_MIN_BATCH_SIZE` values.

--- a/tests/rts_repro/rts_repro.cpp
+++ b/tests/rts_repro/rts_repro.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/unit/MiniTest.h
+++ b/tests/unit/MiniTest.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/unit/TestCometSearchAndPreprocess.cpp
+++ b/tests/unit/TestCometSearchAndPreprocess.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Jimmy Eng
+// Copyright 2012-2026 Jimmy Eng
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Two related bodies of work on the fused FI_DB/PI_DB batch search path:

1. **Memory/performance**: root-caused and fixed a regression where raising `FUSED_FLUSH_MIN_BATCH_SIZE` made batch search both slower and more memory-hungry, by extending the RTS thread-local pooling pattern to the batch path's per-spectrum allocations.
2. **Correctness**: root-caused a series of bugs causing FI_DB batch and RTS searches to return different results on the same data, culminating in a peak-selection bug in RTS's preprocessing that was silently degrading candidate coverage on every real-time FI_DB search.

## Memory/performance work

- Pool the fused batch path's per-spectrum sparse XCorr matrix child blocks (Phase 1) and the outer sparse pointer arrays / `_pResults`/`_pDecoys` (Phase 2), via new `FusedSparseArena`/`FusedResultsArena`/`FusedPointerArena` bump allocators (see `docs/20260723_ExtendFusedBatchPath.md` for full design and measurements).
- Set `FUSED_FLUSH_MIN_BATCH_SIZE = 1000` (previously 5000), the empirically best value found after sweeping 100–20000.
- Add an opt-in `COMET_PRELOAD_BENCHMARK` diagnostic mode that preloads all spectra before searching, reproducing RTS's own benchmarking methodology for apples-to-apples throughput comparisons (`docs/20260724_PreloadBenchmark.md`). Zero effect on the default code path.
- Fix a `std::max` / Windows `max` macro collision in `FusedSparseArena.h` that broke non-`NOMINMAX` builds (`tests/unit/CometUnitTests.vcxproj`).

## Correctness fixes (FI_DB batch vs. RTS divergence)

Found while comparing FI_DB batch search against FI RTS search on identical input (`20170103_Hela_01.raw` / `human.canonical.target-decoy.fasta`). Each fix was independently verified against the full T1–T20 suite and a real 40k-spectrum search; cumulative effect on scans with a different top hit between batch and RTS: **2,824 → 30** (99% reduction), and the identified-scan sets became exactly identical (previously 5 batch-only / 39 RTS-only).

- **`StorePeptideI` order-dependent eviction** (FI_DB/PI_DB): the candidate-retention slot eviction check compared against a stale, score-only cached index instead of a fresh, tie-break-aware recompute (already fixed for FASTA_DB in `StorePeptide`), making which of 3+ exactly-tied candidates survived depend on arrival order.
- **Invalid comparator in AScorePro's site-scoring sort**: `PeptideScoreComparer` wasn't a valid strict-weak-ordering (violated asymmetry on equal peptides, provided no real tie-break for distinct equal-scoring ones), making ambiguous phosphosite localization depend on peptide-generator enumeration order.
- **Redundant re-sort hazard in `AnalyzeSP`**: sorted by xcorr, fully re-sorted by a different comparator (SP score) to assign ranks, then sorted back — a hazard given `isEqual()`'s non-transitive epsilon tolerance. Ranks are now assigned via a side index array so the array is only ever sorted by xcorr once, matching RTS's single-pass structure.
- **Float/double precision mismatch in the FI_DB pre-filter gate**: compared a full-precision double against a value round-tripped through float, silently dropping ~50% of legitimately tied candidates before they ever reached storage.
- **RTS FI_DB peak selection (the dominant cause)**: RTS's single-spectrum preprocessing selected the top-150 fragment peaks for candidate matching by reverse-iterating the raw input arrays (native mass-ascending order) instead of sorting by intensity first, unlike the batch path's `LoadIons()`. This silently selected the 150 *highest-mass* peaks instead of the 150 *highest-intensity* ones on any spectrum with >150 qualifying peaks — a real, independent correctness bug affecting candidate coverage on every RTS FI_DB search, not just this comparison.

## Test plan

- [x] Full `tests/unit/run_tests.py --integration` (T1–T20, 21/21) after each individual commit
- [x] Windows Release full-solution build (`Comet.exe`, `CometWrapper.dll`, `RealtimeSearch.exe`, `CometUnitTests.exe`) after each commit
- [x] Real 40k-spectrum FI_DB batch vs. RTS comparison re-run after each correctness fix to measure incremental impact
- [x] `docs/20260723_ExtendFusedBatchPath.md` / `docs/20260724_PreloadBenchmark.md` contain before/after memory and throughput tables for the pooling work