### PR TITLE
Fix release-asset race across platform build workflows

### DIFF
--- a/.github/workflows/aarch-linux-build.yml
+++ b/.github/workflows/aarch-linux-build.yml
@@ -44,6 +44,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: release/*
+        # Only the platform binary is uploaded here -- README.md is uploaded
+        # once, by linux-build.yml, to avoid all five platform jobs racing
+        # to create/overwrite the same-named release asset concurrently.
+        file: release/comet.aarch64.linux.exe
         overwrite: true
-        file_glob: true

--- a/.github/workflows/aarch-macos-build.yml
+++ b/.github/workflows/aarch-macos-build.yml
@@ -44,6 +44,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: release/*
+        # Only the platform binary is uploaded here -- README.md is uploaded
+        # once, by linux-build.yml, to avoid all five platform jobs racing
+        # to create/overwrite the same-named release asset concurrently.
+        file: release/comet.aarch64.macos.exe
         overwrite: true
-        file_glob: true

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -46,6 +46,9 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
+        # This is the one workflow (of the 5 platform builds) that uploads
+        # README.md as a release asset, so it's created exactly once instead
+        # of racing with the other platform jobs to overwrite the same asset.
         file: release/*
         overwrite: true
         file_glob: true

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -44,6 +44,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: release/*
+        # Only the platform binary is uploaded here -- README.md is uploaded
+        # once, by linux-build.yml, to avoid all five platform jobs racing
+        # to create/overwrite the same-named release asset concurrently.
+        file: release/comet.macos.exe
         overwrite: true
-        file_glob: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -71,12 +71,24 @@ jobs:
         name: comet-windows
         path: release/*
 
-    - name: Upload binaries to the release
+    - name: Upload binary to the release
       uses: svenstaro/upload-release-action@v2
       if: ${{ github.event_name == 'release' }}
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: release/*
+        # README.md is deliberately excluded here and uploaded once, by
+        # linux-build.yml, to avoid all five platform jobs racing to
+        # create/overwrite the same-named release asset concurrently.
+        file: release/comet.win64.exe
+        overwrite: true
+
+    - name: Upload DLLs to the release
+      uses: svenstaro/upload-release-action@v2
+      if: ${{ github.event_name == 'release' }}
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: release/*.dll
         overwrite: true
         file_glob: true


### PR DESCRIPTION
All 5 platform build workflows (macos, linux, windows, aarch-linux, aarch-macos) run in parallel on `release: published` and each copied README.md into its own release/ folder, then uploaded the whole release/* glob as GitHub Release assets. Since every job used the same asset name (README.md) on the same release, and svenstaro/upload-release-action's overwrite:true does a non-atomic check-delete-create, concurrent jobs could race and fail with "ReleaseAsset already_exists" -- this is what broke the macOS build in run 31431004927.

Scope README.md upload to a single workflow (linux-build.yml); the other 4 now upload only their platform binary/binaries to the release, leaving README.md out of that step entirely. windows-build.yml splits into two upload steps (exe, then *.dll) so it doesn't need a brace-glob pattern the underlying action may not support.