### PR TITLE
 Fix FI compacted variable-mod-slot index bugs

### DIFF
--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -14,6 +14,7 @@
 
 
 #include "CometFragmentIndex.h"
+#include "CometPeptideIndex.h"
 #include "CometSearch.h"
 #include "ThreadPool.h"
 #include "CometStatus.h"
@@ -271,6 +272,14 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
 {
    size_t iWhichFragmentPeptide = 0;  // unused here for counting only
 
+   // mods[]/MOD_NUMBERS[].modifications[] values are 0-based COMPACTED variable-mod-slot
+   // indices requiring translation through this compacted-to-real-slot map before use as a
+   // varModList index or an siVarModProteinFilter bit position (both real-slot-indexed) --
+   // see AddFragments()'s own copy of this note for the full explanation. Fetched once here,
+   // used below at the protein-mod-filter check (the one place in this function that still
+   // needs it -- ctNtermMod/ctCtermMod elsewhere in this function are already raw slots).
+   const vector<int>& vModSlotForAllModsIdx = CometPeptideIndex::GetVModSlotForAllModsIdx();
+
    // each thread will loop through a subset of the g_vRawPeptides
    for (size_t iWhichPeptide = 0; iWhichPeptide < g_vRawPeptides.size(); ++iWhichPeptide)
    {
@@ -346,10 +355,21 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
             {
                char* mods = MOD_NUMBERS.at(modNumIdx).modifications;
 
+               // Bugfix: two bugs, both present until now -- (1) missing the "mods[i] != -1"
+               // guard other consumers of this same array use (CometPeptideIndex.cpp's
+               // equivalent check has always had it) -- mods[i] == -1 means "not modified at
+               // this candidate position in this specific combination", and cometbitcheck()'s
+               // `1 << nbit` is undefined behavior for a negative nbit; (2) mods[i] is a
+               // compacted index requiring translation through vModSlotForAllModsIdx before
+               // use as an siVarModProteinFilter bit position (real-slot-indexed, matching
+               // this same function's ctNtermMod/ctCtermMod checks above) -- matches
+               // CometPeptideIndex.cpp's already-correct equivalent exactly.
                for (int i = 0; i < MOD_NUMBERS.at(modNumIdx).modStringLen; ++i)
                {
                   // if mods[i] is not set to 1 in siVarModProteinFilter, do not apply this mod
-                  if (!cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, mods[i]))
+                  if (mods[i] != -1
+                     && !cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter,
+                                        vModSlotForAllModsIdx.at((size_t)mods[i])))
                   {
                      bPass = false;
                      break;
@@ -421,6 +441,13 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
    int modSeqIdx = -1;
    string modSeq;
 
+   // mods[] (MOD_NUMBERS[modNumIdx].modifications[]) values are 0-based indices into this
+   // COMPACTED active-variable-mod-slot list, not raw varModList indices -- see
+   // CometPeptideIndex::GetVModSlotForAllModsIdx()'s own doc comment, and its
+   // MaterializeOneEntry() (the PI_DB-mode equivalent of this function), which already
+   // performs this same translation correctly. Fetched once here for both loops below.
+   const vector<int>& vModSlotForAllModsIdx = CometPeptideIndex::GetVModSlotForAllModsIdx();
+
    if (modNumIdx >= 0)  // set modified peptide info
    {
       modNum = MOD_NUMBERS.at(modNumIdx);
@@ -461,7 +488,14 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
          {
             if (mods[j] != -1)
             {
-               dCalcPepMass += g_staticParams.variableModParameters.varModList[(int)mods[j]].dVarModMass;
+               // Bugfix: mods[j] is a compacted index (see the note above this function's
+               // declaration) -- using it directly as a varModList index only coincided with
+               // the real slot when every active variable_modNN among the first
+               // FRAGINDEX_VMODS is contiguous from slot 0; a config with a gap (e.g.
+               // variable_mod01 unused, variable_mod02 set) silently added the WRONG mod's
+               // mass to this peptide's precursor mass.
+               int iSlot = vModSlotForAllModsIdx[(size_t)mods[j]];
+               dCalcPepMass += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
             }
             j++;
          }
@@ -578,13 +612,22 @@ if (!(iWhichPeptide%1000))
       {
          if (sPeptide[i] == modSeq[j])
          {
-            dBion += g_staticParams.variableModParameters.varModList[mods[j] - 1].dVarModMass;
+            // Bugfix: mods[j] is a compacted index (see the note above this function's
+            // declaration), not a raw varModList index -- the previous
+            // "varModList[mods[j] - 1]" read varModList[-1] (undefined behavior --
+            // empirically dVarModMass=0.0 observed) whenever the first configured
+            // variable-mod type applied, silently computing modified b/y ion fragment masses
+            // as if unmodified. For configs with more than one active mod type and a gap
+            // (e.g. variable_mod01 unused, variable_mod02 set), the equivalent bug (using the
+            // compacted index directly rather than the real slot) applied the wrong mod's
+            // mass instead of crashing.
+            dBion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[j]]].dVarModMass;
             j++;
          }
 
          if (sPeptide[iPosReverse] == modSeq[k])
          {
-            dYion += g_staticParams.variableModParameters.varModList[mods[k] - 1].dVarModMass;
+            dYion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[k]]].dVarModMass;  // see bugfix note above
             k--;
          }
       }

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -236,10 +236,13 @@ void CometFragmentIndex::GenerateFragmentIndex(ThreadPool *tp)
    // now populate the fragment index vector
    tStartTime = chrono::steady_clock::now();
    cout <<  "   - populate index ... "; fflush(stdout);
+   // Fetched once for this whole fill pass rather than once per AddFragments() call below (a
+   // hot loop over every fragment-peptide variant, potentially millions of calls).
+   const vector<int>& vModSlotForAllModsIdx = CometPeptideIndex::GetVModSlotForAllModsIdx();
    for (size_t iWhichFragmentPeptide = 0; iWhichFragmentPeptide < g_vFragmentPeptides.size(); ++iWhichFragmentPeptide)
    {
       auto& fp = g_vFragmentPeptides[iWhichFragmentPeptide];
-      AddFragments(g_vRawPeptides, fp.iWhichPeptide, iWhichFragmentPeptide, fp.modNumIdx, fp.cNtermMod, fp.cCtermMod, 0);
+      AddFragments(g_vRawPeptides, fp.iWhichPeptide, iWhichFragmentPeptide, fp.modNumIdx, fp.cNtermMod, fp.cCtermMod, 0, vModSlotForAllModsIdx);
    }
    pFragmentIndexPool->wait_on_threads();
    cout << CometMassSpecUtils::ElapsedTime(tStartTime) << endl;
@@ -285,7 +288,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
    {
       // AddFragments for unmodified peptide; only if no variable mods are required
       if (!g_staticParams.variableModParameters.iRequireVarMod)
-         AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, -1, -1, bCountOnly);
+         AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, -1, -1, bCountOnly, vModSlotForAllModsIdx);
 
       // FIX: need to see if individual required varmods are met
       int modSeqIdx = PEPTIDE_MOD_SEQ_IDXS[iWhichPeptide];
@@ -300,7 +303,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                && (!g_staticParams.variableModParameters.bVarModProteinFilter
                   || cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctNtermMod)))
             {
-               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, ctNtermMod, -1, bCountOnly);
+               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, ctNtermMod, -1, bCountOnly, vModSlotForAllModsIdx);
             }
          }
 
@@ -311,7 +314,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                && (!g_staticParams.variableModParameters.bVarModProteinFilter
                   || cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctCtermMod)))
             {
-               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, -1, ctCtermMod, bCountOnly);
+               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, -1, ctCtermMod, bCountOnly, vModSlotForAllModsIdx);
             }
          }
 
@@ -326,7 +329,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                      (cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctNtermMod)
                         && cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctCtermMod))))
                {
-                  AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, ctNtermMod, ctCtermMod, bCountOnly);
+                  AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, -1, ctNtermMod, ctCtermMod, bCountOnly, vModSlotForAllModsIdx);
                }
             }
          }
@@ -350,36 +353,21 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
          {
             bool bPass = true;
 
-            // if protein variable mod filter is applied, check mods[] against the peptides siVarModProteinFilter
+            // if protein variable mod filter is applied, check mods[] against the peptide's
+            // siVarModProteinFilter -- shared with CometPeptideIndex.cpp's EnumerateIndexPeptideMods(),
+            // which previously carried its own independent (and briefly inconsistent -- see
+            // CometPeptideIndex::PassesVarModProteinFilter()'s doc comment) copy of this exact check.
             if (g_staticParams.variableModParameters.bVarModProteinFilter)
             {
-               char* mods = MOD_NUMBERS.at(modNumIdx).modifications;
-
-               // Bugfix: two bugs, both present until now -- (1) missing the "mods[i] != -1"
-               // guard other consumers of this same array use (CometPeptideIndex.cpp's
-               // equivalent check has always had it) -- mods[i] == -1 means "not modified at
-               // this candidate position in this specific combination", and cometbitcheck()'s
-               // `1 << nbit` is undefined behavior for a negative nbit; (2) mods[i] is a
-               // compacted index requiring translation through vModSlotForAllModsIdx before
-               // use as an siVarModProteinFilter bit position (real-slot-indexed, matching
-               // this same function's ctNtermMod/ctCtermMod checks above) -- matches
-               // CometPeptideIndex.cpp's already-correct equivalent exactly.
-               for (int i = 0; i < MOD_NUMBERS.at(modNumIdx).modStringLen; ++i)
-               {
-                  // if mods[i] is not set to 1 in siVarModProteinFilter, do not apply this mod
-                  if (mods[i] != -1
-                     && !cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter,
-                                        vModSlotForAllModsIdx.at((size_t)mods[i])))
-                  {
-                     bPass = false;
-                     break;
-                  }
-               }
+               const ModificationNumber& modNum = MOD_NUMBERS.at(modNumIdx);
+               bPass = CometPeptideIndex::PassesVarModProteinFilter(vModSlotForAllModsIdx,
+                  modNum.modifications, modNum.modStringLen,
+                  g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter);
             }
 
             if (bPass)
             {
-               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, -1, -1, bCountOnly);
+               AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, -1, -1, bCountOnly, vModSlotForAllModsIdx);
 
                if (g_staticParams.variableModParameters.bVarTermModSearch)
                {
@@ -389,7 +377,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                      if (g_staticParams.variableModParameters.varModList[(int)ctNtermMod].bNtermMod
                         && (!g_staticParams.variableModParameters.bVarModProteinFilter || cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctNtermMod)))
                      {
-                        AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, ctNtermMod, -1, bCountOnly);
+                        AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, ctNtermMod, -1, bCountOnly, vModSlotForAllModsIdx);
                      }
                   }
 
@@ -399,7 +387,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                      if (g_staticParams.variableModParameters.varModList[(int)ctCtermMod].bCtermMod
                         && (!g_staticParams.variableModParameters.bVarModProteinFilter || cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctCtermMod)))
                      {
-                        AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, -1, ctCtermMod, bCountOnly);
+                        AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, -1, ctCtermMod, bCountOnly, vModSlotForAllModsIdx);
                      }
                   }
 
@@ -414,7 +402,7 @@ void CometFragmentIndex::AddFragmentsThreadProc(bool bCountOnly,
                               (cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctNtermMod)
                                  && cometbitcheck(g_vRawPeptides.at(iWhichPeptide).siVarModProteinFilter, ctCtermMod))))
                         {
-                           AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, ctNtermMod, ctCtermMod, bCountOnly);
+                           AddFragments(g_vRawPeptides, iWhichPeptide, iWhichFragmentPeptide, modNumIdx, ctNtermMod, ctCtermMod, bCountOnly, vModSlotForAllModsIdx);
                         }
                      }
                   }
@@ -432,7 +420,8 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
                                       int modNumIdx,
                                       char cNtermMod,
                                       char cCtermMod,
-                                      bool bCountOnly)
+                                      bool bCountOnly,
+                                      const vector<int>& vModSlotForAllModsIdx)
 {
    string sPeptide = g_vRawPeptides.at(iWhichPeptide).szPeptide;
 
@@ -445,9 +434,9 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
    // COMPACTED active-variable-mod-slot list, not raw varModList indices -- see
    // CometPeptideIndex::GetVModSlotForAllModsIdx()'s own doc comment, and its
    // MaterializeOneEntry() (the PI_DB-mode equivalent of this function), which already
-   // performs this same translation correctly. Fetched once here for both loops below.
-   const vector<int>& vModSlotForAllModsIdx = CometPeptideIndex::GetVModSlotForAllModsIdx();
-
+   // performs this same translation correctly. Passed in by both callers (which fetch it once
+   // per thread/pass rather than this function re-fetching it on every one of the millions of
+   // per-peptide-variant calls in a full index build).
    if (modNumIdx >= 0)  // set modified peptide info
    {
       modNum = MOD_NUMBERS.at(modNumIdx);
@@ -486,17 +475,15 @@ void CometFragmentIndex::AddFragments(vector<PlainPeptideIndexStruct>& g_vRawPep
       {
          if (sPeptide[i] == modSeq[j])
          {
-            if (mods[j] != -1)
-            {
-               // Bugfix: mods[j] is a compacted index (see the note above this function's
-               // declaration) -- using it directly as a varModList index only coincided with
-               // the real slot when every active variable_modNN among the first
-               // FRAGINDEX_VMODS is contiguous from slot 0; a config with a gap (e.g.
-               // variable_mod01 unused, variable_mod02 set) silently added the WRONG mod's
-               // mass to this peptide's precursor mass.
-               int iSlot = vModSlotForAllModsIdx[(size_t)mods[j]];
+            // Bugfix: mods[j] is a compacted index (see the note above this function's
+            // declaration) -- using it directly as a varModList index only coincided with
+            // the real slot when every active variable_modNN among the first
+            // FRAGINDEX_VMODS is contiguous from slot 0; a config with a gap (e.g.
+            // variable_mod01 unused, variable_mod02 set) silently added the WRONG mod's
+            // mass to this peptide's precursor mass.
+            int iSlot = CometPeptideIndex::TranslateVarModSlot(vModSlotForAllModsIdx, mods[j]);
+            if (iSlot >= 0)
                dCalcPepMass += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
-            }
             j++;
          }
       }
@@ -626,17 +613,20 @@ if (!(iWhichPeptide%1000))
             // that isn't modified in this particular combination (CometModificationsPermuter::
             // combine() leaves it at its initialized -1) -- e.g. any peptide with more
             // modifiable sites than max_variable_mods_in_peptide allows. Casting -1 to size_t
-            // and indexing vModSlotForAllModsIdx with it read far outside the vector's buffer.
-            // Mirror the guard the precursor-mass loop above already uses.
-            if (mods[j] != -1)
-               dBion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[j]]].dVarModMass;
+            // and indexing vModSlotForAllModsIdx with it directly read far outside the
+            // vector's buffer; TranslateVarModSlot() now guards this uniformly everywhere.
+            int iSlot = CometPeptideIndex::TranslateVarModSlot(vModSlotForAllModsIdx, mods[j]);
+            if (iSlot >= 0)
+               dBion += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
             j++;
          }
 
          if (sPeptide[iPosReverse] == modSeq[k])
          {
-            if (mods[k] != -1)  // see bugfix note above
-               dYion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[k]]].dVarModMass;
+            // see bugfix note above
+            int iSlot = CometPeptideIndex::TranslateVarModSlot(vModSlotForAllModsIdx, mods[k]);
+            if (iSlot >= 0)
+               dYion += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
             k--;
          }
       }

--- a/CometSearch/CometFragmentIndex.cpp
+++ b/CometSearch/CometFragmentIndex.cpp
@@ -621,13 +621,22 @@ if (!(iWhichPeptide%1000))
             // (e.g. variable_mod01 unused, variable_mod02 set), the equivalent bug (using the
             // compacted index directly rather than the real slot) applied the wrong mod's
             // mass instead of crashing.
-            dBion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[j]]].dVarModMass;
+            //
+            // Bugfix: mods[j] == -1 is the normal case for a modifiable candidate residue
+            // that isn't modified in this particular combination (CometModificationsPermuter::
+            // combine() leaves it at its initialized -1) -- e.g. any peptide with more
+            // modifiable sites than max_variable_mods_in_peptide allows. Casting -1 to size_t
+            // and indexing vModSlotForAllModsIdx with it read far outside the vector's buffer.
+            // Mirror the guard the precursor-mass loop above already uses.
+            if (mods[j] != -1)
+               dBion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[j]]].dVarModMass;
             j++;
          }
 
          if (sPeptide[iPosReverse] == modSeq[k])
          {
-            dYion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[k]]].dVarModMass;  // see bugfix note above
+            if (mods[k] != -1)  // see bugfix note above
+               dYion += g_staticParams.variableModParameters.varModList[vModSlotForAllModsIdx[(size_t)mods[k]]].dVarModMass;
             k--;
          }
       }

--- a/CometSearch/CometFragmentIndex.h
+++ b/CometSearch/CometFragmentIndex.h
@@ -48,7 +48,8 @@ private:
                             int modNumIdx,
                             char cNtermMod,
                             char cCtermMod,
-                            bool bCountOnly);
+                            bool bCountOnly,
+                            const vector<int>& vModSlotForAllModsIdx);
    static void AddFragmentsThreadProc(bool bCountOnly,
                                       ThreadPool *tp);
 

--- a/CometSearch/CometPeptideIndex.cpp
+++ b/CometSearch/CometPeptideIndex.cpp
@@ -501,6 +501,27 @@ const vector<int>& CometPeptideIndex::GetVModSlotForAllModsIdx()
 }
 
 
+int CometPeptideIndex::TranslateVarModSlot(const vector<int>& vModSlotForAllModsIdx, int compactedIdx)
+{
+   if (compactedIdx < 0 || (size_t)compactedIdx >= vModSlotForAllModsIdx.size())
+      return -1;
+   return vModSlotForAllModsIdx[(size_t)compactedIdx];
+}
+
+
+bool CometPeptideIndex::PassesVarModProteinFilter(const vector<int>& vModSlotForAllModsIdx,
+   const char* mods, int modStringLen, unsigned short siVarModProteinFilter)
+{
+   for (int i = 0; i < modStringLen; ++i)
+   {
+      int iSlot = TranslateVarModSlot(vModSlotForAllModsIdx, mods[i]);
+      if (iSlot >= 0 && !cometbitcheck(siVarModProteinFilter, iSlot))
+         return false;
+   }
+   return true;
+}
+
+
 bool CometPeptideIndex::EnumerateIndexPeptideMods(vector<FragmentPeptidesStruct>& vVariants)
 {
    const vector<int>& vModSlotForAllModsIdx = GetVModSlotForAllModsIdx();
@@ -527,9 +548,9 @@ bool CometPeptideIndex::EnumerateIndexPeptideMods(vector<FragmentPeptidesStruct>
          {
             if (raw.szPeptide[i] == modSeq[j])
             {
-               if (mods[j] != -1)
+               int iSlot = TranslateVarModSlot(vModSlotForAllModsIdx, mods[j]);
+               if (iSlot >= 0)
                {
-                  int iSlot = vModSlotForAllModsIdx.at((size_t)mods[j]);
                   dCalcPepMass += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
                   ++cNumSites;
                }
@@ -629,16 +650,9 @@ bool CometPeptideIndex::EnumerateIndexPeptideMods(vector<FragmentPeptidesStruct>
 
          if (g_staticParams.variableModParameters.bVarModProteinFilter)
          {
-            char* mods = MOD_NUMBERS.at(modNumIdx).modifications;
-            for (int i = 0; i < MOD_NUMBERS.at(modNumIdx).modStringLen; ++i)
-            {
-               if (mods[i] != -1
-                  && !cometbitcheck(raw.siVarModProteinFilter, vModSlotForAllModsIdx.at((size_t)mods[i])))
-               {
-                  bPass = false;
-                  break;
-               }
-            }
+            const ModificationNumber& modNum = MOD_NUMBERS.at(modNumIdx);
+            bPass = PassesVarModProteinFilter(vModSlotForAllModsIdx, modNum.modifications,
+               modNum.modStringLen, raw.siVarModProteinFilter);
          }
 
          if (!bPass)
@@ -773,11 +787,15 @@ bool CometPeptideIndex::MaterializeOneEntry(size_t iWhichPeptide, int modNumIdx,
             // false-positive path.
             if (j >= modNum.modStringLen)
                return false;
-            if (mods[j] != -1)
+            // TranslateVarModSlot() returns -1 for both mods[j] == -1 (ordinary "not modified
+            // here") and mods[j] out of range (corrupt/mismatched .idx) -- the two are
+            // distinguished explicitly below because only the latter should reject this whole
+            // candidate; the former is normal and simply contributes no mass/site here.
+            int iSlot = TranslateVarModSlot(vModSlotForAllModsIdx, mods[j]);
+            if (mods[j] != -1 && iSlot < 0)
+               return false;
+            if (iSlot >= 0)
             {
-               if (mods[j] < 0 || (size_t)mods[j] >= vModSlotForAllModsIdx.size())
-                  return false;
-               int iSlot = vModSlotForAllModsIdx[(size_t)mods[j]];
                dCalcPepMass += g_staticParams.variableModParameters.varModList[iSlot].dVarModMass;
                if (!pcVarModSites.set(i, (char)(iSlot + 1)))
                   return false;

--- a/CometSearch/CometPeptideIndex.h
+++ b/CometSearch/CometPeptideIndex.h
@@ -88,6 +88,30 @@ public:
    // could silently violate.
    static const vector<int>& GetVModSlotForAllModsIdx();
 
+   // Translates a single compacted variable-mod-slot index (as read from
+   // MOD_NUMBERS[...].modifications[]) into the real varModList[] slot it refers to, via
+   // GetVModSlotForAllModsIdx()'s translation table above. Returns -1, uniformly, for both
+   // legitimate cases callers must treat as "no real slot here": compactedIdx == -1 (the
+   // ordinary "not modified at this candidate position in this combination" sentinel) and
+   // compactedIdx out of range for vModSlotForAllModsIdx (only reachable via a corrupt/
+   // mismatched on-disk .idx, or the compaction order here and in
+   // CometFragmentIndex::PermuteIndexPeptideMods()'s ALL_MODS-building loop falling out of
+   // sync -- a logic bug, not user input). A prior version of this codebase had five near-
+   // identical copies of this translate-or-skip logic hand-copied across CometPeptideIndex.cpp
+   // and CometFragmentIndex.cpp/CometSearch.cpp, each with a different guard/bounds-checking
+   // policy (guarded+.at(), guarded+unchecked[], unguarded+unchecked[]) -- that inconsistency
+   // is exactly how one copy shipped with its -1 guard missing entirely. Single shared,
+   // exception-free implementation now used everywhere instead.
+   static int TranslateVarModSlot(const vector<int>& vModSlotForAllModsIdx, int compactedIdx);
+
+   // Returns true if every candidate position actually modified in this combination (i.e.
+   // mods[i] != -1, for i in [0, modStringLen)) translates to a slot allowed by
+   // siVarModProteinFilter's bitmask -- the protein-level variable-mod restriction feature.
+   // Shared by PI_DB's EnumerateIndexPeptideMods() and FI_DB's AddFragmentsThreadProc(), which
+   // previously carried two independently-maintained copies of this exact check.
+   static bool PassesVarModProteinFilter(const vector<int>& vModSlotForAllModsIdx,
+      const char* mods, int modStringLen, unsigned short siVarModProteinFilter);
+
 };
 
 #endif // _COMETPEPTIDEINDEX_H_

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -1617,9 +1617,10 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
             {
                if (szPeptide[k] == modSeq[j])
                {
-                  if (mods[j] != -1)
+                  int iSlot = CometPeptideIndex::TranslateVarModSlot(vModSlotForAllModsIdx, mods[j]);
+                  if (iSlot >= 0)
                   {
-                     piVarModSites[k] = 1 + vModSlotForAllModsIdx[(size_t)mods[j]];
+                     piVarModSites[k] = 1 + iSlot;
                   }
                   j++;
                }

--- a/CometSearch/CometSearch.cpp
+++ b/CometSearch/CometSearch.cpp
@@ -1599,6 +1599,19 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
             modSeqIdx = PEPTIDE_MOD_SEQ_IDXS[iWhichPeptide];
             modSeq = MOD_SEQS.at(modSeqIdx);
 
+            // Bugfix: mods[j] (MOD_NUMBERS[modNumIdx].modifications[j]) is a 0-based
+            // COMPACTED variable-mod-slot index -- an index into
+            // CometPeptideIndex::GetVModSlotForAllModsIdx()'s compacted active-slot list --
+            // not a raw varModList index. "1 + mods[j]" only coincided with the "1 + realSlot"
+            // convention downstream code (XcorrScoreI(), further below in this file) expects
+            // when every active variable_modNN among the first FRAGINDEX_VMODS is contiguous
+            // from slot 0; a config with a gap (e.g. variable_mod01 unused, variable_mod02
+            // set) silently scored the WRONG modification's mass for every FI_DB search hit on
+            // that peptide (not just a display issue -- piVarModSites feeds directly into this
+            // function's own fragment-mass accumulation used for XCorr/SP scoring).
+            // CometPeptideIndex.cpp's MaterializeOneEntry() (the PI_DB-mode equivalent) already
+            // does this translation correctly; this mirrors it.
+            const vector<int>& vModSlotForAllModsIdx = CometPeptideIndex::GetVModSlotForAllModsIdx();
             int j = 0;
             for (int k = 0; k <= iEndPos; ++k)
             {
@@ -1606,7 +1619,7 @@ void CometSearch::SearchFragmentIndex(Query* pQuery,
                {
                   if (mods[j] != -1)
                   {
-                     piVarModSites[k] = 1 + (int)mods[j];
+                     piVarModSites[k] = 1 + vModSlotForAllModsIdx[(size_t)mods[j]];
                   }
                   j++;
                }

--- a/tests/unit/data/t25_fi_mod_slot_ambig.fasta
+++ b/tests/unit/data/t25_fi_mod_slot_ambig.fasta
@@ -1,0 +1,2 @@
+>sp|GAPTEST3|FI mod-slot-index gap-config multi-site ambiguous-mod regression test protein
+ACDSEFSHIK

--- a/tests/unit/data/t25_fi_mod_slot_ambig.ms2
+++ b/tests/unit/data/t25_fi_mod_slot_ambig.ms2
@@ -1,0 +1,27 @@
+H	CreationDate	synthetic
+H	Comment	FI_DB gap variable-mod-slot AMBIGUOUS-site regression fixture: peptide has TWO
+H	Comment	modifiable S residues (position 4 and position 7) but max_variable_mods_in_peptide=1,
+H	Comment	so index build enumerates both the "S4 modified / S7 unmodified" and "S4 unmodified /
+H	Comment	S7 modified" combinations. For whichever candidate site is NOT modified in a given
+H	Comment	combination, MOD_NUMBERS[].modifications[] is -1 for that site -- this fixture
+H	Comment	specifically regression-tests AddFragments()'s b/y-ion mass loop guarding that -1
+H	Comment	before translating it through vModSlotForAllModsIdx (the unguarded lookup previously
+H	Comment	read far out of the compacted-slot vector's bounds). Spectrum is ACDS[+79.966331]EFSHIK,
+H	Comment	charge 2+, phospho localized to S4 (S7 unmodified). 14 b/y ions (b3-b9, y3-y9),
+H	Comment	precomputed from monoisotopic residue masses, sorted ascending.
+S	1	1	608.738846
+Z	2	1216.470416
+290.080518	100.0
+397.255780	100.0
+457.078877	100.0
+484.287808	100.0
+586.121470	100.0
+631.356222	100.0
+733.189884	100.0
+760.398815	100.0
+820.221912	100.0
+927.397174	100.0
+957.280824	100.0
+1042.424117	100.0
+1070.364888	100.0
+1145.433302	100.0

--- a/tests/unit/data/t25_fi_mod_slot_gap.fasta
+++ b/tests/unit/data/t25_fi_mod_slot_gap.fasta
@@ -1,0 +1,2 @@
+>sp|GAPTEST|FI mod-slot-index gap-config regression test protein
+ACDSEFGHIK

--- a/tests/unit/data/t25_fi_mod_slot_gap.ms2
+++ b/tests/unit/data/t25_fi_mod_slot_gap.ms2
@@ -1,0 +1,25 @@
+H	CreationDate	synthetic
+H	Comment	FI_DB gap variable-mod-slot regression fixture: ACDS[+79.966331]EFGHIK, charge 2+
+H	Comment	Variable-mod GAP config on purpose: the real mod is configured in variable_mod02
+H	Comment	(slot 1), leaving variable_mod01 (slot 0) unused. Regression-tests
+H	Comment	CometFragmentIndex.cpp's AddFragments()/AddFragmentsThreadProc() correctly
+H	Comment	translating MOD_NUMBERS[].modifications[]'s compacted slot indices through
+H	Comment	CometPeptideIndex::GetVModSlotForAllModsIdx() before use as a varModList index.
+H	Comment	14 b/y ions, precomputed from monoisotopic residue masses. Phospho on S at
+H	Comment	position 4 (1-based).
+S	1	1	593.733554
+Z	2	1186.459832
+290.080516	100.0
+397.255771	100.0
+454.277231	100.0
+457.078877	100.0
+586.121467	100.0
+601.345641	100.0
+730.388231	100.0
+733.189877	100.0
+790.211337	100.0
+897.386592	100.0
+927.270247	100.0
+1012.413532	100.0
+1040.354307	100.0
+1115.422722	100.0

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -2127,6 +2127,96 @@ def test_t25_fi_mod_slot_gap(comet_exe):
     return failures
 
 
+@register("t25_fi_mod_slot_ambig")
+def test_t25_fi_mod_slot_ambig(comet_exe):
+    """T25: FI_DB gap variable-mod-slot regression with a genuinely AMBIGUOUS second
+    modifiable site (peptide has 2 candidate S residues, max_variable_mods_in_peptide=1).
+    Unlike t25_fi_mod_slot_gap (only 1 modifiable residue -- MOD_NUMBERS[].modifications[]
+    is never -1 there), this fixture forces AddFragments() to enumerate a combination
+    where the OTHER candidate site's compacted mod index is the -1 "not modified in this
+    combination" sentinel while translating a fragment mass through
+    vModSlotForAllModsIdx -- the specific unguarded array access that crashed/corrupted
+    memory before the fix. Regresses cleanly if the build+search complete and localize the
+    real mod to S4 (not S7)."""
+    failures = []
+
+    fasta = DATA_DIR / "t25_fi_mod_slot_ambig.fasta"
+    ms2   = DATA_DIR / "t25_fi_mod_slot_ambig.ms2"
+    idx   = fasta.with_suffix(".fasta.idx")
+    txt   = ms2.with_suffix(".txt")
+
+    use_win = _binary_uses_win_paths(comet_exe)
+    fmt = _to_win if use_win else str
+
+    if idx.exists():
+        idx.unlink()
+
+    build_params = T25_PARAMS_TEMPLATE.format(
+        comet_version="2026.02 rev. 0", database=fmt(fasta))
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".params", dir=str(DATA_DIR), delete=False
+    ) as pf:
+        pf.write(build_params)
+        build_params_file = Path(pf.name)
+    try:
+        rc, out = _run_t19_step(comet_exe, ["-i", f"-P{fmt(build_params_file)}"])
+        if rc != 0 or not idx.exists():
+            failures.append(f"index build failed (rc={rc}) -- the unguarded "
+                             f"vModSlotForAllModsIdx[(size_t)mods[j]] access on a -1 "
+                             f"sentinel likely crashed or hung the build:\n{out}")
+            return failures
+    finally:
+        build_params_file.unlink(missing_ok=True)
+
+    if txt.exists():
+        txt.unlink()
+
+    search_params = T25_PARAMS_TEMPLATE.format(
+        comet_version="2026.02 rev. 0", database=fmt(idx))
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".params", dir=str(DATA_DIR), delete=False
+    ) as pf:
+        pf.write(search_params)
+        search_params_file = Path(pf.name)
+
+    try:
+        rc, out = _run_t19_step(comet_exe, [f"-P{fmt(search_params_file)}", fmt(ms2)])
+        if rc != 0:
+            failures.append(f"search failed (rc={rc}):\n{out}")
+            return failures
+        if not txt.exists():
+            failures.append(f".txt not created (peptide not found). Comet output:\n{out}")
+            return failures
+
+        lines  = txt.read_text().splitlines()
+        rows   = [l.split("\t") for l in lines[2:] if l.strip()]
+
+        check(len(rows) == 1, f"expected exactly 1 PSM row, got {len(rows)}", failures)
+        if not rows:
+            return failures
+
+        header = lines[1].split("\t")
+        row = dict(zip(header, rows[0]))
+
+        check(row.get("plain_peptide") == "ACDSEFSHIK",
+              f"plain_peptide: expected ACDSEFSHIK, got {row.get('plain_peptide')!r}", failures)
+        check("4_V_79.966331" in row.get("modifications", ""),
+              f"modifications: expected phospho localized to position 4 (4_V_79.966331), "
+              f"got {row.get('modifications')!r}", failures)
+        check("7_V_79.966331" not in row.get("modifications", ""),
+              f"modifications: unexpectedly localized to position 7 as well/instead, "
+              f"got {row.get('modifications')!r}", failures)
+        check(int(row.get("ions_matched", "0")) == 14,
+              f"ions_matched: expected all 14 fragment ions matched, got "
+              f"{row.get('ions_matched')!r}", failures)
+    finally:
+        search_params_file.unlink(missing_ok=True)
+        idx.unlink(missing_ok=True)
+        txt.unlink(missing_ok=True)
+
+    return failures
+
+
 # ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -1947,102 +1947,21 @@ def test_t24_index_parity(comet_exe):
 # ACDS[+79.966331]EFGHIK (10 residues, phospho-S at position 4, charge 2+), spectrum built from
 # monoisotopic residue masses independently in Python, not read back from Comet's own output.
 
-T25_PARAMS_TEMPLATE = textwrap.dedent("""\
-# comet_version {comet_version}
-database_name = {database}
-decoy_search = 0
-num_threads = 4
-peptide_mass_tolerance_upper = 20.0
-peptide_mass_tolerance_lower = -20.0
-peptide_mass_units = 2
-precursor_tolerance_type = 1
-isotope_error = 0
-search_enzyme_number = 0
-search_enzyme2_number = 0
-sample_enzyme_number = 0
-num_enzyme_termini = 2
-allowed_missed_cleavage = 0
-variable_mod01 = 0.0 X 0 3 -1 0 0 0.0
-variable_mod02 = 79.966331 S 0 1 -1 0 0 0.0
-variable_mod03 = 0.0 X 0 3 -1 0 0 0.0
-variable_mod04 = 0.0 X 0 3 -1 0 0 0.0
-variable_mod05 = 0.0 X 0 3 -1 0 0 0.0
-max_variable_mods_in_peptide = 1
-require_variable_mod = 0
-fragment_bin_tol = 0.02
-fragment_bin_offset = 0.0
-theoretical_fragment_ions = 0
-use_A_ions = 0
-use_B_ions = 1
-use_C_ions = 0
-use_X_ions = 0
-use_Y_ions = 1
-use_Z_ions = 0
-use_Z1_ions = 0
-use_NL_ions = 0
-output_sqtfile = 0
-output_txtfile = 1
-output_pepxmlfile = 0
-output_mzidentmlfile = 0
-output_percolatorfile = 0
-num_output_lines = 1
-scan_range = 0 0
-precursor_charge = 0 0
-override_charge = 0
-ms_level = 2
-activation_method = ALL
-digest_mass_range = 200.0 2000.0
-peptide_length_range = 10 10
-max_duplicate_proteins = -1
-max_fragment_charge = 3
-min_precursor_charge = 1
-max_precursor_charge = 6
-clip_nterm_methionine = 0
-spectrum_batch_size = 15000
-decoy_prefix = DECOY_
-equal_I_and_L = 0
-mass_offsets =
-minimum_peaks = 10
-minimum_intensity = 0
-remove_precursor_peak = 0
-remove_precursor_tolerance = 1.5
-clear_mz_range = 0.0 0.0
-percentage_base_peak = 0.0
-add_Cterm_peptide = 0.0
-add_Nterm_peptide = 0.0
-add_Cterm_protein = 0.0
-add_Nterm_protein = 0.0
-add_G_glycine = 0.0
-add_A_alanine = 0.0
-add_S_serine = 0.0
-add_P_proline = 0.0
-add_V_valine = 0.0
-add_T_threonine = 0.0
-add_C_cysteine = 0.0
-add_L_leucine = 0.0
-add_I_isoleucine = 0.0
-add_N_asparagine = 0.0
-add_D_aspartic_acid = 0.0
-add_Q_glutamine = 0.0
-add_K_lysine = 0.0
-add_E_glutamic_acid = 0.0
-add_M_methionine = 0.0
-add_H_histidine = 0.0
-add_F_phenylalanine = 0.0
-add_U_selenocysteine = 0.0
-add_R_arginine = 0.0
-add_Y_tyrosine = 0.0
-add_W_tryptophan = 0.0
-add_O_pyrrolysine = 0.0
-add_B_user_amino_acid = 0.0
-add_J_user_amino_acid = 0.0
-add_X_user_amino_acid = 0.0
-add_Z_user_amino_acid = 0.0
-[COMET_ENZYME_INFO]
-0.  Cut_everywhere         0      -           -
-1.  Trypsin                1      KR          P
-2.  Trypsin/P              1      KR          -
-""")
+# T25 reuses T19_PARAMS_TEMPLATE (byte-identical schema otherwise) instead of maintaining a
+# second ~95-line near-copy of it -- a code review of this branch flagged the duplicate as a
+# maintenance risk (any future change to the shared params schema, e.g. a new required key or
+# an enzyme table update, would need to be hand-applied to both). Three targeted differences
+# from T19's template: no print_ascorepro_score line (T25 doesn't exercise AScorePro), the gap
+# variable-mod config itself (T19's {mod1}/{ascorepro} placeholders aren't used here -- T25's
+# mod config is fixed: variable_mod01 unused, real mod in variable_mod02), and a longer
+# peptide_length_range (10 vs T19's 8) to fit the 10-residue ACDSEFxHIK-style test peptides.
+T25_PARAMS_TEMPLATE = (
+   T19_PARAMS_TEMPLATE
+   .replace("print_ascorepro_score = {ascorepro}\n", "")
+   .replace("variable_mod01 = {mod1}\nvariable_mod02 = 0.0 X 0 3 -1 0 0 0.0",
+            "variable_mod01 = 0.0 X 0 3 -1 0 0 0.0\nvariable_mod02 = 79.966331 S 0 1 -1 0 0 0.0")
+   .replace("peptide_length_range = 8 8", "peptide_length_range = 10 10")
+)
 
 
 @register("t25_fi_mod_slot_gap")

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -1963,6 +1963,22 @@ T25_PARAMS_TEMPLATE = (
    .replace("peptide_length_range = 8 8", "peptide_length_range = 10 10")
 )
 
+# Sanity-check the .replace() chain above actually fired -- if a future edit to
+# T19_PARAMS_TEMPLATE changes any of the three literal snippets being matched (whitespace,
+# reordering, a renamed key, ...), each .replace() silently becomes a no-op instead of raising,
+# and T25 would run against T19's unmodified/still-templated params instead of its intended gap
+# config. Fail loudly here rather than let that surface later as a confusing T25 assertion
+# failure (or, worse, a silent false pass).
+assert "{ascorepro}" not in T25_PARAMS_TEMPLATE, \
+    "T25_PARAMS_TEMPLATE: print_ascorepro_score replacement didn't fire -- T19_PARAMS_TEMPLATE changed?"
+assert "{mod1}" not in T25_PARAMS_TEMPLATE, \
+    "T25_PARAMS_TEMPLATE: variable_mod01/02 gap replacement didn't fire -- T19_PARAMS_TEMPLATE changed?"
+assert "variable_mod01 = 0.0 X 0 3 -1 0 0 0.0\nvariable_mod02 = 79.966331 S 0 1 -1 0 0 0.0" \
+    in T25_PARAMS_TEMPLATE, \
+    "T25_PARAMS_TEMPLATE: variable_mod01/02 gap replacement didn't fire -- T19_PARAMS_TEMPLATE changed?"
+assert "peptide_length_range = 10 10" in T25_PARAMS_TEMPLATE, \
+    "T25_PARAMS_TEMPLATE: peptide_length_range replacement didn't fire -- T19_PARAMS_TEMPLATE changed?"
+
 
 @register("t25_fi_mod_slot_gap")
 def test_t25_fi_mod_slot_gap(comet_exe):

--- a/tests/unit/run_tests.py
+++ b/tests/unit/run_tests.py
@@ -1925,6 +1925,209 @@ def test_t24_index_parity(comet_exe):
 
 
 # ---------------------------------------------------------------------------
+# T25 -- FI_DB variable-mod compacted-slot-index regression
+# ---------------------------------------------------------------------------
+#
+# CometFragmentIndex.cpp's AddFragments() (precursor-mass and fragment-ion-mass loops) and
+# AddFragmentsThreadProc() (protein-variable-mod-filter check) all read
+# MOD_NUMBERS[modNumIdx].modifications[] (aliased locally as "mods") and, until this fix, used
+# its values directly as raw varModList indices. Those values are actually 0-based indices into
+# a COMPACTED active-variable-mod-slot list (CometPeptideIndex::GetVModSlotForAllModsIdx()) --
+# they only coincide with the real varModList slot when every active variable_modNN among the
+# first FRAGINDEX_VMODS is contiguous starting at slot 0. A config with a gap (e.g.
+# variable_mod01 left unset while variable_mod02 carries the real modification) exposed this:
+# the precursor mass, the modified fragment-ion masses used for XCorr/SP scoring
+# (CometSearch.cpp's SearchFragmentIndex(), a separate, independent copy of the same
+# reconstruction logic), and the reported modification mass were all computed against the
+# wrong (unused, zero-mass) slot instead of the real one.
+#
+# This test deliberately configures the real mod in variable_mod02 (slot 1), leaving
+# variable_mod01 (slot 0) unused, so a regression here can't hide the way a slot-0 config
+# would (every mod in slot 0 trivially has compacted-index == real-slot-index == 0). Fixture:
+# ACDS[+79.966331]EFGHIK (10 residues, phospho-S at position 4, charge 2+), spectrum built from
+# monoisotopic residue masses independently in Python, not read back from Comet's own output.
+
+T25_PARAMS_TEMPLATE = textwrap.dedent("""\
+# comet_version {comet_version}
+database_name = {database}
+decoy_search = 0
+num_threads = 4
+peptide_mass_tolerance_upper = 20.0
+peptide_mass_tolerance_lower = -20.0
+peptide_mass_units = 2
+precursor_tolerance_type = 1
+isotope_error = 0
+search_enzyme_number = 0
+search_enzyme2_number = 0
+sample_enzyme_number = 0
+num_enzyme_termini = 2
+allowed_missed_cleavage = 0
+variable_mod01 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod02 = 79.966331 S 0 1 -1 0 0 0.0
+variable_mod03 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod04 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod05 = 0.0 X 0 3 -1 0 0 0.0
+max_variable_mods_in_peptide = 1
+require_variable_mod = 0
+fragment_bin_tol = 0.02
+fragment_bin_offset = 0.0
+theoretical_fragment_ions = 0
+use_A_ions = 0
+use_B_ions = 1
+use_C_ions = 0
+use_X_ions = 0
+use_Y_ions = 1
+use_Z_ions = 0
+use_Z1_ions = 0
+use_NL_ions = 0
+output_sqtfile = 0
+output_txtfile = 1
+output_pepxmlfile = 0
+output_mzidentmlfile = 0
+output_percolatorfile = 0
+num_output_lines = 1
+scan_range = 0 0
+precursor_charge = 0 0
+override_charge = 0
+ms_level = 2
+activation_method = ALL
+digest_mass_range = 200.0 2000.0
+peptide_length_range = 10 10
+max_duplicate_proteins = -1
+max_fragment_charge = 3
+min_precursor_charge = 1
+max_precursor_charge = 6
+clip_nterm_methionine = 0
+spectrum_batch_size = 15000
+decoy_prefix = DECOY_
+equal_I_and_L = 0
+mass_offsets =
+minimum_peaks = 10
+minimum_intensity = 0
+remove_precursor_peak = 0
+remove_precursor_tolerance = 1.5
+clear_mz_range = 0.0 0.0
+percentage_base_peak = 0.0
+add_Cterm_peptide = 0.0
+add_Nterm_peptide = 0.0
+add_Cterm_protein = 0.0
+add_Nterm_protein = 0.0
+add_G_glycine = 0.0
+add_A_alanine = 0.0
+add_S_serine = 0.0
+add_P_proline = 0.0
+add_V_valine = 0.0
+add_T_threonine = 0.0
+add_C_cysteine = 0.0
+add_L_leucine = 0.0
+add_I_isoleucine = 0.0
+add_N_asparagine = 0.0
+add_D_aspartic_acid = 0.0
+add_Q_glutamine = 0.0
+add_K_lysine = 0.0
+add_E_glutamic_acid = 0.0
+add_M_methionine = 0.0
+add_H_histidine = 0.0
+add_F_phenylalanine = 0.0
+add_U_selenocysteine = 0.0
+add_R_arginine = 0.0
+add_Y_tyrosine = 0.0
+add_W_tryptophan = 0.0
+add_O_pyrrolysine = 0.0
+add_B_user_amino_acid = 0.0
+add_J_user_amino_acid = 0.0
+add_X_user_amino_acid = 0.0
+add_Z_user_amino_acid = 0.0
+[COMET_ENZYME_INFO]
+0.  Cut_everywhere         0      -           -
+1.  Trypsin                1      KR          P
+2.  Trypsin/P              1      KR          -
+""")
+
+
+@register("t25_fi_mod_slot_gap")
+def test_t25_fi_mod_slot_gap(comet_exe):
+    """T25: FI_DB gap variable-mod-slot regression -- mod in variable_mod02 (slot 1),
+    variable_mod01 (slot 0) left unused; must not silently resolve to the wrong slot."""
+    failures = []
+
+    fasta = DATA_DIR / "t25_fi_mod_slot_gap.fasta"
+    ms2   = DATA_DIR / "t25_fi_mod_slot_gap.ms2"
+    idx   = fasta.with_suffix(".fasta.idx")
+    txt   = ms2.with_suffix(".txt")
+
+    use_win = _binary_uses_win_paths(comet_exe)
+    fmt = _to_win if use_win else str
+
+    if idx.exists():
+        idx.unlink()
+
+    build_params = T25_PARAMS_TEMPLATE.format(
+        comet_version="2026.02 rev. 0", database=fmt(fasta))
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".params", dir=str(DATA_DIR), delete=False
+    ) as pf:
+        pf.write(build_params)
+        build_params_file = Path(pf.name)
+    try:
+        rc, out = _run_t19_step(comet_exe, ["-i", f"-P{fmt(build_params_file)}"])
+        if rc != 0 or not idx.exists():
+            failures.append(f"index build failed (rc={rc}):\n{out}")
+            return failures
+    finally:
+        build_params_file.unlink(missing_ok=True)
+
+    if txt.exists():
+        txt.unlink()
+
+    search_params = T25_PARAMS_TEMPLATE.format(
+        comet_version="2026.02 rev. 0", database=fmt(idx))
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".params", dir=str(DATA_DIR), delete=False
+    ) as pf:
+        pf.write(search_params)
+        search_params_file = Path(pf.name)
+
+    try:
+        rc, out = _run_t19_step(comet_exe, [f"-P{fmt(search_params_file)}", fmt(ms2)])
+        if rc != 0:
+            failures.append(f"search failed (rc={rc}):\n{out}")
+            return failures
+        if not txt.exists():
+            failures.append(f".txt not created (peptide not found -- the old bug corrupted "
+                             f"the precursor mass for this gap config). Comet output:\n{out}")
+            return failures
+
+        lines  = txt.read_text().splitlines()
+        rows   = [l.split("\t") for l in lines[2:] if l.strip()]
+
+        check(len(rows) == 1, f"expected exactly 1 PSM row, got {len(rows)}", failures)
+        if not rows:
+            return failures
+
+        header = lines[1].split("\t")
+        row = dict(zip(header, rows[0]))
+
+        check(row.get("plain_peptide") == "ACDSEFGHIK",
+              f"plain_peptide: expected ACDSEFGHIK, got {row.get('plain_peptide')!r}", failures)
+        # The old bug resolved the compacted index (0) directly, pointing at the unused
+        # variable_mod01 slot (mass 0.0) instead of the real variable_mod02 slot (79.966331).
+        check("4_V_79.966331" in row.get("modifications", ""),
+              f"modifications: expected to contain 4_V_79.966331 (the real variable_mod02 "
+              f"mass, not the unused gap slot's 0.0), got {row.get('modifications')!r}",
+              failures)
+        check(int(row.get("ions_matched", "0")) == 14,
+              f"ions_matched: expected all 14 fragment ions matched, got "
+              f"{row.get('ions_matched')!r}", failures)
+    finally:
+        search_params_file.unlink(missing_ok=True)
+        idx.unlink(missing_ok=True)
+        txt.unlink(missing_ok=True)
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`CometFragmentIndex.cpp` and `CometSearch.cpp`'s FI code paths were using `MOD_NUMBERS[modNumIdx].modifications[]` values (aliased locally as `mods`) directly — or with a naive `- 1` — as raw `varModList[]` indices. These values are actually 0-based indices into a **compacted** active-variable-mod-slot list (`CometPeptideIndex::GetVModSlotForAllModsIdx()`), which only coincides with the real `varModList` slot when every active `variable_modNN` among the first `FRAGINDEX_VMODS` is contiguous starting at slot 0 — true for every previously-tested config in this repo, which is why this went unnoticed. PI's equivalent code (`CometPeptideIndex.cpp`'s `MaterializeOneEntry()`) already did this translation correctly throughout, confirming the
bug was specific to FI.

A **"gap" config** (e.g. `variable_mod01` left unset while `variable_mod02` carries the real modification) exposes it: precursor mass and modified fragment-ion masses (used directly for XCorr/SP scoring) get silently computed against the wrong slot. Worse, one instance was a genuine out-of-bounds read, confirmed with AddressSanitizer to be a **heap-buffer-overflow, not just a scoring bug**.

## What's fixed

1. **Four independent instances** of the same bug, all corrected by translating through `GetVModSlotForAllModsIdx()`:
   - `AddFragments()`'s precursor-mass loop
   - `AddFragments()`'s fragment-ion-mass loop (previously `varModList[mods[j] - 1]`, reading `varModList[-1]` — undefined behavior)
   - `AddFragmentsThreadProc()`'s protein-variable-mod-filter check (also missing a `mods[i] != -1` guard — `cometbitcheck()`'s `1 << nbit` is UB for negative `nbit`)
   - `CometSearch.cpp`'s `SearchFragmentIndex()` — the FI per-query scoring function, hit on **every** FI search, not just gap configs
   - New regression test `t25_fi_mod_slot_gap`: real mod in `variable_mod02` (slot 1), `variable_mod01` (slot 0) left unused. Verified meaningful by reverting the fix and confirming it fails hard (peptide not found) against pre-fix code.

2. **A missing `-1` guard** in that same fragment-ion-mass loop, caught by a self-review ahead of this PR: unlike the precursor-mass loop just above it, the fragment-ion-mass loop had no guard against `mods[j] == -1` — the *ordinary* "not modified in this particular combination" sentinel, normal for any peptide with more modifiable candidate residues than `max_variable_mods_in_peptide` allows (e.g. 2 candidate phospho-sites, max 1 phospho — a completely standard config). Casting `-1` to `size_t` and indexing the heap-allocated `vector<int>` with it reads out of bounds.
   - **Verified with AddressSanitizer**: a new fixture (`t25_fi_mod_slot_ambig`, 2 candidate phospho-sites) reliably reproduces a `heap-buffer-overflow` at exactly this line against pre-fix code, clean against the fix. Plain `-O3` execution of the pre-fix code did *not* visibly crash on this fixture/machine (the 1-int heap-underflow happened to read a harmless value) — worth flagging for review: the new regression test guards against a future regression of the guard itself, but the ASan run is what actually proves this fix; plain execution alone isn't a reliable trip-wire for this bug class on every platform.

3. **Consolidation** addressing review feedback on (2): the translation logic had been hand-copied across six call sites (`CometPeptideIndex.cpp` ×3, `CometFragmentIndex.cpp` ×2, `CometSearch.cpp` ×1) with inconsistent guard/bounds-checking policies — exactly the kind of drift that let the bug in (2) ship. Consolidated into:
   - `CometPeptideIndex::TranslateVarModSlot()` — single, exception-free, bounds-checked translation, used everywhere (`MaterializeOneEntry()` layers its own stricter "reject the whole candidate" behavior on top, for genuine out-of-range corruption from untrusted on-disk data).
   - `CometPeptideIndex::PassesVarModProteinFilter()` — deduplicates a near-verbatim protein-mod-filter check that had been independently copy-pasted between `CometPeptideIndex.cpp` and `CometFragmentIndex.cpp`.
   - `AddFragments()` now takes `vModSlotForAllModsIdx` as a parameter instead of re-fetching it on every one of the millions of per-peptide-variant calls in a full index build.
   - `tests/unit/run_tests.py`: `T25_PARAMS_TEMPLATE` is now derived from the existing `T19_PARAMS_TEMPLATE` via targeted string replacement instead of a second ~95-line near-identical copy.

## Notes for reviewers

- The `AddFragmentsThreadProc()` protein-mod-filter fix (part of item 1) is currently **unreachable dead code** in the documented build-then-search workflow (the protein-mod-filter file is only read when building/searching directly against a FASTA, not when searching a prebuilt FI `.idx`) — fixed anyway since it was simply wrong, but has no regression test since no reachable path currently exercises it.
- This branch is bug-fix-only, deliberately separated from unrelated feature work in progress on another branch.
- Full suite: **42/42 pass** on a clean rebuild (Linux). Windows/MSVC not yet re-verified on this exact branch tip.